### PR TITLE
fix(playback): direct-play multichannel audio by default and preserve surround codec on transcode

### DIFF
--- a/locale/custom/en_US.json
+++ b/locale/custom/en_US.json
@@ -390,7 +390,7 @@
   "MessageActionWhenPreviewSegmentDetected": "Action to take when a Preview segment is detected during playback.",
   "MessageActionWhenRecapSegmentDetected": "Action to take when a Recap segment is detected during playback.",
   "MessageActionWhenUnknownSegmentDetected": "Action to take when an Unknown segment type is detected during playback.",
-  "MessageAllowTheRokuToDecodeMultichannel": "When enabled (default), the Roku decodes multichannel audio sources directly. Disable this to force the server to transcode multichannel audio instead — useful if Roku's audio output sounds incorrect on your system, or if you want guaranteed surround codec output (EAC3/AC3/DTS) to a passthrough-capable receiver.",
+  "MessageAllowTheRokuToDecodeMultichannel": "When enabled (default), Roku decodes multichannel audio sources directly. Disable to force the server to transcode instead. Useful if Roku audio sounds incorrect, or to guarantee surround passthrough (EAC3/AC3/DTS) to a capable receiver.",
   "MessageAreYouSureThisWillReset": "Are you sure? This will reset the setting to its default value.",
   "MessageAreYouSureYouWantTo": "Are you sure you want to exit JellyRock?",
   "MessageAreYouSureYouWantTo2": "Are you sure you want to reset all settings to their default values? Your login session will not be affected.",

--- a/locale/custom/en_US.json
+++ b/locale/custom/en_US.json
@@ -390,7 +390,7 @@
   "MessageActionWhenPreviewSegmentDetected": "Action to take when a Preview segment is detected during playback.",
   "MessageActionWhenRecapSegmentDetected": "Action to take when a Recap segment is detected during playback.",
   "MessageActionWhenUnknownSegmentDetected": "Action to take when an Unknown segment type is detected during playback.",
-  "MessageAllowTheRokuToDecodeMultichannel": "Allow the Roku to decode multichannel audio formats (AAC, FLAC, etc.) to stereo. When disabled, forces the server to transcode to 2-channel audio instead of relying on Roku's downmix, which may improve audio quality on some systems.",
+  "MessageAllowTheRokuToDecodeMultichannel": "When enabled (default), the Roku decodes multichannel audio sources directly. Disable this to force the server to transcode multichannel audio instead — useful if Roku's audio output sounds incorrect on your system, or if you want guaranteed surround codec output (EAC3/AC3/DTS) to a passthrough-capable receiver.",
   "MessageAreYouSureThisWillReset": "Are you sure? This will reset the setting to its default value.",
   "MessageAreYouSureYouWantTo": "Are you sure you want to exit JellyRock?",
   "MessageAreYouSureYouWantTo2": "Are you sure you want to reset all settings to their default values? Your login session will not be affected.",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -87,7 +87,7 @@
       },
       {
         "title": "Decode Multichannel Audio",
-        "description": "Allow the Roku to decode multichannel audio formats (AAC, FLAC, etc.) to stereo. When disabled, forces the server to transcode to 2-channel audio instead of relying on Roku's downmix, which may improve audio quality on some systems.",
+        "description": "When enabled (default), the Roku decodes multichannel audio sources directly. Disable this to force the server to transcode multichannel audio instead — useful if Roku's audio output sounds incorrect on your system, or if you want guaranteed surround codec output (EAC3/AC3/DTS) to a passthrough-capable receiver.",
         "settingName": "playbackDecodeMultichannelAudio",
         "type": "bool",
         "default": "true",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -87,7 +87,7 @@
       },
       {
         "title": "Decode Multichannel Audio",
-        "description": "When enabled (default), the Roku decodes multichannel audio sources directly. Disable this to force the server to transcode multichannel audio instead — useful if Roku's audio output sounds incorrect on your system, or if you want guaranteed surround codec output (EAC3/AC3/DTS) to a passthrough-capable receiver.",
+        "description": "When enabled (default), Roku decodes multichannel audio sources directly. Disable to force the server to transcode instead. Useful if Roku audio sounds incorrect, or to guarantee surround passthrough (EAC3/AC3/DTS) to a capable receiver.",
         "settingName": "playbackDecodeMultichannelAudio",
         "type": "bool",
         "default": "true",

--- a/source/api/items.bs
+++ b/source/api/items.bs
@@ -202,26 +202,26 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
           end for
         end if
 
-        ' Remove AAC from codec list in two scenarios:
-        ' 1. ANY multichannel source (>2ch) when user has passthrough support - prevents transcoding to AAC which would downmix to stereo
-        ' 2. Unsupported AAC profiles (Main, HE-AAC) - TODO: Remove after server supports transcoding between AAC profiles
-        shouldRemoveAac = false
+        ' Tailor the device profile's transcoding AudioCodec list to the source in two scenarios:
+        ' 1. Multichannel source (>2ch) with passthrough support - drops stereo-output codecs so
+        '    the server only offers surround variants (eac3/ac3/dts) in the HLS master playlist.
+        '    Without this, Roku's HLS player has been observed to pick the stereo variant.
+        ' 2. AAC source with unsupported profile (Main, HE-AAC) - drops AAC so transcoding
+        '    falls through to MP3.  TODO: remove once server transcodes between AAC profiles.
+        shouldOptimize = false
 
-        ' Scenario 1: ANY multichannel source with passthrough support
-        ' Removes AAC to force server to use surround passthrough codecs (eac3, ac3, dts) instead of transcoding to stereo AAC
         if channelCount > 2 and hasPassthruSupport
-          shouldRemoveAac = true
+          shouldOptimize = true
         end if
 
-        ' Scenario 2: AAC with unsupported profile
         if isValid(selectedAudioStream.Codec) and LCase(selectedAudioStream.Codec) = "aac"
           if isValid(selectedAudioStream.Profile) and (LCase(selectedAudioStream.Profile) = "main" or LCase(selectedAudioStream.Profile) = "he-aac")
-            shouldRemoveAac = true
+            shouldOptimize = true
           end if
         end if
 
-        if shouldRemoveAac
-          removeUnsupportedAacFromProfile(postData.DeviceProfile, channelCount)
+        if shouldOptimize
+          optimizeAudioCodecListForSource(postData.DeviceProfile, channelCount)
         end if
       end if
     end if
@@ -514,37 +514,51 @@ sub applyMediaSourceToPostData(postData as object, mediaSourceId as string, forc
   end if
 end sub
 
-' Removes AAC from the device profile codec list to prevent stereo downmix of multichannel audio.
-' Also handles unsupported AAC profiles (Main, HE-AAC).
-' For stereo sources (≤2ch), also removes surround passthrough codecs (eac3, ac3, dts)
-' so transcoding falls through to MP3 (better compatibility + smaller files).
-sub removeUnsupportedAacFromProfile(deviceProfile as object, channelCount as integer)
+' Tailors a video transcoding profile's AudioCodec list to the current source's channel count
+' so the server (and downstream HLS variant selection) can't fall back to a less-desirable codec.
+'
+' Multichannel source (>2ch):
+'   Strips ALL stereo-output codecs (aac, mp3, flac, alac, pcm, lpcm, wav, vorbis). Without this,
+'   Jellyfin's HLS muxer offers BOTH the surround codec AND a stereo fallback as separate variants
+'   in the master playlist, and Roku's HLS player has been observed to pick the stereo variant —
+'   defeating the entire point of having surround passthrough hardware. Caller must already have
+'   verified the device has surround passthrough before invoking with channelCount > 2.
+'
+' Stereo source (≤2ch):
+'   Strips surround passthrough codecs (eac3, ac3, dts) plus aac so transcoding falls through to
+'   mp3. Avoids handing the server a surround target codec for content that's only 2ch anyway.
+sub optimizeAudioCodecListForSource(deviceProfile as object, channelCount as integer)
   ' Validate inputs
   if not isValid(deviceProfile) then return
   if not isValid(deviceProfile.TranscodingProfiles) then return
 
-  ' Surround passthrough codecs that should be removed for stereo sources
-  surroundCodecs = ["eac3", "ac3", "dts"]
+  ' Codecs that decode multichannel sources to stereo PCM only — strip these for multichannel
+  ' sources so the server is forced to pick a surround codec from the remaining list.
+  stereoOnlyCodecs = ["aac", "mp3", "flac", "alac", "pcm", "lpcm", "wav", "vorbis"]
+  ' Surround passthrough codecs — pointless for stereo sources, strip them.
+  surroundCodecs = ["eac3", "ac3", "dts", "truehd", "dtshd"]
 
   for each rule in deviceProfile.TranscodingProfiles
     if isValid(rule.Type) and rule.Type = "Video"
       if isValid(rule.AudioCodec)
-        ' Split codec list into array
         codecList = rule.AudioCodec.split(",")
         newCodecList = []
 
-        ' Remove AAC always, and surround codecs for stereo sources
         for each codec in codecList
           skipCodec = false
 
-          ' Always skip AAC to prevent downmix
-          if codec = "aac"
+          if channelCount > 2 and arrayHasValue(stereoOnlyCodecs, codec)
             skipCodec = true
           end if
 
-          ' For stereo sources (≤2ch), also skip surround codecs
-          ' This ensures transcoding goes to MP3 instead of trying AC3/EAC3
           if channelCount <= 2 and arrayHasValue(surroundCodecs, codec)
+            skipCodec = true
+          end if
+
+          ' Stereo sources also drop AAC (covered by stereoOnlyCodecs check above only fires for
+          ' multichannel; explicitly drop AAC for stereo to keep prior behavior of falling
+          ' through to mp3 for max compatibility).
+          if channelCount <= 2 and codec = "aac"
             skipCodec = true
           end if
 
@@ -553,7 +567,6 @@ sub removeUnsupportedAacFromProfile(deviceProfile as object, channelCount as int
           end if
         end for
 
-        ' Rebuild codec string
         rule.AudioCodec = newCodecList.join(",")
       end if
     end if

--- a/source/api/items.bs
+++ b/source/api/items.bs
@@ -520,7 +520,8 @@ end sub
 ' Multichannel source (>2ch):
 '   Strips ALL stereo-output codecs (aac, mp3, flac, alac, pcm, lpcm, wav, vorbis). Without this,
 '   Jellyfin's HLS muxer offers BOTH the surround codec AND a stereo fallback as separate variants
-'   in the master playlist, and Roku's HLS player has been observed to pick the stereo variant —
+'   in the master playlist, and Roku's HLS player has been observed (via in-house testing on
+'   physical hardware; no upstream tracking issue at time of writing) to pick the stereo variant —
 '   defeating the entire point of having surround passthrough hardware. Caller must already have
 '   verified the device has surround passthrough before invoking with channelCount > 2.
 '
@@ -532,11 +533,13 @@ sub optimizeAudioCodecListForSource(deviceProfile as object, channelCount as int
   if not isValid(deviceProfile) then return
   if not isValid(deviceProfile.TranscodingProfiles) then return
 
-  ' Codecs that decode multichannel sources to stereo PCM only — strip these for multichannel
-  ' sources so the server is forced to pick a surround codec from the remaining list.
+  ' Codecs that, as a server transcode target, can't carry surround channels — strip these for
+  ' multichannel sources so the server is forced to pick a surround codec from the remaining list.
+  ' Note: this list is intentionally distinct from `stereoOutputCodecs` in deviceCapabilities.bs;
+  ' that list represents Roku decode-path behavior (different concept), so the contents differ.
   stereoOnlyCodecs = ["aac", "mp3", "flac", "alac", "pcm", "lpcm", "wav", "vorbis"]
   ' Surround passthrough codecs — pointless for stereo sources, strip them.
-  surroundCodecs = ["eac3", "ac3", "dts", "truehd", "dtshd"]
+  surroundCodecs = ["eac3", "ac3", "dts"]
 
   for each rule in deviceProfile.TranscodingProfiles
     if isValid(rule.Type) and rule.Type = "Video"
@@ -551,14 +554,7 @@ sub optimizeAudioCodecListForSource(deviceProfile as object, channelCount as int
             skipCodec = true
           end if
 
-          if channelCount <= 2 and arrayHasValue(surroundCodecs, codec)
-            skipCodec = true
-          end if
-
-          ' Stereo sources also drop AAC (covered by stereoOnlyCodecs check above only fires for
-          ' multichannel; explicitly drop AAC for stereo to keep prior behavior of falling
-          ' through to mp3 for max compatibility).
-          if channelCount <= 2 and codec = "aac"
+          if channelCount <= 2 and (codec = "aac" or arrayHasValue(surroundCodecs, codec))
             skipCodec = true
           end if
 
@@ -566,6 +562,10 @@ sub optimizeAudioCodecListForSource(deviceProfile as object, channelCount as int
             newCodecList.push(codec)
           end if
         end for
+
+        if newCodecList.count() = 0 and codecList.count() > 0
+          print "[optimizeAudioCodecListForSource] WARN: AudioCodec list for container '" + rule.Container + "' became empty after optimization (source ch=" + channelCount.toStr() + ", original=" + rule.AudioCodec + "); server may reject the transcoding rule"
+        end if
 
         rule.AudioCodec = newCodecList.join(",")
       end if

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -589,24 +589,27 @@ function getCodecProfiles() as object
   resolutionConditions = getResolutionConditions()
 
   ' ========================================
-  ' DETECT SURROUND PASSTHROUGH SUPPORT
+  ' USER SETTING — FORCE SERVER-SIDE MULTICHANNEL HANDLING
   ' ========================================
-
-  sixChannelPassthruCodecs = getSupportedPassthruCodecs(di, 6)
-  eightChannelPassthruCodecs = getSupportedPassthruCodecs(di, 8)
-  hasSurroundPassthru = sixChannelPassthruCodecs.count() > 0 or eightChannelPassthruCodecs.count() > 0
-
-  ' Check user setting for multichannel decode preference
-  ' When disabled, force stereo-output codecs to 2ch max (same as passthrough behavior)
+  '
+  ' playbackDecodeMultichannelAudio = false means the user has explicitly asked us to keep
+  ' multichannel sources off the Roku's decoder — usually because Roku's downmix sounded worse
+  ' than the server's on their system, or because they want bitstream surround output preserved
+  ' via server transcoding instead of relying on Roku PCM output.
+  '
+  ' Effect: cap stereo-output codecs at 2ch in the codec profile so the server is forced to
+  ' transcode multichannel sources rather than offering them for direct play.
   userWantsDecodeLimit = not globalUserSettings.playbackDecodeMultichannelAudio
 
   ' ========================================
   ' CODEC CATEGORIES
   ' ========================================
 
-  ' Codecs that Roku decodes multichannel but only OUTPUTS as stereo PCM
-  ' When user has a receiver, we force these to 2ch max to trigger transcoding
-  ' to surround output codecs (eac3/ac3/dts) instead of direct playing and downmixing
+  ' Codecs whose decode-then-output path on Roku does not always pass through multichannel —
+  ' depending on the user's Audio Output Mode and HDMI/eARC sink, these may downmix to 2ch PCM.
+  ' We do NOT cap these at 2ch by default: most modern HDMI sinks accept multichannel PCM and
+  ' the official Roku decode behavior produces correct multichannel output for capable users.
+  ' The cap is applied only when userWantsDecodeLimit is true (see setting above).
   stereoOutputCodecs = ["aac", "flac", "alac", "pcm", "lpcm", "wav", "opus", "vorbis"]
 
   ' ========================================
@@ -617,11 +620,12 @@ function getCodecProfiles() as object
   audioChannels = [8, 6, 2] ' highest first
 
   for each audioCodec in audioCodecs
-    ' Special handling for stereo-output codecs when user has surround passthrough OR user disabled multichannel decode
-    ' These codecs decode multichannel but Roku only outputs as stereo PCM
-    if arrayHasValue(stereoOutputCodecs, audioCodec) and (hasSurroundPassthru or userWantsDecodeLimit)
-      ' Force to 2 channels maximum to prevent Roku from downmixing multichannel to stereo
-      ' This triggers server to transcode to surroundOutputCodecs (eac3/ac3/dts) or stereo instead
+    ' When the user has explicitly disabled on-device multichannel decoding, cap stereo-output
+    ' codecs at 2ch to force server-side transcoding for multichannel sources.
+    if arrayHasValue(stereoOutputCodecs, audioCodec) and userWantsDecodeLimit
+      ' Force to 2 channels maximum to prevent Roku from decoding the multichannel source.
+      ' Server transcodes to a surround codec (eac3/ac3/dts) if surround passthrough is
+      ' available, otherwise transcodes to stereo.
       for each codecType in ["VideoAudio", "Audio"]
         ' Special AAC profile restrictions (Main and HE-AAC not supported)
         if audioCodec = "aac"

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -500,7 +500,9 @@ function getTranscodingProfiles() as object
   for each container in transcodingContainers
     audioCodecList = []
 
-    ' 1. AAC always first (efficient for stereo, removed at playback time for multichannel sources with passthrough)
+    ' 1. AAC always first (efficient for stereo). On multichannel + passthru playback, all
+    '    stereo-output codecs (including AAC) are stripped at playback time by
+    '    optimizeAudioCodecListForSource (see items.bs).
     audioCodecList.push("aac")
 
     ' 2. Add surround passthrough codecs if supported (in preference order)
@@ -610,6 +612,9 @@ function getCodecProfiles() as object
   ' We do NOT cap these at 2ch by default: most modern HDMI sinks accept multichannel PCM and
   ' the official Roku decode behavior produces correct multichannel output for capable users.
   ' The cap is applied only when userWantsDecodeLimit is true (see setting above).
+  '
+  ' Note: this list is intentionally distinct from `stereoOnlyCodecs` in items.bs; that list
+  ' represents server transcode-target capability (different concept), so the contents differ.
   stereoOutputCodecs = ["aac", "flac", "alac", "pcm", "lpcm", "wav", "opus", "vorbis"]
 
   ' ========================================

--- a/tests/source/unit/api/ItemsAudioHandling.spec.bs
+++ b/tests/source/unit/api/ItemsAudioHandling.spec.bs
@@ -3,7 +3,7 @@ import "pkg:/source/utils/misc.bs"
 
 namespace tests
 
-  @suite("Items.bs - removeUnsupportedAacFromProfile()")
+  @suite("Items.bs - optimizeAudioCodecListForSource()")
   class ItemsAudioHandlingTests extends tests.BaseTestSuite
 
     protected override function setup()
@@ -11,19 +11,16 @@ namespace tests
     end function
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    @describe("Multichannel Audio (>2ch) - AAC Removal")
+    @describe("Multichannel Audio (>2ch) - Stereo Codec Removal")
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
     @it("removes AAC from ts container codec list for 6ch audio")
     function _()
-      ' GIVEN: Device profile with passthrough support and multichannel source
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-with-passthrough")
       channelCount = 6
 
-      ' WHEN: removeUnsupportedAacFromProfile is called
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
-      ' THEN: AAC is removed from ts container
       tsProfile = invalid
       for each profile in deviceProfile.TranscodingProfiles
         if profile.Container = "ts"
@@ -41,7 +38,7 @@ namespace tests
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-8ch-passthrough")
       channelCount = 8
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       mp4Profile = invalid
       for each profile in deviceProfile.TranscodingProfiles
@@ -60,7 +57,7 @@ namespace tests
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-with-passthrough")
       channelCount = 6
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       tsProfile = invalid
       for each profile in deviceProfile.TranscodingProfiles
@@ -76,12 +73,16 @@ namespace tests
       m.assertTrue(tsProfile.AudioCodec.inStr("dts") >= 0, "dts should be preserved")
     end function
 
-    @it("preserves other codecs (mp3, flac, alac, pcm) for multichannel audio")
+    @it("removes stereo-output codecs (mp3, flac, alac, pcm) for multichannel audio")
     function _()
+      ' GIVEN: a multichannel source with passthrough support, the server has been observed to
+      ' offer BOTH surround AND stereo variants in its HLS master playlist when stereo codecs
+      ' remain in the AudioCodec list, with Roku then picking the stereo variant. Stripping
+      ' stereo codecs forces the server to only emit surround variants.
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-with-passthrough")
       channelCount = 6
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       tsProfile = invalid
       for each profile in deviceProfile.TranscodingProfiles
@@ -92,10 +93,30 @@ namespace tests
       end for
 
       m.assertNotInvalid(tsProfile)
-      m.assertTrue(tsProfile.AudioCodec.inStr("mp3") >= 0, "mp3 should be preserved")
-      m.assertTrue(tsProfile.AudioCodec.inStr("flac") >= 0, "flac should be preserved")
-      m.assertTrue(tsProfile.AudioCodec.inStr("alac") >= 0, "alac should be preserved")
-      m.assertTrue(tsProfile.AudioCodec.inStr("pcm") >= 0, "pcm should be preserved")
+      m.assertFalse(tsProfile.AudioCodec.inStr("mp3") >= 0, "mp3 should be removed for multichannel")
+      m.assertFalse(tsProfile.AudioCodec.inStr("flac") >= 0, "flac should be removed for multichannel")
+      m.assertFalse(tsProfile.AudioCodec.inStr("alac") >= 0, "alac should be removed for multichannel")
+      m.assertFalse(tsProfile.AudioCodec.inStr("pcm") >= 0, "pcm should be removed for multichannel")
+    end function
+
+    @it("strips all stereo-output codecs leaving only surround codecs for multichannel audio")
+    function _()
+      deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-with-passthrough")
+      channelCount = 6
+
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
+
+      tsProfile = invalid
+      for each profile in deviceProfile.TranscodingProfiles
+        if profile.Container = "ts"
+          tsProfile = profile
+          exit for
+        end if
+      end for
+
+      m.assertNotInvalid(tsProfile)
+      ' Source list: aac,eac3,ac3,dts,mp3,flac,alac,pcm — after optimization should be eac3,ac3,dts
+      m.assertEqual(tsProfile.AudioCodec, "eac3,ac3,dts", "only surround codecs should remain for multichannel")
     end function
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -107,7 +128,7 @@ namespace tests
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-stereo-only")
       channelCount = 2
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       tsProfile = invalid
       for each profile in deviceProfile.TranscodingProfiles
@@ -126,7 +147,7 @@ namespace tests
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-stereo-only")
       channelCount = 2
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       tsProfile = invalid
       for each profile in deviceProfile.TranscodingProfiles
@@ -147,7 +168,7 @@ namespace tests
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-stereo-only")
       channelCount = 2
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       tsProfile = invalid
       for each profile in deviceProfile.TranscodingProfiles
@@ -169,7 +190,7 @@ namespace tests
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-stereo-only")
       channelCount = 2
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       tsProfile = invalid
       for each profile in deviceProfile.TranscodingProfiles
@@ -196,7 +217,7 @@ namespace tests
       channelCount = 6
 
       ' Should not crash
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       tsProfile = invalid
       for each profile in deviceProfile.TranscodingProfiles
@@ -215,7 +236,7 @@ namespace tests
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-aac-only")
       channelCount = 6
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       tsProfile = invalid
       for each profile in deviceProfile.TranscodingProfiles
@@ -245,7 +266,7 @@ namespace tests
       channelCount = 6
 
       ' Should not crash when AudioCodec field is missing
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       ' Profile should remain unchanged
       m.assertFalse(deviceProfile.TranscodingProfiles[0].DoesExist("AudioCodec"), "AudioCodec field should remain non-existent")
@@ -267,10 +288,10 @@ namespace tests
       }
       channelCount = 6
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
-      ' mkv container should have AAC removed like all other video containers
-      m.assertEqual(deviceProfile.TranscodingProfiles[0].AudioCodec, "eac3,ac3,mp3", "mkv container should have AAC removed")
+      ' Multichannel: aac and mp3 stripped, surround codecs preserved
+      m.assertEqual(deviceProfile.TranscodingProfiles[0].AudioCodec, "eac3,ac3", "mkv container should have stereo codecs stripped for multichannel")
     end function
 
     @it("ignores non-Video type profiles (only processes Type=Video)")
@@ -296,12 +317,12 @@ namespace tests
       channelCount = 6
       originalAudioProfileCodecs = deviceProfile.TranscodingProfiles[0].AudioCodec
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       ' Audio profile should remain unchanged
       m.assertEqual(deviceProfile.TranscodingProfiles[0].AudioCodec, originalAudioProfileCodecs, "Audio type profile should not be modified")
-      ' Video profile should have AAC removed
-      m.assertEqual(deviceProfile.TranscodingProfiles[1].AudioCodec, "eac3,ac3,mp3", "Video type profile should have AAC removed")
+      ' Video profile: multichannel optimization strips aac and mp3, keeps surround codecs
+      m.assertEqual(deviceProfile.TranscodingProfiles[1].AudioCodec, "eac3,ac3", "Video type profile should have stereo codecs stripped for multichannel")
     end function
 
     @it("processes both ts and mp4 containers in same profile")
@@ -309,7 +330,7 @@ namespace tests
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-with-passthrough")
       channelCount = 6
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       ' Both containers should have AAC removed
       tsProfile = invalid
@@ -326,6 +347,8 @@ namespace tests
       m.assertNotInvalid(mp4Profile, "mp4 profile should exist")
       m.assertFalse(tsProfile.AudioCodec.inStr("aac") >= 0, "AAC should be removed from ts")
       m.assertFalse(mp4Profile.AudioCodec.inStr("aac") >= 0, "AAC should be removed from mp4")
+      m.assertFalse(tsProfile.AudioCodec.inStr("mp3") >= 0, "MP3 should be removed from ts for multichannel")
+      m.assertFalse(mp4Profile.AudioCodec.inStr("mp3") >= 0, "MP3 should be removed from mp4 for multichannel")
     end function
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -337,7 +360,7 @@ namespace tests
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-with-passthrough")
       channelCount = 6
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       tsProfile = invalid
       for each profile in deviceProfile.TranscodingProfiles
@@ -354,12 +377,12 @@ namespace tests
       m.assertFalse(tsProfile.AudioCodec.Right(1) = ",", "Should not end with comma")
     end function
 
-    @it("maintains codec order after AAC removal")
+    @it("maintains codec order after stripping stereo codecs")
     function _()
       deviceProfile = MockDataLoader.LoadDeviceProfile("device-profile-with-passthrough")
       channelCount = 6
 
-      removeUnsupportedAacFromProfile(deviceProfile, channelCount)
+      optimizeAudioCodecListForSource(deviceProfile, channelCount)
 
       tsProfile = invalid
       for each profile in deviceProfile.TranscodingProfiles
@@ -372,9 +395,10 @@ namespace tests
       m.assertNotInvalid(tsProfile)
       codecList = tsProfile.AudioCodec.Split(",")
 
-      ' Expected order after AAC removal: eac3, ac3, dts, mp3, flac, alac, pcm
-      ' (based on original order: aac,eac3,ac3,dts,mp3,flac,alac,pcm)
-      m.assertEqual(codecList[0], "eac3", "eac3 should be first after AAC removal")
+      ' Source order: aac,eac3,ac3,dts,mp3,flac,alac,pcm
+      ' Multichannel optimization strips aac,mp3,flac,alac,pcm → eac3,ac3,dts (relative order preserved)
+      m.assertEqual(codecList.Count(), 3, "only 3 surround codecs should remain")
+      m.assertEqual(codecList[0], "eac3", "eac3 should be first")
       m.assertEqual(codecList[1], "ac3", "ac3 should be second")
       m.assertEqual(codecList[2], "dts", "dts should be third")
     end function


### PR DESCRIPTION
## Changes

Two related bugs in JellyRock's multichannel audio handling on Roku devices with surround output:

### Bug 1 — Server transcoding to MP3 2ch instead of preserving multichannel

When the codec profile cap forced a transcode (multichannel source + surround passthrough hardware), Jellyfin's HLS pipeline emitted both an EAC3 6ch variant AND an MP3 2ch variant in the master playlist, and Roku's HLS player picked the stereo variant — defeating the multichannel intent.

Fix: strip all stereo-output codecs (`aac, mp3, flac, alac, pcm, lpcm, wav, vorbis`) from the transcoding `AudioCodec` list when the source is multichannel and the device has passthrough support. Renamed the helper from `removeUnsupportedAacFromProfile` → `optimizeAudioCodecListForSource` to reflect what it actually does.

### Bug 2 — Cap firing too aggressively, forcing unnecessary transcoding

The codec profile cap on stereo-output codecs (the gate that triggered Bug 1's transcode in the first place) fired whenever the device had surround passthrough hardware OR the user had disabled `playbackDecodeMultichannelAudio`. The hardware-detection half was based on a wrong premise — that Roku always downmixes these codecs to 2ch PCM. Field evidence (#510) shows that on modern HDMI/eARC sinks Roku does pass multichannel PCM through correctly. The cap was forcing unnecessary transcoding on those setups.

Fix: decoupled the two triggers. The cap now fires only when the user has explicitly disabled `playbackDecodeMultichannelAudio`. Default behavior on multichannel sources is now direct play, with the Roku handling output per its Audio Mode and sink capability.

## Behavioral change

For users with surround passthrough hardware on the default setting, the playback path changes:

| Source | Before | After |
|---|---|---|
| Opus 5.1 / AAC 5.1 / FLAC 5.1 (non-passthrough multichannel) | Forced transcode to bitstream EAC3 (or MP3 2ch pre-Bug-1-fix) | Direct play; Roku decodes; outputs PCM via Audio Mode + sink |
| EAC3 / AC3 / DTS multichannel (passthrough-eligible) | Direct play with bitstream passthrough | Unchanged |
| Stereo content | Direct play | Unchanged |

Users whose hardware does not handle on-device multichannel decoding correctly retain the existing escape hatch via `playbackDecodeMultichannelAudio = false`. Setting description updated to describe both use cases (the original Roku-downmix-quality concern AND the new guaranteed-bitstream-surround case).

## Issues

Fixes #512
Closes #510

## Test plan

Verified manually on Roku Ultra + 5.1 soundbar:

- [x] Opus 5.1 / AV1 webm sample (#510 reproduction): direct plays with setting enabled (default); transcodes to EAC3 6ch with setting disabled
- [x] Stereo content: direct plays (unchanged)
- [x] H.264 + AAC stereo direct-play-eligible content: direct plays (unchanged)
- [x] DoVi remux with EAC3 8ch Atmos audio: direct plays with bitstream passthrough (unchanged)

Audible 5.1-vs-stereo verification on direct play was not possible without a soundbar that displays format; behavior is consistent with the Roku's own multichannel PCM output capability. Recovery via the existing setting if any user's hardware needs it.