### PR TITLE
fix: Quick Connect on Jellyfin 10.9+ servers

### DIFF
--- a/components/data/SceneManager.bs
+++ b/components/data/SceneManager.bs
@@ -265,7 +265,9 @@ end sub
 sub userMessage(title as string, message as string)
   dialog = createObject("roSGNode", "StandardMessageDialog")
   dialog.title = title
-  dialog.message = message
+  ' StandardMessageDialog.message is an array-of-strings field; assigning a
+  ' bare string fails silently and renders an empty body.
+  dialog.message = [message]
   dialog.buttons = [translate(translationKeys.ButtonOk)]
   dialog.observeField("buttonSelected", "dismissDialog")
   m.scene.dialog = dialog

--- a/components/data/jellyfin/JellyfinServer.xml
+++ b/components/data/jellyfin/JellyfinServer.xml
@@ -34,6 +34,10 @@
     <!-- Branding Cache (invalid = not loaded yet, true/false = loaded) -->
     <field id="isSplashscreenEnabled" type="boolean" />
 
+    <!-- Quick Connect capability. Fail-open: defaults true; QuickConnectEnabledTask
+         only writes false when the server explicitly reports it disabled. -->
+    <field id="isQuickConnectEnabled" type="boolean" value="true" />
+
     <!-- DEBUG ONLY: Raw server info for debugging - only populated when bs_const=debug=true -->
     <field id="rawServerInfo" type="assocarray" />
   </interface>

--- a/components/login/UserSelect.bs
+++ b/components/login/UserSelect.bs
@@ -13,16 +13,26 @@ sub init()
   m.top.findNode("manualLoginButton").text = translate(translationKeys.ButtonManualLogin)
   m.buttons = m.top.findNode("buttons")
 
-  ' Quick Connect requires server >= 10.8.0. Remove the button entirely (rather
-  ' than hiding it) when unsupported - JRButtonGroup focus/navigation honors
-  ' isEnabled but not visible, so an invisible button at index 0 would silently
-  ' steal default focus.
-  quickConnectButton = m.top.findNode("quickConnect")
-  if versionChecker(m.global.server.version, "10.8.0")
-    quickConnectButton.text = translate(translationKeys.ButtonQuickConnect)
+  ' Quick Connect requires server >= 10.8.0 AND must be enabled in server config.
+  ' Remove the button entirely (rather than hiding it) when unsupported -
+  ' JRButtonGroup focus/navigation honors isEnabled but not visible, so an
+  ' invisible button at index 0 would silently steal default focus.
+  m.quickConnectButton = m.top.findNode("quickConnect")
+  if not versionChecker(m.global.server.version, "10.8.0")
+    removeQuickConnectButton("server version below 10.8.0, version:" + m.global.server.version)
   else
-    m.buttons.removeChild(quickConnectButton)
-    m.log.debug("Quick Connect removed - server version below 10.8.0", "version:", m.global.server.version)
+    m.quickConnectButton.text = translate(translationKeys.ButtonQuickConnect)
+    ' Apply prior probe result immediately if already known disabled this session.
+    ' Default of true (fail-open) means the button stays unless we have evidence.
+    if m.global.server.isQuickConnectEnabled = false
+      removeQuickConnectButton("server reports Quick Connect disabled (cached)")
+    else
+      ' Probe the server now; observer below removes the button if it returns false.
+      m.global.server.observeFieldScoped("isQuickConnectEnabled", "onQuickConnectEnabledChanged")
+      m.quickConnectEnabledTask = createObject("roSGNode", "QuickConnectEnabledTask")
+      m.quickConnectEnabledTask.control = "RUN"
+      m.log.debug("Started QuickConnectEnabledTask")
+    end if
   end if
 
   m.buttons.callFunc("center")
@@ -30,6 +40,25 @@ sub init()
   ' Create branding config task (reusable instance)
   m.brandingTask = createObject("roSGNode", "BrandingConfigTask")
   m.log.debug("Created BrandingConfigTask")
+end sub
+
+' Probe completion handler. Fail-open: only act on a definitive false.
+sub onQuickConnectEnabledChanged()
+  if m.global.server.isQuickConnectEnabled = false
+    removeQuickConnectButton("server reports Quick Connect disabled")
+  end if
+end sub
+
+' Remove the Quick Connect button and re-center the remaining buttons.
+' Safe to call repeatedly - removeChild is a no-op once the node is detached.
+sub removeQuickConnectButton(reason as string)
+  if not isValid(m.quickConnectButton) then return
+  if isValid(m.quickConnectButton.getParent())
+    m.buttons.removeChild(m.quickConnectButton)
+    m.buttons.callFunc("center")
+  end if
+  m.quickConnectButton = invalid
+  m.log.info("Quick Connect button removed", reason)
 end sub
 
 sub itemContentChanged()
@@ -203,6 +232,15 @@ sub destroy()
   m.brandingTask.callFunc("empty")
   m.brandingTask = invalid
 
+  ' Stop Quick Connect availability probe (only present when version gate passed)
+  m.global.server.unobserveFieldScoped("isQuickConnectEnabled")
+  if isValid(m.quickConnectEnabledTask)
+    m.quickConnectEnabledTask.control = "STOP"
+    m.quickConnectEnabledTask.callFunc("empty")
+    m.quickConnectEnabledTask = invalid
+  end if
+
   ' Clear node references
+  m.quickConnectButton = invalid
   m.buttons = invalid
 end sub

--- a/components/login/UserSelect.bs
+++ b/components/login/UserSelect.bs
@@ -27,11 +27,9 @@ sub init()
     if m.global.server.isQuickConnectEnabled = false
       removeQuickConnectButton("server reports Quick Connect disabled (cached)")
     else
-      ' Probe the server now; observer below removes the button if it returns false.
-      m.global.server.observeFieldScoped("isQuickConnectEnabled", "onQuickConnectEnabledChanged")
+      ' Probe is started in OnScreenShown (matches BrandingConfigTask timing).
       m.quickConnectEnabledTask = createObject("roSGNode", "QuickConnectEnabledTask")
-      m.quickConnectEnabledTask.control = "RUN"
-      m.log.debug("Started QuickConnectEnabledTask")
+      m.log.debug("Created QuickConnectEnabledTask")
     end if
   end if
 
@@ -42,9 +40,28 @@ sub init()
   m.log.debug("Created BrandingConfigTask")
 end sub
 
-' Probe completion handler. Fail-open: only act on a definitive false.
-sub onQuickConnectEnabledChanged()
-  if m.global.server.isQuickConnectEnabled = false
+' Probe the server's /QuickConnect/Enabled endpoint and remove the QC button if
+' the server reports it disabled. Mirrors loadSplashscreen()'s wiring of
+' BrandingConfigTask: observe the task's responseCode, read the global field
+' on completion. Fail-open: only act on a definitive false.
+sub probeQuickConnectAvailability()
+  if not isValid(m.quickConnectEnabledTask) then return
+  m.log.info("Probing /QuickConnect/Enabled to gate the Quick Connect button")
+  m.quickConnectEnabledTask.observeFieldScoped("responseCode", "onQuickConnectEnabledProbeComplete")
+  m.quickConnectEnabledTask.control = "RUN"
+end sub
+
+' Called when QuickConnectEnabledTask finishes. Reads the global field the task
+' wrote and removes the button if the server reports Quick Connect disabled.
+sub onQuickConnectEnabledProbeComplete()
+  responseCode = m.quickConnectEnabledTask.responseCode
+  enabled = m.global.server.isQuickConnectEnabled
+  m.log.info("Quick Connect probe complete", "responseCode:", responseCode, "enabled:", enabled)
+
+  m.quickConnectEnabledTask.unobserveFieldScoped("responseCode")
+  m.quickConnectEnabledTask.callFunc("empty")
+
+  if enabled = false
     removeQuickConnectButton("server reports Quick Connect disabled")
   end if
 end sub
@@ -95,6 +112,9 @@ sub OnScreenShown()
 
   ' Load splashscreen (handles race condition)
   loadSplashscreen()
+
+  ' Probe Quick Connect availability so the button can hide on disabled servers.
+  probeQuickConnectAvailability()
 end sub
 
 ' JRScreen hook called when the screen is hidden by the screen manager
@@ -233,9 +253,9 @@ sub destroy()
   m.brandingTask = invalid
 
   ' Stop Quick Connect availability probe (only present when version gate passed)
-  m.global.server.unobserveFieldScoped("isQuickConnectEnabled")
   if isValid(m.quickConnectEnabledTask)
     m.quickConnectEnabledTask.control = "STOP"
+    m.quickConnectEnabledTask.unobserveFieldScoped("responseCode")
     m.quickConnectEnabledTask.callFunc("empty")
     m.quickConnectEnabledTask = invalid
   end if

--- a/components/tasks/QuickConnectEnabledTask.bs
+++ b/components/tasks/QuickConnectEnabledTask.bs
@@ -1,0 +1,42 @@
+import "pkg:/source/api/ApiClient.bs"
+import "pkg:/source/api/apiPool.bs"
+import "pkg:/source/roku_modules/log/LogMixin.brs"
+
+sub init()
+  m.log = new log.Logger("QuickConnectEnabledTask")
+  m.top.functionName = "fetchQuickConnectEnabled"
+end sub
+
+' Orchestrator Task: probes /QuickConnect/Enabled off the render thread.
+' Updates m.global.server.isQuickConnectEnabled. Fail-open: leaves the field
+' at its existing value (defaults true) on any error so a transient failure
+' never hides a working feature.
+' Sets responseCode to 200 on success, -1 on failure.
+sub fetchQuickConnectEnabled()
+  m.log.info("Probing Quick Connect availability")
+
+  res = fetchRes(GetApi().BuildGetQuickConnectEnabledRequest(), "quickConnectEnabled")
+  if isValid(res) and res.ok
+    ' Endpoint returns a plain boolean body. Coerce defensively in case a
+    ' future server returns an object envelope.
+    enabled = res.json
+    if type(enabled) <> "Boolean" then enabled = (enabled = true)
+
+    m.global.server.isQuickConnectEnabled = enabled
+    m.log.info("Quick Connect availability probed", "enabled:", enabled)
+    m.top.responseCode = 200
+  else
+    ' Fail-open: do not touch isQuickConnectEnabled. Default (true) keeps
+    ' the button visible; the existing /QuickConnect/Initiate fallback
+    ' surfaces a clear error if QC actually turns out to be disabled.
+    m.log.warn("Quick Connect probe failed - keeping default availability")
+    m.top.responseCode = -1
+    m.top.failureReason = "API call failed or returned invalid"
+  end if
+end sub
+
+' Reset task to default state
+sub empty()
+  m.top.responseCode = invalid
+  m.top.failureReason = ""
+end sub

--- a/components/tasks/QuickConnectEnabledTask.bs
+++ b/components/tasks/QuickConnectEnabledTask.bs
@@ -13,26 +13,44 @@ end sub
 ' never hides a working feature.
 ' Sets responseCode to 200 on success, -1 on failure.
 sub fetchQuickConnectEnabled()
-  m.log.info("Probing Quick Connect availability")
-
-  res = fetchRes(GetApi().BuildGetQuickConnectEnabledRequest(), "quickConnectEnabled")
-  if isValid(res) and res.ok
-    ' Endpoint returns a plain boolean body. Coerce defensively in case a
-    ' future server returns an object envelope.
-    enabled = res.json
-    if type(enabled) <> "Boolean" then enabled = (enabled = true)
-
-    m.global.server.isQuickConnectEnabled = enabled
-    m.log.info("Quick Connect availability probed", "enabled:", enabled)
-    m.top.responseCode = 200
+  req = GetApi().BuildGetQuickConnectEnabledRequest()
+  if isValid(req)
+    m.log.info("Probing Quick Connect availability", "url:", req.url)
   else
-    ' Fail-open: do not touch isQuickConnectEnabled. Default (true) keeps
-    ' the button visible; the existing /QuickConnect/Initiate fallback
-    ' surfaces a clear error if QC actually turns out to be disabled.
-    m.log.warn("Quick Connect probe failed - keeping default availability")
+    m.log.warn("Quick Connect probe skipped - server URL not configured")
     m.top.responseCode = -1
-    m.top.failureReason = "API call failed or returned invalid"
+    m.top.failureReason = "server URL not configured"
+    return
   end if
+
+  res = fetchRes(req, "quickConnectEnabled")
+  if not isValid(res)
+    m.log.warn("Quick Connect probe returned no response (timeout or queue unavailable)")
+    m.top.responseCode = -1
+    m.top.failureReason = "fetchRes returned invalid"
+    return
+  end if
+
+  if not res.ok
+    ' Server reachable but returned a non-2xx status. Log and fail-open.
+    m.log.warn("Quick Connect probe got non-OK response", "statusCode:", res.statusCode, "text:", res.text)
+    m.top.responseCode = -1
+    m.top.failureReason = "non-ok statusCode: " + res.statusCode.toStr()
+    return
+  end if
+
+  ' Endpoint returns a plain boolean body. Coerce defensively in case a
+  ' future server returns an object envelope or wraps the value as a string.
+  enabled = res.json
+  enabledType = type(enabled)
+  if enabledType <> "Boolean" and enabledType <> "roBoolean"
+    m.log.warn("Quick Connect probe got unexpected body type", "type:", enabledType, "raw:", res.text)
+    enabled = (LCase(res.text.Trim()) = "true")
+  end if
+
+  m.global.server.isQuickConnectEnabled = enabled
+  m.log.info("Quick Connect availability probed", "enabled:", enabled, "statusCode:", res.statusCode)
+  m.top.responseCode = 200
 end sub
 
 ' Reset task to default state

--- a/components/tasks/QuickConnectEnabledTask.xml
+++ b/components/tasks/QuickConnectEnabledTask.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="QuickConnectEnabledTask" extends="Task">
+  <interface>
+    <field id="responseCode" type="integer" />
+    <field id="failureReason" type="string" value="" />
+    <function name="empty" />
+  </interface>
+</component>

--- a/locale/custom/en_US.json
+++ b/locale/custom/en_US.json
@@ -275,7 +275,7 @@
   "LabelPreviewAction": "Preview Action",
   "LabelPrimary": "Primary",
   "LabelPrograms": "Programs",
-  "LabelQuickConnectNotAvailable": "Quick Connect not available.",
+  "LabelQuickConnectNotAvailable": "Quick Connect is disabled on this server.",
   "LabelRandom": "Random",
   "LabelRandomOff": "Random Off",
   "LabelRandomOn": "Random On",

--- a/source/api/ApiClient.bs
+++ b/source/api/ApiClient.bs
@@ -543,9 +543,11 @@ class ApiClient
 
   ' Build a request AA for GetQuickConnectEnabled, for use with fetchRes() or fetchJson().
   ' Server responds with a plain boolean body (true = enabled, false = disabled).
+  ' Lowercase path matches the existing /quickconnect/initiate convention - Jellyfin's
+  ' routing is case-insensitive but reverse proxies in the wild sometimes are not.
   ' @returns Request AA: { method, url } or invalid if server URL not set
   function BuildGetQuickConnectEnabledRequest() as dynamic
-    return m.validatedReq("GET", buildURL("/QuickConnect/Enabled"))
+    return m.validatedReq("GET", buildURL("/quickconnect/enabled"))
   end function
 
   ' ═══════════════════════════════════════════════════════════════════════════

--- a/source/api/ApiClient.bs
+++ b/source/api/ApiClient.bs
@@ -541,6 +541,13 @@ class ApiClient
     return sdk.quickConnect.Connect(secret)
   end function
 
+  ' Build a request AA for GetQuickConnectEnabled, for use with fetchRes() or fetchJson().
+  ' Server responds with a plain boolean body (true = enabled, false = disabled).
+  ' @returns Request AA: { method, url } or invalid if server URL not set
+  function BuildGetQuickConnectEnabledRequest() as dynamic
+    return m.validatedReq("GET", buildURL("/QuickConnect/Enabled"))
+  end function
+
   ' ═══════════════════════════════════════════════════════════════════════════
   ' VIEWS ENDPOINTS
   ' ═══════════════════════════════════════════════════════════════════════════

--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/api/baseRequest.bs"
+import "pkg:/source/utils/misc.bs"
 
 ' Jellyfin SDK — thin wrappers around API endpoints.
 ' Only used by ApiClient (via GetApi()). Do NOT call these functions directly.
@@ -32,8 +33,17 @@ namespace sdk
     end function
 
     ' Initiate a new quick connect request.
+    ' Method changed at the same boundary as the apiVersion split:
+    '   apiVersion 1 (10.7.x - 10.8.x): GET
+    '   apiVersion 2 (10.9+):           POST
+    ' Sending the wrong method on modern servers yields 401 ("Quick connect is
+    ' not active on this server"), which is misleading - it is actually a
+    ' route mismatch, not a feature gate.
     function Initiate()
       req = APIRequest("/quickconnect/initiate")
+      if getApiVersionFromGlobal() >= 2
+        return postJson(req, "")
+      end if
       return getJson(req)
     end function
   end namespace

--- a/tests/source/unit/components/login/UserSelect.spec.bs
+++ b/tests/source/unit/components/login/UserSelect.spec.bs
@@ -7,6 +7,9 @@ namespace tests
 
     protected override function teardown()
       m.userSelect = invalid
+      ' Reset the global Quick Connect availability to its XML default so state
+      ' from one test cannot leak into the next.
+      m.global.server.isQuickConnectEnabled = true
     end function
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -66,6 +69,37 @@ namespace tests
       buttons = m.userSelect.findNode("buttons")
 
       m.assertEqual(buttons.getChild(0).id, "manualLoginButton")
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Server reports Quick Connect disabled (cached probe result)")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("removes the Quick Connect button when isQuickConnectEnabled is false at init")
+    ' Covers the synchronous "cached" path: a prior probe in this session wrote
+    ' false on the global server node, so init removes the button immediately
+    ' without waiting for another probe.
+    function _()
+      m.global.server.version = "10.10.0"
+      m.global.server.isQuickConnectEnabled = false
+      m.userSelect = CreateObject("roSGNode", "UserSelect")
+      buttons = m.userSelect.findNode("buttons")
+
+      m.assertEqual(buttons.getChildCount(), 1)
+      m.assertInvalid(buttons.findNode("quickConnect"))
+      m.assertEqual(buttons.getChild(0).id, "manualLoginButton")
+    end function
+
+    @it("keeps the Quick Connect button when isQuickConnectEnabled is true (default)")
+    ' Fail-open default: probe hasn't completed yet, button stays visible.
+    function _()
+      m.global.server.version = "10.10.0"
+      m.global.server.isQuickConnectEnabled = true
+      m.userSelect = CreateObject("roSGNode", "UserSelect")
+      buttons = m.userSelect.findNode("buttons")
+
+      m.assertEqual(buttons.getChildCount(), 2)
+      m.assertNotInvalid(buttons.findNode("quickConnect"))
     end function
 
   end class


### PR DESCRIPTION
NOTE: Quick connect worked with my home server before this PR but using the button with the demo server exposed the bug fixed in this PR.

The "Quick Connect not available" dialog on modern servers was caused by `sdk.quickConnect.Initiate` sending GET on every version. The spec changed to POST in Jellyfin 10.9.0, so modern servers respond with 401 *"Quick connect is not active on this server"* — which reads like a feature gate but is actually a route mismatch. Verified working on the Jellyfin demo (10.11/unstable), latest stable, and 10.7.

Also fixes a latent bug in `SceneManager.userMessage()` where the dialog body was assigned a string to an array-of-strings field (silently rendered empty), and adds a proactive `/QuickConnect/Enabled` probe so the button is hidden on servers where an admin has disabled the feature in config.

## Changes

- Version-dispatch `sdk.quickConnect.Initiate()`: GET on apiVersion 1 (10.7.x–10.8.x), POST on apiVersion 2 (10.9+)
- Add `BuildGetQuickConnectEnabledRequest()` and `QuickConnectEnabledTask` to probe `/quickconnect/enabled` off the render thread (mirrors `BrandingConfigTask` shape and routes through the API pool)
- Add `isQuickConnectEnabled` field on `JellyfinServer` (default `true`, fail-open) and gate the QC button on it from `UserSelect`
- Fix `SceneManager.userMessage()` empty-body bug (`StandardMessageDialog.message` is array-of-strings, was being assigned a bare string); also unblocks two settings.bs validation dialogs
- Sharpen fallback copy: *"Quick Connect not available."* → *"Quick Connect is disabled on this server."*
- Add unit tests for the cached-disabled and default-enabled UserSelect paths

## Test plan

- [x] `npm run test:unit` — 2022 / 2022 pass
- [x] Manual: latest stable Jellyfin — Quick Connect button shows, click reveals code as before
- [x] Manual: Jellyfin demo (10.11/unstable) — Quick Connect button shows, click reveals code (was failing pre-fix with empty dialog)
- [x] Manual: 10.7 server — no regression (QC button correctly hidden by existing version gate)


## Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/94a56640-7849-4369-ba25-800d1121fa5c" />

## After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2213f85d-da8f-436f-91c9-7ba408da08f7" />
