### PR TITLE
feat: support Quick Connect on Jellyfin 10.7.x

### DIFF
--- a/components/login/UserSelect.bs
+++ b/components/login/UserSelect.bs
@@ -13,24 +13,23 @@ sub init()
   m.top.findNode("manualLoginButton").text = translate(translationKeys.ButtonManualLogin)
   m.buttons = m.top.findNode("buttons")
 
-  ' Quick Connect requires server >= 10.8.0 AND must be enabled in server config.
-  ' Remove the button entirely (rather than hiding it) when unsupported -
-  ' JRButtonGroup focus/navigation honors isEnabled but not visible, so an
-  ' invisible button at index 0 would silently steal default focus.
+  ' Quick Connect is supported on every Jellyfin version JellyRock targets
+  ' (>= 10.7.0). Endpoint and request-shape differences are handled inside
+  ' sdk.quickConnect.* via versionChecker / apiVersion dispatch. The button is
+  ' removed only when the server explicitly reports the feature disabled.
   m.quickConnectButton = m.top.findNode("quickConnect")
-  if not versionChecker(m.global.server.version, "10.8.0")
-    removeQuickConnectButton("server version below 10.8.0, version:" + m.global.server.version)
+  m.quickConnectButton.text = translate(translationKeys.ButtonQuickConnect)
+  ' Apply prior probe result immediately if already known disabled this session.
+  ' Default of true (fail-open) means the button stays unless we have evidence.
+  if m.global.server.isQuickConnectEnabled = false
+    removeQuickConnectButton("server reports Quick Connect disabled (cached)")
   else
-    m.quickConnectButton.text = translate(translationKeys.ButtonQuickConnect)
-    ' Apply prior probe result immediately if already known disabled this session.
-    ' Default of true (fail-open) means the button stays unless we have evidence.
-    if m.global.server.isQuickConnectEnabled = false
-      removeQuickConnectButton("server reports Quick Connect disabled (cached)")
-    else
-      ' Probe is started in OnScreenShown (matches BrandingConfigTask timing).
-      m.quickConnectEnabledTask = createObject("roSGNode", "QuickConnectEnabledTask")
-      m.log.debug("Created QuickConnectEnabledTask")
-    end if
+    ' Probe is started in OnScreenShown (matches BrandingConfigTask timing).
+    ' On 10.7 the /QuickConnect/Enabled endpoint is missing, so the probe
+    ' fails open (button stays visible) - the dialog fallback handles the
+    ' rare admin-disabled case there.
+    m.quickConnectEnabledTask = createObject("roSGNode", "QuickConnectEnabledTask")
+    m.log.debug("Created QuickConnectEnabledTask")
   end if
 
   m.buttons.callFunc("center")

--- a/docs/dev/jellyfin-server-versioning.md
+++ b/docs/dev/jellyfin-server-versioning.md
@@ -102,13 +102,26 @@ The `MediaSegments` API provides segment timing data (intro, outro, recap, previ
 
 ### 5. Authentication Compatibility
 
-Most authentication flows work across all versions, with one exception:
+Most authentication flows work across all versions, with one quirk for
+Quick Connect.
 
-**Quick Connect Field Name:**
+**Quick Connect:**
 
-- 10.7.x: Uses `Token` field
-- 10.8.x+: Uses `Secret` field
-- Current implementation uses `Secret` (10.8.x+ compatible)
+The two QC dispatches operate on different version boundaries — the SDK
+handles them separately:
+
+| Concern | 10.7.x | 10.8.x | 10.9.0+ | Boundary |
+| ------- | ------ | ------ | ------- | -------- |
+| `AuthenticateWithQuickConnect` body | `{ "Token": secret }` | `{ "Secret": secret }` | `{ "Secret": secret }` | `versionChecker(version, "10.8.0")` |
+| `/QuickConnect/Initiate` HTTP method | `GET` | `GET` | `POST` | `getApiVersionFromGlobal() >= 2` |
+| `/QuickConnect/Connect` | `GET ?secret=` | same | same | n/a |
+| `/QuickConnect/Enabled` (gating probe) | missing | present | present | fail-open in `QuickConnectEnabledTask` |
+
+`source/api/sdk.bs` dispatches both at call time, so callers
+(`source/api/userAuth.bs`, `components/quickConnect/*`) are version-agnostic.
+The Token→Secret split happens at 10.8.0 (a *finer* boundary than the
+`apiVersion` 1→2 split at 10.9.0), so it uses raw `versionChecker` rather than
+the `apiVersion` integer.
 
 Username/password authentication works identically across all versions.
 

--- a/docs/user/jellyfin-server-feature-matrix.md
+++ b/docs/user/jellyfin-server-feature-matrix.md
@@ -14,7 +14,7 @@ This document shows which JellyRock features require specific Jellyfin server ve
 | Feature                   | 10.7.x | 10.8.x | 10.9.x | 10.10.x+ | Notes                           |
 | ------------------------- | ------ | ------ | ------ | -------- | ------------------------------- |
 | **Trickplay Thumbnails**  | ❌     | ❌     | ✅     | ✅       | Video preview scrubbing         |
-| **Quick Connect**         | ❌     | ✅     | ✅     | ✅       | 10.7 uses "Token" not "Secret"  |
+| **Quick Connect**         | ✅     | ✅     | ✅     | ✅       | Auto-dispatches per server API  |
 | **Media Segments**        | ❌     | ❌     | ❌     | ✅       | Skip intro/outro/recap/etc.     |
 
 ## Legend
@@ -28,12 +28,16 @@ This document shows which JellyRock features require specific Jellyfin server ve
 
 ### Quick Connect
 
-Quick Connect authentication requires Jellyfin 10.8 or newer.
+Quick Connect works on every supported Jellyfin version. JellyRock auto-detects
+the server version and uses the right request shape.
 
-- **10.7**: ❌ Does not work (API uses "Token" field, app sends "Secret")
-- **10.8+**: ✅ Works correctly
+- **10.7.x**: ✅ Works — uses `Token` body field on `AuthenticateWithQuickConnect`
+- **10.8.x**: ✅ Works — uses `Secret` body field; `Initiate` is `GET`
+- **10.9.0+**: ✅ Works — uses `Secret` body field; `Initiate` is `POST`
 
-Use username/password login for 10.7 servers.
+The Quick Connect button is hidden when the server explicitly reports the
+feature disabled (10.8+ via `/QuickConnect/Enabled`); on 10.7 the button is
+always shown and a clear dialog appears if Quick Connect is unavailable.
 
 ### Media Segments
 

--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -80,9 +80,15 @@ namespace sdk
     end function
 
     ' Authenticates a user with quick connect.
+    ' Body field renamed in 10.8.0 (a finer boundary than the apiVersion split):
+    '   10.7.x:   { "Token": secret }
+    '   10.8.0+:  { "Secret": secret }
     function AuthenticateWithQuickConnect(secret as string)
       req = APIRequest("/users/authenticatewithquickconnect")
-      return postJson(req, FormatJson({ "secret": secret }))
+      if versionChecker(m.global.server.version, "10.8.0")
+        return postJson(req, FormatJson({ "Secret": secret }))
+      end if
+      return postJson(req, FormatJson({ "Token": secret }))
     end function
   end namespace
 

--- a/tests/source/unit/components/login/UserSelect.spec.bs
+++ b/tests/source/unit/components/login/UserSelect.spec.bs
@@ -1,6 +1,6 @@
 namespace tests
 
-  @suite("UserSelect - Quick Connect button gating by server version")
+  @suite("UserSelect - Quick Connect button gating")
   class UserSelectQuickConnectTests extends tests.BaseTestSuite
 
     private userSelect as object
@@ -13,13 +13,19 @@ namespace tests
     end function
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    @describe("Server supports Quick Connect (version >= 10.8.0)")
+    @describe("Quick Connect button is shown on every supported server version")
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
     @it("renders the Quick Connect button inside the button group")
+    ' Quick Connect is supported on every Jellyfin version JellyRock targets
+    ' (>= 10.7.0). Version differences in request shape are handled inside
+    ' sdk.quickConnect.* via per-call dispatch, not by hiding the button.
+    @params("10.7.0")
+    @params("10.7.9")
     @params("10.8.0")
     @params("10.9.5")
     @params("10.10.0")
+    @params("10.11.8")
     function _(version as string)
       m.global.server.version = version
       m.userSelect = CreateObject("roSGNode", "UserSelect")
@@ -31,6 +37,7 @@ namespace tests
     end function
 
     @it("places Quick Connect at index 0 (default focus position)")
+    @params("10.7.0")
     @params("10.8.0")
     @params("10.10.0")
     function _(version as string)
@@ -39,36 +46,6 @@ namespace tests
       buttons = m.userSelect.findNode("buttons")
 
       m.assertEqual(buttons.getChild(0).id, "quickConnect")
-    end function
-
-    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    @describe("Server does not support Quick Connect (version < 10.8.0)")
-    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-    @it("removes the Quick Connect button from the button group")
-    ' Regression guard: a hidden-but-present button at index 0 would silently
-    ' steal default focus, since JRButtonGroup honors isEnabled but not visible.
-    @params("10.7.9")
-    @params("10.6.0")
-    @params("10.0.0")
-    function _(version as string)
-      m.global.server.version = version
-      m.userSelect = CreateObject("roSGNode", "UserSelect")
-      buttons = m.userSelect.findNode("buttons")
-
-      m.assertEqual(buttons.getChildCount(), 1)
-      m.assertInvalid(buttons.findNode("quickConnect"))
-    end function
-
-    @it("leaves Manual Login as the index-0 (default focus) child")
-    @params("10.7.9")
-    @params("10.0.0")
-    function _(version as string)
-      m.global.server.version = version
-      m.userSelect = CreateObject("roSGNode", "UserSelect")
-      buttons = m.userSelect.findNode("buttons")
-
-      m.assertEqual(buttons.getChild(0).id, "manualLoginButton")
     end function
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Quick Connect now works on every Jellyfin version JellyRock targets. The only meaningful difference on 10.7 is that `AuthenticateWithQuickConnect` expects `{ "Token": secret }` rather than the `{ "Secret": secret }` shape introduced in 10.8.0. The dispatch lives inside `sdk.users.AuthenticateWithQuickConnect` so callers stay version-agnostic. Verified end-to-end on a 10.7 server (button shown, code displayed, approval signs the user in).

The Token→Secret boundary is finer than the existing `apiVersion` 1→2 boundary (which sits at 10.9.0), so this dispatch uses raw `versionChecker(version, "10.8.0")` rather than `getApiVersionFromGlobal()`.

## Changes

- Version-dispatch `sdk.users.AuthenticateWithQuickConnect`: 10.7.x sends `{ "Token": secret }`, 10.8.0+ sends `{ "Secret": secret }`
- Remove the `>= 10.8.0` Quick Connect button gate from `UserSelect`; 10.7 is the lowest supported server, so the gate was always true. The `/QuickConnect/Enabled` probe still hides the button on disabled servers and fails open on 10.7 (endpoint missing)
- Update `docs/user/jellyfin-server-feature-matrix.md` to mark 10.7 as ✅ for Quick Connect with per-version notes
- Update `docs/dev/jellyfin-server-versioning.md` with a Quick Connect dispatch table showing both boundaries (10.8.0 for the body field, 10.9.0 for the HTTP method)
- Replace the obsolete "button hidden on < 10.8.0" unit tests with a cross-version "button shown" check covering 10.7.0 → 10.11.8

## Test plan

- [x] `npm run test:unit` — 2021 / 2021 pass
- [x] Manual: 10.7 server — Quick Connect button shows, code displays, web-client approval signs in
- [x] Manual: latest stable + 10.11/unstable still work (no regression — same dispatch infrastructure as the prior PR)