### PR TITLE
fix(trackDropdown): measure dropdown width with themed Label

### DIFF
--- a/components/ui/dropdown/TrackDropdown.bs
+++ b/components/ui/dropdown/TrackDropdown.bs
@@ -40,17 +40,6 @@ const TRACK_DROPDOWN_ROW_H_PADDING = 12
 ' widths plus this gutter so an open menu never spans more than two columns of
 ' horizontal real estate.
 const TRACK_DROPDOWN_INTER_SLOT_GUTTER = 30
-' Multiplier applied to the TextSizeTask measurement when computing menu width.
-' GetOneLineWidth returns the font-metric width which can come up a few pixels
-' short of how the actual ScrollingLabel renders. The gap varies per string —
-' caps-heavy strings with numbers ("ENGLISH TRUEHD 7.1") drift only ~2-3px while
-' mixed-case strings with punctuation ("Spanish; Castilian SUBRIP") can drift
-' more — so a flat fudge constant is the wrong shape: it either over-pads short
-' strings or under-pads long ones. Scaling proportionally to the measured width
-' tracks the actual risk: short strings get a small buffer (no wasted space),
-' long strings get a larger buffer (no clipping). 3% is the lowest stable value
-' on tested hardware; bump to 1.04 / 1.05 if any title ever clips again.
-const TRACK_DROPDOWN_TEXT_WIDTH_MULTIPLIER = 1.03
 
 sub init()
   m.log = new log.Logger("TrackDropdown")
@@ -69,12 +58,12 @@ sub init()
   m.visibleRows = 5
   m.rowHeight = 0 ' computed in onItemsChanged
 
-  ' TextSizeTask is required because roFontRegistry / Font.GetOneLineWidth are
-  ' MAIN|TASK-only — they cannot be created on the render thread where component
-  ' field observers run. The task receives titles + font size, returns a width
-  ' array we observe on the "width" field. See JRButtons.bs for the same pattern.
-  m.textSizeTask = CreateObject("roSGNode", "TextSizeTask")
-  m.textSizeTask.observeField("width", "onTextSizeTaskComplete")
+  ' Hidden Label used to measure each item's natural pixel width before we size the
+  ' menu. We use a themed LabelPrimarySmaller — same theme as the rendered row's
+  ' ScrollingLabel — so font URI + fontSizeSmaller + uiFontFallback scaling come
+  ' for free via LabelSmaller.init / JRLabel.init. Same trick FontScalingTask uses
+  ' against scene-level defaultFont/fallbackFont nodes (see FontScalingTask.bs).
+  m.measureLabel = m.top.findNode("measureLabel")
 
   m.top.observeField("focusedChild", "onFocusChanged")
 
@@ -163,7 +152,6 @@ end sub
 ' duplication read as "your current value, persistent above and inside the menu"
 ' rather than competing with the alternatives. See TrackDropdownRow.onFocusStateChanged.
 sub onItemsChanged()
-  ' Clear existing items
   m.menuItems.removeChildren(m.menuItems.getChildren(-1, 0))
   m.menuItems.translation = [0, 0]
   m.focusedItemIndex = 0
@@ -176,129 +164,66 @@ sub onItemsChanged()
   end if
 
   constants = m.global.constants
-  slotWidth = m.top.slotWidth
+  slotWidth = int(m.top.slotWidth)
 
   ' Row height matches trigger font (fontSizeSmaller 25) with breathing padding so
   ' focus border doesn't crowd the text. Mirrors JRDropdown's formula structure
   ' (line height + padding) scaled for the smaller font.
   m.rowHeight = int(constants.fontSizeSmaller * 1.0) + 20
 
-  ' Initial menu width = slotWidth. The async TextSizeTask measures each title and
-  ' may widen the menu up to 2 slot widths + the inter-slot gutter if titles are
-  ' long. In normal usage the task completes well before the user opens the menu,
-  ' so the user sees the auto-sized width — not the slotWidth fallback. If the
-  ' task hasn't completed (or doesn't run, e.g. in unit-test environment), the
-  ' menu still renders correctly at slotWidth, just without the long-title fit.
-  initialWidth = slotWidth
+  menuWidth = computeMenuWidth(items, slotWidth)
 
   for each item in items
     menuItem = CreateObject("roSGNode", "TrackDropdownRow")
     menuItem.text = item.title
     menuItem.itemId = item.id
-    menuItem.itemWidth = initialWidth
+    menuItem.itemWidth = menuWidth
     menuItem.itemHeight = m.rowHeight
     m.menuItems.appendChild(menuItem)
   end for
 
   visibleRows = m.visibleRows
   if items.count() < visibleRows then visibleRows = items.count()
-
   viewportHeight = m.rowHeight * visibleRows
+
   ' clippingRect is in the viewport's local coords: [x, y, width, height]. Anything the
   ' menuItems LayoutGroup draws outside this rect is invisible, enabling the scroll UX.
-  m.menuViewport.clippingRect = [0, 0, initialWidth, viewportHeight]
-
-  m.menuBackground.width = initialWidth
+  m.menuViewport.clippingRect = [0, 0, menuWidth, viewportHeight]
+  m.menuBackground.width = menuWidth
   m.menuBackground.height = viewportHeight
 
   if isValidAndNotEmpty(m.top.selectedItemId)
     onSelectedItemChanged()
   end if
-
-  ' Kick off async measurement to refine width once the task returns.
-  measureMenuWidthAsync(items)
 end sub
 
-' measureMenuWidthAsync: Pushes the item titles through TextSizeTask so the task
-' can call roFontRegistry / GetOneLineWidth on a non-render thread (the registry
-' is MAIN|TASK-only). Result is delivered via the "width" observer below.
-sub measureMenuWidthAsync(items as object)
-  if not isValid(m.textSizeTask) then return
-  ' Cancel any in-flight measurement so an older items[] response can't overwrite
-  ' a newer one.
-  m.textSizeTask.control = "STOP"
-
-  titles = []
-  for each item in items
-    if isValid(item.title) then titles.push(item.title)
-  end for
-  if titles.count() = 0 then return
-
-  m.textSizeTask.fontsize = m.global.constants.fontSizeSmaller
-  ' Leave maxWidth at its XML default (1920 = full screen width). 1920 is wider
-  ' than any realistic track title at fontSizeSmaller so GetOneLineWidth returns
-  ' natural unwrapped widths, and we avoid passing an unusually large value that
-  ' could perturb the font-metric calculation.
-  m.textSizeTask.text = titles
-  m.textSizeTask.control = "RUN"
-end sub
-
-' onTextSizeTaskComplete: Reads the per-title widths produced by TextSizeTask,
-' picks the maximum, adds row padding, and clamps to [slotWidth, slotWidth*2 +
-' interSlotGutter]. The lower clamp keeps the menu anchored under its trigger
-' column; the upper clamp prevents an open menu from spanning more than two
-' columns of horizontal real estate. Then resizes menuBackground, the clipping
-' viewport, and every row in lockstep.
-sub onTextSizeTaskComplete()
-  widths = m.textSizeTask.width
-  if not isValid(widths) or widths.count() = 0 then return
-
-  ' Reject stale results: when the user changes the video source we STOP+RUN the
-  ' task with new titles, but a result from the previous run can still land
-  ' (control=STOP doesn't interrupt a synchronous getTextSize() in progress). If
-  ' the menu's current row count no longer matches the measured count, the items
-  ' array changed mid-flight — drop this result and let the in-flight task's
-  ' completion apply the up-to-date measurements.
-  if widths.count() <> m.menuItems.getChildCount() then return
-
+' Returns the menu width that fits the longest item title, clamped to
+' [slotWidth, slotWidth*2 + interSlotGutter]. The lower clamp keeps the menu
+' anchored under its trigger column; the upper clamp stops an open menu from
+' spanning more than two columns of horizontal real estate.
+'
+' Measurement is pixel-exact: m.measureLabel is a themed LabelPrimarySmaller, so
+' setting its text and reading boundingRect().width returns the same width the
+' rendered row's ScrollingLabel will use (same font, same fontSizeSmaller, same
+' uiFontFallback scale factor). No fudge multiplier needed. Same render-thread
+' boundingRect technique FontScalingTask uses against the scene's defaultFont /
+' fallbackFont labels.
+function computeMenuWidth(items as object, slotWidth as integer) as integer
   maxTextWidth = 0
-  for each w in widths
-    iw = int(w)
-    if iw > maxTextWidth then maxTextWidth = iw
+  for each item in items
+    if isValid(item.title)
+      m.measureLabel.text = item.title
+      w = int(m.measureLabel.boundingRect().width)
+      if w > maxTextWidth then maxTextWidth = w
+    end if
   end for
 
-  ' Scale the measured width by the multiplier to compensate for the per-string
-  ' render-vs-metric gap (see TRACK_DROPDOWN_TEXT_WIDTH_MULTIPLIER comment for
-  ' rationale), then add row padding for the menu's inner edges.
-  desired = int(maxTextWidth * TRACK_DROPDOWN_TEXT_WIDTH_MULTIPLIER) + (TRACK_DROPDOWN_ROW_H_PADDING * 2)
-  ' m.top.slotWidth is dynamic (node field); coerce to int so 'desired' stays
-  ' integer-typed across the clamp comparisons.
-  slotWidth = int(m.top.slotWidth)
+  desired = maxTextWidth + (TRACK_DROPDOWN_ROW_H_PADDING * 2)
   if desired < slotWidth then desired = slotWidth
   upperBound = (slotWidth * 2) + TRACK_DROPDOWN_INTER_SLOT_GUTTER
   if desired > upperBound then desired = upperBound
-
-  applyMenuWidth(desired)
-end sub
-
-' applyMenuWidth: Resizes the menu in lockstep — background + clipping viewport +
-' every row's itemWidth. Called from onTextSizeTaskComplete; no-op if the menu
-' has been torn down between task launch and task completion.
-sub applyMenuWidth(width as integer)
-  if not isValid(m.menuItems) then return
-  rowCount = m.menuItems.getChildCount()
-  if rowCount = 0 then return
-
-  visibleRows = m.visibleRows
-  if rowCount < visibleRows then visibleRows = rowCount
-  viewportHeight = m.rowHeight * visibleRows
-
-  m.menuViewport.clippingRect = [0, 0, width, viewportHeight]
-  m.menuBackground.width = width
-  for i = 0 to rowCount - 1
-    m.menuItems.getChild(i).itemWidth = width
-  end for
-end sub
+  return desired
+end function
 
 sub onSelectedItemChanged()
   selectedId = m.top.selectedItemId
@@ -604,16 +529,11 @@ sub destroy()
 
   m.menuItems.removeChildren(m.menuItems.getChildren(-1, 0))
 
-  if isValid(m.textSizeTask)
-    m.textSizeTask.unobserveField("width")
-    m.textSizeTask.control = "STOP"
-    m.textSizeTask = invalid
-  end if
-
   m.buttonBackground = invalid
   m.buttonBorder = invalid
   m.triggerLabel = invalid
   m.triggerChevron = invalid
+  m.measureLabel = invalid
   m.menuContainer = invalid
   m.menuBackground = invalid
   m.menuViewport = invalid

--- a/components/ui/dropdown/TrackDropdown.xml
+++ b/components/ui/dropdown/TrackDropdown.xml
@@ -36,6 +36,15 @@
          Sized 1:1 with the source bitmap so it renders crisp at native resolution. -->
     <Poster id="triggerChevron" uri="pkg:/images/icons/expand.png" width="24" height="24" />
 
+    <!-- Hidden Label used to measure each item title's natural pixel width before
+         the menu is sized. LabelPrimarySmaller mirrors the rendered row's font/scale
+         (LabelSmaller.init sets fontSizeSmaller; JRLabel.init applies tmp:/font +
+         fontScaleFactor when uiFontFallback is on), so boundingRect().width returns
+         the same width the ScrollingLabel inside TrackDropdownRow will render at.
+         Same render-thread technique FontScalingTask uses against the scene's
+         defaultFont / fallbackFont labels. -->
+    <LabelPrimarySmaller id="measureLabel" visible="false" />
+
     <!-- Dropdown menu: background + clipped viewport containing a LayoutGroup of
          JRDropdownItem children. The viewport's clippingRect caps visible rows; the
          inner LayoutGroup translation scrolls longer lists in and out of view. -->

--- a/tests/source/unit/components/TrackDropdown.spec.bs
+++ b/tests/source/unit/components/TrackDropdown.spec.bs
@@ -176,16 +176,17 @@ namespace tests
       m.assertEqual(int(clipRect.height), 225)
     end function
 
-    @it("menu starts at slotWidth on items[] change (TextSizeTask refines async)")
+    @it("menu width clamps up to slotWidth when titles are narrower than the slot")
     function _()
-      ' Initial menu width is slotWidth in sync state — the auto-expand happens
-      ' async via TextSizeTask once it returns measured widths. This test locks in
-      ' the synchronous fallback so a future change can't accidentally leave the
-      ' menu at zero width if the task fails to run.
-      ' NOTE: the auto-expand-to-fit-long-titles behavior (upper clamp at 2 slots
-      ' + inter-slot gutter = 586) is NOT covered by unit tests because TextSizeTask
-      ' creates roFontRegistry on its own thread and unit tests don't drive the
-      ' task scheduler synchronously. Verified via manual / integration testing.
+      ' computeMenuWidth measures each title via the hidden LabelPrimarySmaller and
+      ' clamps the result to [slotWidth, slotWidth*2 + interSlotGutter]. "Off" / "On"
+      ' both measure well below slotWidth, so the lower clamp wins and the menu
+      ' renders at slotWidth — locking the menu to its trigger column when nothing
+      ' is long enough to warrant expansion.
+      ' NOTE: the upper-clamp / auto-expand-for-long-titles behavior is NOT covered
+      ' here because boundingRect() on a Label returns 0 outside a real scene tree;
+      ' the unit-test dropdown isn't attached to a scene. Verified via manual /
+      ' integration testing on device.
       m.dropdown.items = [
         { id: "1", title: "Off" },
         { id: "2", title: "On" }


### PR DESCRIPTION
Open-menu width came back too narrow for the longest title (e.g. `[Colourized] 480p H264` clipped to `[Colourized] 480p H2…`). Root cause was a font-metric mismatch: `TextSizeTask`'s `roFontRegistry.GetDefaultFont` + `GetOneLineWidth` measurement returned widths up to ~58px short of what the rendered `ScrollingLabel` actually drew, and the `1.03` fudge multiplier was a flat scalar that couldn't keep up — short caps-heavy strings barely drift, mixed-case strings with brackets/punctuation drift much more.

This swaps the measurement technique to a hidden, themed `LabelPrimarySmaller` measured via `boundingRect()` on the render thread — same approach `FontScalingTask` already uses against the scene's `defaultFont` / `fallbackFont` labels. Because the measurer is a themed label, font URI + `fontSizeSmaller` + `uiFontFallback` scale factor all come for free via `LabelSmaller.init` / `JRLabel.init`, so it works for the Roku default font and any user-installed fallback font without a code path change.

Probe results from device confirmed pixel-exact widths (`[Colourized] 480p H264` → 268px, `English AAC stereo (default)` → 313px) with both `boundingRect()` and `localBoundingRect()` returning the same numbers synchronously.

## Changes

- Removed `TextSizeTask` wiring from `TrackDropdown` (creation, observer, destroy cleanup) and the `TRACK_DROPDOWN_TEXT_WIDTH_MULTIPLIER = 1.03` fudge constant
- Added a hidden `<LabelPrimarySmaller id="measureLabel" visible="false" />` to `TrackDropdown.xml`
- Replaced async `measureMenuWidthAsync` / `onTextSizeTaskComplete` / `applyMenuWidth` with a synchronous `computeMenuWidth(items, slotWidth)` function that measures via `m.measureLabel.boundingRect().width`
- `onItemsChanged` now computes the final menu width up-front and creates rows at that width — no more "render at slotWidth, resize on async result" two-step
- Updated the unit-test narrative for the slotWidth-clamp case (assertion unchanged; old comment referenced the deleted async path)

## Test plan

- [ ] Open Dracula → expand Video — `[Colourized] 480p H264` renders fully, no `…`
- [ ] Audio dropdown fits `English AAC stereo (default)` (313px) without truncation
- [ ] Subtitles `Off` / single-language menu still pins to `slotWidth` (no over-expansion)
- [ ] Enable `uiFontFallback` and verify the same items measure correctly with the user font
- [ ] Switch video source while dropdown is closed; reopen — width re-measures against new items (no stale-measurement regression)
- [ ] Confirm an artificially long title still caps at `slotWidth*2 + 30 = 586px`
- [ ] `npm run test:unit` passes

## Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/465f5ebe-1ff1-455a-9879-44e13affce3d" />

## After 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e2b19a7b-8570-44d0-ae67-2b6bdaafb3e5" />
