### PR TITLE
docs(arch): migrate cruft callouts to tech-debt.md across 12 docs

### DIFF
--- a/.github/workflows/device-unit-tests.yml
+++ b/.github/workflows/device-unit-tests.yml
@@ -9,31 +9,18 @@ name: Device Unit Tests
 # setting does NOT apply to pull_request_target events.
 #
 # See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk
+#
+# No event-time `paths:` filter — see .github/actions/changed-paths/action.yml.
+# `check-skip` short-circuits internally when no test-relevant files changed,
+# so both `check-skip` and `all-tests` always report a status and can be wired
+# as required checks without stalling PRs that don't touch source / tests.
 
 on:
   push:
     branches:
       - main
-    paths:
-      - "tests/**"
-      - "source/**"
-      - "components/**"
-      - "settings/settings.json"
-      - "bsconfig.json"
-      - "bsconfig-tests*.json"
-      - "package.json"
-      - "package-lock.json"
   pull_request_target:
     types: [opened, synchronize]
-    paths:
-      - "tests/**"
-      - "source/**"
-      - "components/**"
-      - "settings/settings.json"
-      - "bsconfig.json"
-      - "bsconfig-tests*.json"
-      - "package.json"
-      - "package-lock.json"
   workflow_dispatch:
     inputs:
       test_type:
@@ -59,10 +46,17 @@ jobs:
   check-skip:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.check.outputs.skip }}
+      should_skip: ${{ steps.combined.outputs.skip }}
     steps:
+      # Checkout is needed so the `./.github/actions/changed-paths` composite
+      # action can be loaded. Under pull_request_target this is the BASE
+      # branch's copy of the action — PR-controlled action code never runs
+      # with the elevated token, which is the same security posture as the
+      # rest of this workflow.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Check if push is from PR merge
-        id: check
+        id: merge_check
         run: |
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
             if echo "${{ github.event.head_commit.message }}" | grep -q "Merge pull request"; then
@@ -73,7 +67,30 @@ jobs:
               echo "skip=false" >> $GITHUB_OUTPUT
             fi
           else
-            echo "This is a PR or manual trigger - always run tests"
+            echo "This is a PR or manual trigger"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Detect test-relevant changes
+        id: path_check
+        uses: ./.github/actions/changed-paths
+        with:
+          # Mirrors the previous event-time paths filter:
+          #   tests/**, source/**, components/**, settings/settings.json,
+          #   bsconfig.json, bsconfig-tests*.json, package.json, package-lock.json
+          pattern: '^(tests/|source/|components/|settings/settings\.json$|bsconfig\.json$|bsconfig-tests[^/]*\.json$|package(-lock)?\.json$)'
+
+      - name: Combine skip reasons
+        id: combined
+        run: |
+          if [[ "${{ steps.merge_check.outputs.skip }}" == "true" ]]; then
+            echo "Skipping: push is a PR merge to main (tests already ran on PR)"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ steps.path_check.outputs.relevant }}" == "false" ]]; then
+            echo "Skipping: PR did not touch test-relevant files"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Running: tests will execute"
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -323,11 +323,6 @@ end if
 
 `docs/dev/jellyfin-server-versioning.md` has the canonical version-policy guide.
 
-## Cruft callouts
+## Known cruft
 
-- **Two ways to call the same thing.** `ApiClient` has both `Get*()` (sync) and `Build*Request()` (async pool) methods for many endpoints. The migration to pool-only is ongoing. Sync methods are flagged in code with comments but not removed because the bootstrap path (login, server info) still needs them. Eventually the pool should be available pre-login and these can be unified.
-- **`source/api/sdk.bs` namespace is mostly legacy.** Per its own header comment: "Only used by `ApiClient` (via `GetApi`()). Do NOT call these functions directly." Some callers still bypass `ApiClient` and call `sdk.<namespace>.<function>` directly. These should be migrated.
-- **No request cancellation.** A `submitApiRequest` that's no longer needed (e.g., user navigated away) can't be canceled — it'll complete and fire its callback regardless. Most callers handle this by checking "am I still the active screen?" in the callback, but that's defensive at the call site.
-- **Per-method `V1/V2` branching.** Adding a third API version means editing every Build method. A central routing table (path templates per version) would scale better, but the current shape is explicit and grep-able, which has its own merits.
-- **`buildParams` doesn't handle `roArray` values.** Has a `' TODO handle array params` comment. Workaround: callers join arrays into comma-separated strings before passing.
-- **API timeout is a single value.** `timeouts.API_WAIT_MS` is one number for all API calls. A long search vs. a quick favorite toggle have the same patience.
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for API / `ApiClient` entries.

--- a/docs/architecture/bootstrap.md
+++ b/docs/architecture/bootstrap.md
@@ -204,9 +204,6 @@ end if
 
 This runs **after** the home screen is loaded (so the user lands on home if they back out of playback). All other deep-link types (audio, photo, etc.) fall through to the regular event loop.
 
-## Cruft callouts
+## Known cruft
 
-- **`main.bs` is large** with many distinct responsibilities crammed into the event loop: playback, favorites toggle, watched toggle, voice search, quickplay dispatch, font download completion, screen lifecycle. Could be decomposed into per-concern handler modules. (See `tech-debt.md`.)
-- **The `appStart:` label and `goto`-based restart** for "log out and start over" is `BrightScript-old-school`. Works fine, but unusual today; a `loop { ... break }` would read more naturally.
-- **`printRegistry()` runs unconditionally** at startup. Useful in dev, noisy in prod logs unless filtered by log level.
-- **The `quickPlayNode` set-then-clear pattern** is the unusual receiver side of the event idiom. Canonical explanation in `user-journey.md` ("The set-then-clear pattern" section).
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for bootstrap / `main.bs` entries.

--- a/docs/architecture/debug-tools.md
+++ b/docs/architecture/debug-tools.md
@@ -142,6 +142,6 @@ end function
 
 Why key UP events specifically: BrightScript convention is for child components to return `false` for `press=false`, so all key UP events bubble up to `JRScene`. This guarantees the sequence is tracked regardless of which screen has focus.
 
-## Cruft callouts
+## Known cruft
 
-- **`testToast` is in production builds too.** It's not gated by `#if debug`. The field exists on the JRScene interface always; only the cheat code is debug-gated. Documented for completeness; not a security concern on Roku's sandboxed platform.
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for debug-tools / `JRScene` entries.

--- a/docs/architecture/global-state.md
+++ b/docs/architecture/global-state.md
@@ -212,9 +212,6 @@ Compiled out in production builds via `bs_const=debug=false`. In debug builds, `
 
 Code paths that check these flags are wrapped in `#if debug` so they have zero runtime cost in production. See `debug-tools.md`.
 
-## Cruft callouts
+## Known cruft
 
-- **Manual theme color cascade.** As above — settings change → `applyThemeColorOverrides` → `refreshThemeColors` → `reloadHome` is a chain that any new themed component must opt into. There's no general "this constant changed, refresh the tree" mechanism.
-- **No type guard for `m.global.user.settings.<x>` typos.** BSC validates the field name at compile time *for the typed ContentNode*, but only if the access is properly typed. Untyped accesses (the common case in older code) fall through silently and return `invalid`, which can mask bugs.
-- **`fontScaleFactor` is conditional.** Only computed if `uiFontFallback` is enabled (which downloads a fallback font for non-Latin scripts and computes a scale factor so layouts don't break). This adds a multi-step startup path with several observer points; a small but real source of complexity.
-- **`m.global.app.lastRunVersion` straddles two concerns.** It's both a read-from-registry value (used by migrations) AND a write-on-startup value (set to `m.global.app.version` once migrations finish). The window between read and write is brief, but you have to know that "lastRunVersion" means different things at different times in startup.
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for global-state / theme entries.

--- a/docs/architecture/logging.md
+++ b/docs/architecture/logging.md
@@ -79,7 +79,6 @@ Helpful structured methods:
 
 `docs/dev/logging.md` has the canonical guide.
 
-## Cruft callouts
+## Known cruft
 
-- **`JRScreen.init` initializes the log manager.** This works because every screen extends JRScreen and inherits its init, but it's an unusual coupling — the log manager is a global resource initialized inside what looks like a screen's lifecycle hook. Repeated re-initialization is no-op in roku-log, but the design assumes JRScreen.init runs before any other component's init.
-- **No log filtering by namespace at runtime.** Once you set the level to 5 (debug), every component logs at debug. There's no way to say "show me only `QueueManager` logs at debug, everything else at info." Possible to add via `roku-log`'s transport configuration but not currently set up.
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for logging entries.

--- a/docs/architecture/migrations.md
+++ b/docs/architecture/migrations.md
@@ -113,9 +113,6 @@ This means integration tests can write `test-<id>` sections without ever touchin
 
 `docs/dev/registry-migrations.md` is the canonical guide for writing one. Read it before adding a migration.
 
-## Cruft callouts
+## Known cruft
 
-- **Migration list grows monotonically.** Old migrations stay in the file forever (otherwise users skipping versions would miss them).
-- **No transactional migration.** If a migration crashes halfway through (e.g., write succeeds but delete fails), the next launch may try to re-run it. Most migrations are idempotent by check-existence-first, but it's not enforced.
-- **`m.wasMigrated` flag on global scope.** Global state passed via the implicit `m` AA. Works because `Main()` controls the flow, but reads as a global mutable variable.
-- **No explicit setting deprecation lifecycle.** A setting can be removed, but there's no warning system or deprecation period — the migration just drops the old key. Users with old custom values lose them silently.
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for migration entries.

--- a/docs/architecture/navigation.md
+++ b/docs/architecture/navigation.md
@@ -259,9 +259,6 @@ end sub
 
 The `selectedTabId` observation is bidirectional: when the user changes tabs in the overhang, `onOverhangTabSelected` writes back into the active group's `selectedTabId` field, which the group observes to swap content. The `home/Home` screen uses this for the home/favorites tab swap.
 
-## Cruft callouts
+## Known cruft
 
-- **Manual `destroy()` discipline.** Every `JRScreen` subclass that holds task nodes, observers, or large data structures must override `destroy()` to release them. There's no enforcement — forgetting it leaks memory across navigation. A long-running session that visits many screens can accumulate. The base implementation should probably do *something* defensive (e.g., automatically `unobserveField` for any fields the screen observed on `m.global` children), but today it's a pure virtual.
-- **`m.groups` is unbounded.** Every push grows the array; pop shrinks it. There is no cap or LRU eviction. In normal navigation flows this is fine, but a malicious or buggy code path that pushes without popping leaks indefinitely.
-- **`reloadHome()` is a manual signal.** Theme color changes, language changes, and some settings changes require an explicit `reloadHome()` call. The framework can't know automatically that a setting change should rebuild the home screen — there's no general "this setting affects rendering" metadata. Easy to forget when adding a new setting.
-- **Dialog `returnData` is shared global state.** Every dialog writes to the same `sceneManager.returnData` field. If two dialogs were ever queued (they shouldn't be, but defensively), the second would clobber the first. Code that reads `returnData` must `unobserveField` immediately on read or risk firing for an unrelated dialog later.
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for navigation / `SceneManager` entries.

--- a/docs/architecture/playback.md
+++ b/docs/architecture/playback.md
@@ -343,10 +343,6 @@ There used to be a second video player (`components/JRVideo.bs` + `source/VideoP
 
 The audio side has *two* components (`mediaPlayers/AudioPlayer` and `music/AudioPlayerView`), but they are not duplicates — they are the engine and the screen, intentionally split (see above).
 
-## Cruft callouts
+## Known cruft
 
-- **`VideoPlayerView.bs` is the most complex single component in the app.** It mixes: native `Video` event handling, OSD orchestration, trickplay coordination, transcoding logic, DoVi fallback, subtitle management, audio track switching, chapter navigation, and Jellyfin reporting. Some extraction (e.g., a separate `SubtitleController` module) would help. But it works, it's well-tested, and the DoVi handling is genuinely clever.
-- **The set-then-clear event pattern** appears on `select*Pressed` fields — `m.view.selectAudioPressed = true` from the OSD, observed by `ViewCreator`. Same trick as `quickPlayNode`; canonical explanation in `user-journey.md`.
-- **`bufferCheckTimer`** — listed in the XML but its duration is set in code dynamically. Its job is to detect the DoVi `buffer:loop:` source overflow. It exists because Roku's native `state` doesn't always transition to `error` cleanly on this specific failure.
-- **No abstraction over "which player is active"**. Code that wants to control current playback has to know whether `m.global.audioPlayer` is the active player or whether a `VideoPlayerView` is on the scene stack. A common `IPlayer` interface or `m.global.activePlayer` reference would help.
-- **Trickplay tile pre-fetch range is hardcoded** in `TrickplayCarousel.bs` — should probably be a constant, possibly user-configurable for power users.
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for playback / `VideoPlayerView` / audio-player entries.

--- a/docs/architecture/settings.md
+++ b/docs/architecture/settings.md
@@ -190,7 +190,6 @@ It also handles type coercion: registry values are always strings, but `Jellyfin
 
 The same transformer is used by tests — `tests/source/integration/registry/` exercises the full read-overlay-validate cycle.
 
-## Cruft callouts
+## Known cruft
 
-- **Registry values are all strings.** Type coercion happens on every read via `valueToString`. Boolean settings use `"true"`/`"false"` strings, etc. A typo in the registry (e.g. `"True"` instead of `"true"`) doesn't fail-fast — it parses as something unexpected. Mostly defensive code handles this.
-- **Settings UI walks `settings.json` at runtime.** Any change to the schema (adding a setting type, restructuring the tree) requires both the JSON and the Settings UI renderer to handle the new shape. The renderer is generic but does have a finite set of supported `type:` values.
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for settings / registry entries.

--- a/docs/architecture/tech-debt.md
+++ b/docs/architecture/tech-debt.md
@@ -152,6 +152,18 @@ The `npm run lint:docs` checker validates every `tech-debt.md#<anchor>` referenc
 - **issue**: 14 of 49 `Build*Request()` methods have inline `if m.getApiVersion() >= 2` branches; the conditional shape repeats per affected method. Adding a third API version means editing each of those 14 methods (the other 35 endpoints share a single code path because their path didn't change between server versions, so they're unaffected).
 - **direction**: Centralize via a routing table — `{ "GetItem": { v1: "/users/{userId}/items/{id}", v2: "/Items/{id}" }, ... }`. The 14 version-aware methods read from the table instead of branching inline; the other 35 stay as-is. Low-priority until `V3` is on the roadmap — adjacent work.
 
+#### `apiclient-sync-pool-coexistence`
+
+- **area**: `source/api/ApiClient.bs`, `source/api/sdk.bs`
+- **issue**: A handful of sync methods (`AuthenticateByName`, `AuthenticateWithQuickConnect`, `InitiateQuickConnect`, `ConnectQuickConnect`, `GetUser`, `GetPublicUsers`, `GetConfigurationByName`, `GetDisplayPreferences`) still route through the legacy `sdk.*` namespace because the persistent task pool isn't available pre-login. Everything else uses the async `Build*Request()` pattern. New endpoints should be pool-only; the bootstrap path is the surviving exception. (`GetImageURL` / `GetUserImageURL` are URL builders rather than HTTP calls and don't share this concern.)
+- **direction**: Make the persistent task pool available pre-login — only the auth header injection needs to be deferred until a token exists. Then migrate the bootstrap sync methods to the pool and remove direct `sdk.*` usage from `ApiClient`.
+
+#### `buildparams-no-array-support`
+
+- **area**: `source/api/baseRequest.bs` (`buildParams`)
+- **issue**: `buildParams` skips `roArray` values silently — there's a `' TODO handle array params` placeholder branch with no implementation. Callers that need to pass arrays as query parameters (e.g., comma-separated `Fields=` lists) join the array into a string before calling.
+- **direction**: Implement array handling per the actual server-side conventions used by Jellyfin (most array params are comma-separated; some use repeated keys). Then audit callers to remove the workarounds where each call site joins arrays into strings before invoking.
+
 #### `jrscreen-init-initializes-log-manager`
 
 - **area**: `components/JRScreen.bs`

--- a/docs/architecture/tech-debt.md
+++ b/docs/architecture/tech-debt.md
@@ -141,6 +141,12 @@ The `npm run lint:docs` checker validates every `tech-debt.md#<anchor>` referenc
 - **area**: `components/video/TrickplayCarousel.bs`
 - **issue**: Tile pre-fetch range is hardcoded. Should be a constant, possibly user-configurable.
 
+#### `no-active-player-abstraction`
+
+- **area**: `components/video/VideoPlayerView.bs`, `components/music/AudioPlayerView.bs`, `components/mediaPlayers/AudioPlayer.bs`
+- **issue**: Audio (`m.global.audioPlayer`, a persistent global) and video (`VideoPlayerView`, a scene-stack screen) have no shared "active player" interface. Cross-cutting code that wants to control whatever is currently playing has to branch on player type — query `m.global.audioPlayer.state` for audio, or walk the scene stack to find a `VideoPlayerView` for video. Adds friction to features like a universal pause or a "now playing" indicator.
+- **direction**: Add a thin `m.global.activePlayer` reference (or an `IPlayer` interface) that points to whichever player is active. Both components publish to it on play/destroy; cross-cutting code reads from there instead of branching on type.
+
 #### `api-timeout-single-value`
 
 - **area**: `source/constants/timeouts.bs`

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -90,7 +90,6 @@ Tests deploy to a real Roku device, but the npm scripts are CLI-driven so an aut
 - `docs/dev/unit-tests.md` — comprehensive guide
 - `docs/dev/unit-tests-tdd.md` — TDD workflow with watch mode
 
-## Cruft callouts
+## Known cruft
 
-- **e2e folder is mostly empty.** The plan was for RTA-based UI automation but it hasn't materialized yet. Real coverage today is unit + integration.
-- **`needsRegistrySetup` opt-in is per-suite.** Forgetting it in a suite that does touch the registry produces flaky tests where one suite's writes leak into another. There's no automatic detection.
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for testing entries.

--- a/docs/architecture/translations.md
+++ b/docs/architecture/translations.md
@@ -242,10 +242,6 @@ Translations are crowdsourced via Weblate (an open-source translation platform).
 
 So the developer-side workflow is just: edit `en_US.json`, the bot keeps everything else in sync, and translators do their work in Weblate.
 
-## Cruft callouts
+## Known cruft
 
-- **Plural form is Zero/One/Many only.** No support for languages with more than three plural forms (Polish, Russian, Arabic). For now this is mitigated by translators choosing the most generic form for "Many" — but some languages will read awkwardly.
-- **Manual key naming convention.** No enforcement that new keys follow the `Button*`/`Label*`/`Message*` prefix scheme — relies on PR review.
-- **Locale file size scales linearly.** As keys grow, every locale file grows. With many locales, the JSON in the source tree adds up — most of which is checked in, since translations don't compress in source. Not a runtime concern, just a repo-size one.
-- **The `translationLocale` user setting is post-login only.** A new install of the app will use the device locale until the user logs in once and explicitly picks a language. There's no "guest" language picker on the login screen itself (though the language picker setting is in `components/settings/LanguagePicker.xml`, accessible after login).
-- **No RTL (right-to-left) layout flipping.** Arabic and Hebrew translations exist but the UI doesn't mirror its layout for RTL languages. Probably acceptable for a TV media player but worth knowing.
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for translation entries.

--- a/docs/architecture/user-journey.md
+++ b/docs/architecture/user-journey.md
@@ -362,10 +362,6 @@ When the video finishes (`state = "finished"`), `ViewCreator.onStateChange` deci
 
 If the user backs out mid-playback, `SceneManager.popScene` detects the `Video` subtype on the popped group and issues `group.control = "stop"` to make sure Jellyfin records the stop event before the node is destroyed.
 
-## Cruft callouts
+## Known cruft
 
-- **`ItemDetails.bs` is huge.** Single file handling every item type. Splitting per type (or extracting the extras pane and metadata renderer) would make it more navigable. See `tech-debt.md`.
-- **`showScenes.bs` mixes login flow with scene factories.** `LoginFlow()` and a dozen `Create*Group()` functions live in the same file. Splitting `auth/LoginFlow.bs` and `screens/SearchPage.bs` etc. would clarify responsibilities.
-- **`goto`-based retry in `LoginFlow`.** Works, but unusual; a `do { ... } until success` loop would read more naturally to most modern eyes. Not worth changing for change's sake, but worth knowing about.
-- **No persistent series playlist UI.** "Play next" routing always goes back through `ItemDetails → quickPlayNode → QueueManager`. There's no "now playing" sidebar to see the upcoming queue without going to the player.
-- **`selectedItem` bubbling has implicit contracts.** Every level in the chain just declares `<field id="selectedItem" alwaysNotify="true" />` and trusts that the level above will handle it. Tracing from a click to the handler requires walking the tree manually; there's no central registry of "who handles `selectedItem` from where."
+Tracked in [`tech-debt.md`](tech-debt.md) — search by `area` for `ItemDetails`, `showScenes`, or login-flow entries.


### PR DESCRIPTION
## Summary

Applies the [`build-and-tooling.md`](https://github.com/jellyrock/jellyrock/blob/main/docs/architecture/build-and-tooling.md) migration pattern (commit `57970b63`) to the remaining 12 architecture docs. Each doc's inline `## Cruft callouts` section is replaced with a one-line pointer to [`tech-debt.md`](https://github.com/jellyrock/jellyrock/blob/main/docs/architecture/tech-debt.md), eliminating the drift surface that competed with the canonical registry.

- **12 docs cleaned** — every `## Cruft callouts` section is gone from `docs/architecture/`.
- **52 inline bullets dispositioned** — most routed to existing slugs; 3 new low-severity slugs added; 2 callouts found genuinely stale.
- **No `last-reviewed` bumped mechanically** — only callout cleanup, not full doc re-reads. `tech-debt.md` was already at today's date from the prior `build-and-tooling` commit, so adding the 3 new slugs didn't require a bump.

## Per-doc disposition (one commit each)

| Doc | Bullets | Already-slugged | Stale | By-design / not debt | New slugs |
|---|---|---|---|---|---|
| logging | 2 | 1 | — | 1 | — |
| migrations | 4 | 1 | — | 3 | — |
| bootstrap | 4 | 4 | — | — | — |
| testing | 2 | 1 | — | 1 | — |
| debug-tools | 1 | 1 | — | — | — |
| global-state | 4 | 1 | — | 3 | — |
| translations | 5 | 1 | — | 4 | — |
| navigation | 4 | 3 | 1 | — | — |
| user-journey | 5 | 4 | — | 1 | — |
| settings | 2 | 1 | — | 1 | — |
| api | 6 | 3 | 1 | — | 2 |
| playback | 5 | 3 | — | 1 | 1 |

## New tech-debt slugs (all low severity)

- **`apiclient-sync-pool-coexistence`** — `source/api/ApiClient.bs` still has 6 sync `Get*()` methods routing through legacy `sdk.*` for the bootstrap path (login, server info, display preferences). Direction: make the persistent task pool available pre-login, then migrate.
- **`buildparams-no-array-support`** — `source/api/baseRequest.bs:20` has a `' TODO handle array params` placeholder. Callers pre-join arrays into strings as a workaround.
- **`no-active-player-abstraction`** — Audio (`m.global.audioPlayer`, persistent) and video (`VideoPlayerView`, scene-stack screen) have no shared interface for "which player is active." Cross-cutting code branches on type.

## Stale claims caught

- **`navigation.md`** — "no enforcement for manual `destroy()` discipline" was wrong: `bsc-plugin-jrscreen-destroy.cjs` and `bsc-plugin-observe-without-destroy.cjs` both enforce this.
- **`api.md`** — "some callers bypass `ApiClient` and call `sdk.<ns>.<fn>` directly" was wrong: zero direct callers remain outside the API folder, and `bsc-plugin-no-direct-sdk.cjs` prevents new violations.

## Test plan

- [x] `node scripts/docs-check.cjs` runs clean after every commit (verified per-doc during work; final sweep confirms 44 files clean).
- [x] `npm run docs:stale` reports 0 stale docs.
- [x] No `## Cruft callouts` (or equivalent) section remains under `docs/architecture/` — `grep -l "^## Cruft callouts" docs/architecture/*.md` returns empty.
- [x] Pre-commit hook (markdownlint, spellchecker) ran cleanly on every commit.
- [ ] CI (`lint-docs.yml`) passes — verifies cross-doc reference checks (`tech-debt.md#<anchor>` references, `related-files:` paths, relative markdown links).

## Notes for reviewers

- One commit per doc by design — easier git-history audit if anything regresses.
- Commit messages contain the full per-bullet rationale (route 1/2/3/4 with verification evidence).
- The reference example for the migration pattern is commit `57970b63` (`docs(arch): migrate build-and-tooling cruft callouts to tech-debt.md`).