### PR TITLE
Add Vitest coverage for update-translations and changelog-syncer

### DIFF
--- a/scripts/changelog-syncer.js
+++ b/scripts/changelog-syncer.js
@@ -98,13 +98,17 @@ class ChangelogSyncer {
   validate() {
     console.log('🔍 Validating changelog consistency...');
 
+    // File-existence check has to come before getStatus(), which reads the
+    // file unconditionally. Without this guard, a missing CHANGELOG.md
+    // crashes with ENOENT instead of producing the intended issue.
+    if (!fs.existsSync(this.changelogPath)) {
+      console.log('❌ Changelog validation failed:');
+      console.log('  - CHANGELOG.md file missing');
+      return false;
+    }
+
     const status = this.getStatus();
     const issues = [];
-
-    // Check file exists
-    if (!fs.existsSync(this.changelogPath)) {
-      issues.push('CHANGELOG.md file missing');
-    }
 
     // Check unreleased section consistency
     if (status.unreleasedCommits > 0 && !status.hasUnreleased) {

--- a/tests/scripts/unit/_helpers/temp-git-fixture.js
+++ b/tests/scripts/unit/_helpers/temp-git-fixture.js
@@ -1,0 +1,73 @@
+// Fixture helper for tests that drive scripts/changelog-syncer.js (or any
+// other script that needs a synthetic git repo).
+//
+// Builds a temp dir, runs `git init`, configures user, and exposes
+// commit/tag/branch helpers that operate on it. The script-under-test is
+// invoked via spawnScript() with cwd set to the fixture dir.
+//
+// Merge commits are intentionally rejected: changelog-syncer.js shells out to
+// `gh pr view` for any commit whose subject begins with "Merge pull request",
+// which would either fail (no auth) or hit live GitHub. Non-merge commits keep
+// tests offline and hermetic.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function git(dir, ...args) {
+  return execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+}
+
+/**
+ * Build a temp git-repo fixture.
+ *
+ * @returns {{
+ *   dir: string,
+ *   commit: (msg: string, files?: Object<string, string>) => void,
+ *   tag: (name: string) => void,
+ *   branch: (name: string) => void,
+ *   git: (...args: string[]) => string,
+ *   cleanup: () => void,
+ * }}
+ */
+export function createGitFixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'jellyrock-changelog-syncer-'));
+
+  git(dir, 'init', '--quiet', '--initial-branch=main');
+  git(dir, 'config', 'user.email', 'test@example.com');
+  git(dir, 'config', 'user.name', 'Test');
+  // Disable signing so tests run on contributor machines that have commit.gpgsign=true.
+  git(dir, 'config', 'commit.gpgsign', 'false');
+
+  return {
+    dir,
+    commit(msg, files) {
+      if (msg.startsWith('Merge ')) {
+        throw new Error(
+          `temp-git-fixture refuses merge commits — changelog-syncer shells to gh pr view for them. msg="${msg}"`,
+        );
+      }
+      if (files) {
+        for (const [relPath, contents] of Object.entries(files)) {
+          writeFileSync(join(dir, relPath), contents);
+        }
+      } else {
+        // Touch a placeholder so there's always a real diff.
+        writeFileSync(join(dir, `_${Date.now()}_${Math.random().toString(36).slice(2)}.txt`), msg);
+      }
+      git(dir, 'add', '.');
+      git(dir, 'commit', '--quiet', '--no-gpg-sign', '-m', msg);
+    },
+    tag(name) {
+      git(dir, 'tag', name);
+    },
+    branch(name) {
+      git(dir, 'branch', name);
+    },
+    git: (...args) => git(dir, ...args),
+    cleanup() {
+      if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}

--- a/tests/scripts/unit/_helpers/temp-locale-fixture.js
+++ b/tests/scripts/unit/_helpers/temp-locale-fixture.js
@@ -1,0 +1,63 @@
+// Fixture helper for tests that drive scripts/lint/update-translations.cjs.
+//
+// Builds a temp dir with a synthetic locale + source-file layout matching what
+// the script expects (locale/custom/*.json, locale/languages.json, source/**/*.bs,
+// components/**/*.bs). Specs compose this with spawnScript() to invoke the
+// script-under-test against the fixture.
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+function serialize(value) {
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value, null, 2) + '\n';
+}
+
+function writeFile(dir, relPath, contents) {
+  const fullPath = join(dir, relPath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, typeof contents === 'string' ? contents : serialize(contents));
+}
+
+/**
+ * Build a temp locale fixture directory.
+ *
+ * @param {object} opts
+ * @param {object|string} [opts.en_US]         Becomes locale/custom/en_US.json. Object → JSON-stringified; string → written verbatim (use for malformed-JSON scenarios).
+ * @param {Object<string, object|string>} [opts.locales]  Additional locale/custom/<code>.json files keyed by locale code.
+ * @param {Array<object>|string} [opts.languagesJson]     Optional locale/languages.json contents.
+ * @param {Object<string, string>} [opts.sources]         Synthetic source-tree files keyed by repo-relative path (e.g. 'source/Foo.bs').
+ * @returns {{ dir: string, write: (relPath: string, contents: any) => void, cleanup: () => void }}
+ */
+export function createLocaleFixture(opts = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'jellyrock-update-translations-'));
+
+  if (opts.en_US !== undefined) {
+    writeFile(dir, 'locale/custom/en_US.json', opts.en_US);
+  }
+
+  if (opts.locales) {
+    for (const [code, contents] of Object.entries(opts.locales)) {
+      writeFile(dir, `locale/custom/${code}.json`, contents);
+    }
+  }
+
+  if (opts.languagesJson !== undefined) {
+    writeFile(dir, 'locale/languages.json', opts.languagesJson);
+  }
+
+  if (opts.sources) {
+    for (const [relPath, contents] of Object.entries(opts.sources)) {
+      writeFile(dir, relPath, contents);
+    }
+  }
+
+  return {
+    dir,
+    write: (relPath, contents) => writeFile(dir, relPath, contents),
+    cleanup: () => {
+      if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}

--- a/tests/scripts/unit/changelog-syncer.test.js
+++ b/tests/scripts/unit/changelog-syncer.test.js
@@ -1,0 +1,294 @@
+// Tests for scripts/changelog-syncer.js.
+//
+// Each scenario builds a synthetic git-repo fixture in a tmpdir, optionally
+// seeds a CHANGELOG.md, invokes the script via spawnScript with cwd set to
+// the fixture, and asserts on exit code, stdout/stderr, and post-run
+// CHANGELOG.md contents.
+//
+// Fixture rule: no merge commits and no `(#N)` PR-suffix subjects, because
+// changelog-syncer shells out to `gh pr view` for both. createGitFixture
+// rejects merge subjects; we keep regular commit subjects PR-number-free here.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnScript } from './_helpers/spawn-script.js';
+import { createGitFixture } from './_helpers/temp-git-fixture.js';
+
+const SCRIPT = 'scripts/changelog-syncer.js';
+
+const VALID_HEADER =
+  '<!-- markdownlint-disable -->\n# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).\n\n';
+
+function readChangelog(dir) {
+  return readFileSync(join(dir, 'CHANGELOG.md'), 'utf8');
+}
+
+function writeChangelog(dir, contents) {
+  writeFileSync(join(dir, 'CHANGELOG.md'), contents);
+}
+
+describe('changelog-syncer.js', () => {
+  let fixture;
+
+  afterEach(() => {
+    if (fixture) fixture.cleanup();
+    fixture = undefined;
+  });
+
+  // --------------------------------------------------------------------
+  // status
+  // --------------------------------------------------------------------
+
+  describe('status', () => {
+    it('reports zeros on a fresh repo with a minimal CHANGELOG.md', () => {
+      fixture = createGitFixture();
+      writeChangelog(fixture.dir, VALID_HEADER);
+
+      const { exitCode, stdout } = spawnScript(SCRIPT, ['status'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+      expect(stdout).toMatch(/Latest tag: none/);
+      expect(stdout).toMatch(/Unreleased commits: 0/);
+      expect(stdout).toMatch(/Has unreleased section: false/);
+      expect(stdout).toMatch(/Version entries: 0/);
+    });
+
+    it('reports tag and commits-since count', () => {
+      fixture = createGitFixture();
+      fixture.commit('chore: initial');
+      fixture.tag('v1.0.0');
+      fixture.commit('feat: a');
+      fixture.commit('fix: b');
+      fixture.commit('feat: c');
+      writeChangelog(fixture.dir, VALID_HEADER);
+
+      const { exitCode, stdout } = spawnScript(SCRIPT, ['status'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+      expect(stdout).toMatch(/Latest tag: v1\.0\.0/);
+      expect(stdout).toMatch(/Unreleased commits: 3/);
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // validate
+  // --------------------------------------------------------------------
+
+  describe('validate', () => {
+    it('exits 1 when CHANGELOG.md is missing', () => {
+      fixture = createGitFixture();
+      // No CHANGELOG.md written. The script's validate() reaches getStatus()
+      // which reads the file — assert that the script reports the error and
+      // exits non-zero, accepting either the script's intended message or the
+      // ENOENT crash path that the current code produces.
+      const { exitCode, stdout, stderr } = spawnScript(SCRIPT, ['validate'], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stdout + stderr).toMatch(/CHANGELOG\.md file missing|ENOENT/);
+    });
+
+    it('exits 1 when CHANGELOG.md is missing the # Changelog header', () => {
+      fixture = createGitFixture();
+      // Has the Keep a Changelog reference but no `# Changelog` heading.
+      writeChangelog(
+        fixture.dir,
+        'Some other heading\n\n[Keep a Changelog](https://keepachangelog.com/en/1.0.0/)\n',
+      );
+      const { exitCode, stdout } = spawnScript(SCRIPT, ['validate'], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/Missing changelog header/);
+    });
+
+    it('exits 1 when CHANGELOG.md is missing the Keep a Changelog reference', () => {
+      fixture = createGitFixture();
+      writeChangelog(fixture.dir, '# Changelog\n\nNo reference here.\n');
+      const { exitCode, stdout } = spawnScript(SCRIPT, ['validate'], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/Missing Keep a Changelog reference/);
+    });
+
+    it('exits 1 when there are unreleased commits but no [Unreleased] section', () => {
+      fixture = createGitFixture();
+      fixture.commit('chore: initial');
+      fixture.tag('v1.0.0');
+      fixture.commit('feat: a');
+      writeChangelog(fixture.dir, VALID_HEADER);
+
+      const { exitCode, stdout } = spawnScript(SCRIPT, ['validate'], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/unreleased commits but no \[Unreleased\] section/);
+    });
+
+    it('exits 0 on a valid CHANGELOG.md', () => {
+      fixture = createGitFixture();
+      // No commits → no unreleased-commit consistency error.
+      writeChangelog(fixture.dir, VALID_HEADER);
+      const { exitCode, stdout } = spawnScript(SCRIPT, ['validate'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+      expect(stdout).toMatch(/Changelog validation passed/);
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // sync-unreleased
+  // --------------------------------------------------------------------
+
+  describe('sync-unreleased', () => {
+    it('inserts an [Unreleased] section with feat → Added and fix → Fixed', () => {
+      fixture = createGitFixture();
+      fixture.commit('chore: initial');
+      fixture.tag('v1.0.0');
+      fixture.commit('feat: add login screen');
+      fixture.commit('fix: broken thumbnail loader');
+      writeChangelog(fixture.dir, VALID_HEADER);
+
+      const { exitCode } = spawnScript(SCRIPT, ['sync-unreleased'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+
+      const changelog = readChangelog(fixture.dir);
+      expect(changelog).toMatch(/## \[Unreleased\]/);
+      expect(changelog).toMatch(/### Added/);
+      expect(changelog).toMatch(/add login screen/);
+      expect(changelog).toMatch(/### Fixed/);
+      expect(changelog).toMatch(/broken thumbnail loader/);
+    });
+
+    it('is a no-op with "No unreleased changes" when there are no commits since the latest tag', () => {
+      fixture = createGitFixture();
+      fixture.commit('chore: initial');
+      fixture.tag('v1.0.0');
+      writeChangelog(fixture.dir, VALID_HEADER);
+
+      const before = readChangelog(fixture.dir);
+      const { exitCode, stdout } = spawnScript(SCRIPT, ['sync-unreleased'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+      expect(stdout).toMatch(/No unreleased changes/);
+      expect(readChangelog(fixture.dir)).toBe(before);
+    });
+
+    it('creates CHANGELOG.md when none exists', () => {
+      fixture = createGitFixture();
+      fixture.commit('chore: initial');
+      fixture.tag('v1.0.0');
+      fixture.commit('feat: bootstrap');
+
+      expect(existsSync(join(fixture.dir, 'CHANGELOG.md'))).toBe(false);
+      const { exitCode } = spawnScript(SCRIPT, ['sync-unreleased'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+
+      const changelog = readChangelog(fixture.dir);
+      expect(changelog).toMatch(/# Changelog/);
+      expect(changelog).toMatch(/Keep a Changelog/);
+      expect(changelog).toMatch(/## \[Unreleased\]/);
+    });
+
+    it('inserts [Unreleased] before an existing version section', () => {
+      fixture = createGitFixture();
+      fixture.commit('chore: initial');
+      fixture.tag('v1.0.0');
+      fixture.commit('feat: bar');
+
+      writeChangelog(
+        fixture.dir,
+        VALID_HEADER + '## [1.0.0] - 2025-01-01\n\n### Added\n\n- something\n',
+      );
+
+      const { exitCode } = spawnScript(SCRIPT, ['sync-unreleased'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+
+      const changelog = readChangelog(fixture.dir);
+      const unreleasedIdx = changelog.indexOf('## [Unreleased]');
+      const v100Idx = changelog.indexOf('## [1.0.0]');
+      expect(unreleasedIdx).toBeGreaterThan(-1);
+      expect(v100Idx).toBeGreaterThan(-1);
+      expect(unreleasedIdx).toBeLessThan(v100Idx);
+    });
+
+    it('is idempotent: running twice produces byte-identical CHANGELOG.md', () => {
+      fixture = createGitFixture();
+      fixture.commit('chore: initial');
+      fixture.tag('v1.0.0');
+      fixture.commit('feat: a');
+      fixture.commit('fix: b');
+      writeChangelog(fixture.dir, VALID_HEADER);
+
+      const first = spawnScript(SCRIPT, ['sync-unreleased'], { cwd: fixture.dir });
+      expect(first.exitCode).toBe(0);
+      const afterFirst = readChangelog(fixture.dir);
+
+      const second = spawnScript(SCRIPT, ['sync-unreleased'], { cwd: fixture.dir });
+      expect(second.exitCode).toBe(0);
+      expect(readChangelog(fixture.dir)).toBe(afterFirst);
+    });
+
+    it('categorizes commits: feat → Added, fix → Fixed, security → Security, chore → filtered', () => {
+      fixture = createGitFixture();
+      fixture.commit('chore: initial');
+      fixture.tag('v1.0.0');
+      fixture.commit('feat: add login');
+      fixture.commit('fix: broken auth');
+      fixture.commit('chore: bump unrelated tooling');
+      fixture.commit('fix: patch security vulnerability in cookies');
+      writeChangelog(fixture.dir, VALID_HEADER);
+
+      const { exitCode } = spawnScript(SCRIPT, ['sync-unreleased'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+      const changelog = readChangelog(fixture.dir);
+
+      expect(changelog).toMatch(/### Added[\s\S]*add login/);
+      expect(changelog).toMatch(/### Fixed[\s\S]*broken auth/);
+      expect(changelog).toMatch(/### Security[\s\S]*security vulnerability/);
+      // Chore commits are filtered out entirely.
+      expect(changelog).not.toMatch(/bump unrelated tooling/);
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // sync-release <version>
+  // --------------------------------------------------------------------
+
+  describe('sync-release', () => {
+    it('converts [Unreleased] to a versioned section with a compare URL when a previous tag exists', () => {
+      fixture = createGitFixture();
+      fixture.commit('chore: initial');
+      fixture.tag('v1.2.2');
+      fixture.commit('feat: thing');
+      fixture.tag('v1.2.3');
+      writeChangelog(fixture.dir, VALID_HEADER + '## [Unreleased]\n\n### Added\n\n- thing\n');
+
+      const { exitCode } = spawnScript(SCRIPT, ['sync-release', '1.2.3'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+
+      const changelog = readChangelog(fixture.dir);
+      expect(changelog).not.toMatch(/## \[Unreleased\]/);
+      const today = new Date().toISOString().slice(0, 10);
+      expect(changelog).toContain(
+        `## [1.2.3](https://github.com/jellyrock/jellyrock/compare/v1.2.2...v1.2.3) - ${today}`,
+      );
+    });
+
+    it('uses the release-tag URL fallback for the first release (no previous tag)', () => {
+      fixture = createGitFixture();
+      fixture.commit('chore: initial');
+      fixture.commit('feat: bootstrap');
+      fixture.tag('v1.0.0');
+      writeChangelog(fixture.dir, VALID_HEADER + '## [Unreleased]\n\n### Added\n\n- bootstrap\n');
+
+      const { exitCode } = spawnScript(SCRIPT, ['sync-release', '1.0.0'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+
+      const changelog = readChangelog(fixture.dir);
+      expect(changelog).toContain(
+        '## [1.0.0](https://github.com/jellyrock/jellyrock/releases/tag/v1.0.0)',
+      );
+      expect(changelog).not.toMatch(/\/compare\//);
+    });
+
+    it('exits 1 with a format error on an invalid version string', () => {
+      fixture = createGitFixture();
+      const { exitCode, stderr } = spawnScript(SCRIPT, ['sync-release', '1.2'], {
+        cwd: fixture.dir,
+      });
+      expect(exitCode).toBe(1);
+      expect(stderr).toMatch(/Invalid version format/);
+    });
+  });
+});

--- a/tests/scripts/unit/changelog-syncer.test.js
+++ b/tests/scripts/unit/changelog-syncer.test.js
@@ -76,13 +76,9 @@ describe('changelog-syncer.js', () => {
   describe('validate', () => {
     it('exits 1 when CHANGELOG.md is missing', () => {
       fixture = createGitFixture();
-      // No CHANGELOG.md written. The script's validate() reaches getStatus()
-      // which reads the file — assert that the script reports the error and
-      // exits non-zero, accepting either the script's intended message or the
-      // ENOENT crash path that the current code produces.
-      const { exitCode, stdout, stderr } = spawnScript(SCRIPT, ['validate'], { cwd: fixture.dir });
+      const { exitCode, stdout } = spawnScript(SCRIPT, ['validate'], { cwd: fixture.dir });
       expect(exitCode).toBe(1);
-      expect(stdout + stderr).toMatch(/CHANGELOG\.md file missing|ENOENT/);
+      expect(stdout).toMatch(/CHANGELOG\.md file missing/);
     });
 
     it('exits 1 when CHANGELOG.md is missing the # Changelog header', () => {

--- a/tests/scripts/unit/lint/update-translations.test.js
+++ b/tests/scripts/unit/lint/update-translations.test.js
@@ -1,0 +1,227 @@
+// Tests for scripts/lint/update-translations.cjs.
+//
+// Each scenario builds a synthetic locale + source-tree fixture in a tmpdir
+// (via createLocaleFixture), invokes the script via spawnScript with cwd set
+// to the fixture, and asserts on exit code, output streams, and (in --fix
+// mode) the post-run state of mutated files.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnScript } from '../_helpers/spawn-script.js';
+import { createLocaleFixture } from '../_helpers/temp-locale-fixture.js';
+
+const SCRIPT = 'scripts/lint/update-translations.cjs';
+
+// Baseline source file referencing both Hello and World via the
+// translationKeys.* form so the script counts them as used (and does not flag
+// them as hardcoded).
+const BASELINE_SOURCE = {
+  'source/main.bs':
+    'sub init()\n  translate(translationKeys.Hello)\n  translate(translationKeys.World)\nend sub\n',
+};
+const BASELINE_EN_US = { Hello: 'Hello', World: 'World' };
+
+function readJson(dir, relPath) {
+  return JSON.parse(readFileSync(join(dir, relPath), 'utf8'));
+}
+
+function readText(dir, relPath) {
+  return readFileSync(join(dir, relPath), 'utf8');
+}
+
+describe('update-translations.cjs', () => {
+  let fixture;
+
+  afterEach(() => {
+    if (fixture) fixture.cleanup();
+    fixture = undefined;
+  });
+
+  // --------------------------------------------------------------------
+  // Lint mode
+  // --------------------------------------------------------------------
+
+  describe('lint mode (default)', () => {
+    it('exits 0 with clean en_US and matching code references', () => {
+      fixture = createLocaleFixture({ en_US: BASELINE_EN_US, sources: BASELINE_SOURCE });
+      const { exitCode, stdout } = spawnScript(SCRIPT, [], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+      expect(stdout).toMatch(/0 errors/);
+    });
+
+    it('exits 1 when en_US.json keys are out of alphabetical order', () => {
+      fixture = createLocaleFixture({
+        // Object key order is preserved by JSON.stringify, so this is unsorted on disk.
+        en_US: { World: 'World', Hello: 'Hello' },
+        sources: BASELINE_SOURCE,
+      });
+      const { exitCode, stdout } = spawnScript(SCRIPT, [], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/keys not sorted/);
+    });
+
+    it('exits 1 when en_US.json contains an orphan key', () => {
+      fixture = createLocaleFixture({
+        en_US: { Hello: 'Hello', Orphan: 'no one references me', World: 'World' },
+        sources: BASELINE_SOURCE,
+      });
+      const { exitCode, stdout } = spawnScript(SCRIPT, [], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/orphan key\(s\)/);
+      expect(stdout).toMatch(/Orphan/);
+    });
+
+    it('exits 1 when code references a key not in en_US.json', () => {
+      fixture = createLocaleFixture({
+        en_US: BASELINE_EN_US,
+        sources: {
+          'source/main.bs':
+            'sub init()\n  translate(translationKeys.Hello)\n  translate(translationKeys.World)\n  translate(translationKeys.Missing)\nend sub\n',
+        },
+      });
+      const { exitCode, stdout } = spawnScript(SCRIPT, [], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/missing key\(s\)/);
+      expect(stdout).toMatch(/Missing/);
+    });
+
+    it('exits 1 when source contains a hardcoded translate("Literal") call', () => {
+      fixture = createLocaleFixture({
+        en_US: BASELINE_EN_US,
+        sources: {
+          'source/main.bs':
+            'sub init()\n  translate(translationKeys.Hello)\n  translate(translationKeys.World)\n  translate("Hello")\nend sub\n',
+        },
+      });
+      const { exitCode, stdout } = spawnScript(SCRIPT, [], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/hardcoded translation key/);
+    });
+
+    it('exits 1 with malformed JSON in en_US.json', () => {
+      fixture = createLocaleFixture({
+        en_US: '{ "Hello": "Hello"  ', // malformed: missing closing brace
+        sources: BASELINE_SOURCE,
+      });
+      const { exitCode, stderr } = spawnScript(SCRIPT, [], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stderr).toMatch(/has invalid JSON/);
+    });
+
+    it('exits 1 on placeholder mismatch between en_US and another locale', () => {
+      fixture = createLocaleFixture({
+        en_US: { Greeting: 'Hello {0}' },
+        locales: { de_DE: { Greeting: 'Hallo' } },
+        sources: {
+          'source/main.bs': 'sub init()\n  translate(translationKeys.Greeting)\nend sub\n',
+        },
+      });
+      const { exitCode, stdout } = spawnScript(SCRIPT, [], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/placeholder mismatch/);
+      expect(stdout).toMatch(/Greeting/);
+    });
+
+    it('exits 1 on incomplete plural set in en_US.json', () => {
+      // FooZero + FooOne are present, FooMany is missing.
+      // Source references the concrete plural keys directly (avoiding
+      // translatePlural() which would also pull all 3 into usedKeys and produce
+      // a missing-key error in addition to the plural error we want to assert).
+      fixture = createLocaleFixture({
+        en_US: { FooOne: 'one foo', FooZero: 'no foos' },
+        sources: {
+          'source/main.bs':
+            'sub init()\n  translate(translationKeys.FooZero)\n  translate(translationKeys.FooOne)\nend sub\n',
+        },
+      });
+      const { exitCode, stdout } = spawnScript(SCRIPT, [], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/Incomplete plural set/);
+      expect(stdout).toMatch(/FooMany/);
+    });
+
+    it('exits 1 when languages.json is out of sync with locale files', () => {
+      fixture = createLocaleFixture({
+        en_US: BASELINE_EN_US,
+        locales: { de_DE: { Hello: 'Hallo', World: 'Welt' } },
+        languagesJson: [{ code: '', name: 'Automatic', nativeName: 'Automatic' }],
+        sources: BASELINE_SOURCE,
+      });
+      const { exitCode, stdout } = spawnScript(SCRIPT, [], { cwd: fixture.dir });
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/locale file\(s\) not registered/);
+      expect(stdout).toMatch(/de_DE/);
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // Fix mode (--fix)
+  // --------------------------------------------------------------------
+
+  describe('fix mode (--fix)', () => {
+    it('rewrites en_US.json in sorted order when keys are unsorted', () => {
+      fixture = createLocaleFixture({
+        en_US: { World: 'World', Hello: 'Hello' },
+        sources: BASELINE_SOURCE,
+      });
+      const { exitCode } = spawnScript(SCRIPT, ['--fix'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+      // Object.keys preserves insertion order, which after JSON.parse mirrors file order.
+      expect(Object.keys(readJson(fixture.dir, 'locale/custom/en_US.json'))).toEqual([
+        'Hello',
+        'World',
+      ]);
+    });
+
+    it('removes orphan keys from en_US.json', () => {
+      fixture = createLocaleFixture({
+        en_US: { Hello: 'Hello', Orphan: 'remove me', World: 'World' },
+        sources: BASELINE_SOURCE,
+      });
+      const { exitCode } = spawnScript(SCRIPT, ['--fix'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+      const enUs = readJson(fixture.dir, 'locale/custom/en_US.json');
+      expect(enUs).not.toHaveProperty('Orphan');
+      expect(Object.keys(enUs).sort()).toEqual(['Hello', 'World']);
+    });
+
+    it('adds missing locale entries to languages.json from LANGUAGE_METADATA', () => {
+      fixture = createLocaleFixture({
+        en_US: BASELINE_EN_US,
+        locales: { de: { Hello: 'Hallo', World: 'Welt' } },
+        languagesJson: [{ code: '', name: 'Automatic', nativeName: 'Automatic' }],
+        sources: BASELINE_SOURCE,
+      });
+      const { exitCode } = spawnScript(SCRIPT, ['--fix'], { cwd: fixture.dir });
+      expect(exitCode).toBe(0);
+      const langs = readJson(fixture.dir, 'locale/languages.json');
+      const de = langs.find((l) => l.code === 'de');
+      expect(de).toEqual({ code: 'de', name: 'German', nativeName: 'Deutsch' });
+      // The Automatic ("") entry stays pinned first.
+      expect(langs[0].code).toBe('');
+    });
+
+    it('is idempotent: a second --fix run on already-clean input does not mutate files', () => {
+      fixture = createLocaleFixture({
+        en_US: BASELINE_EN_US,
+        locales: { de: { Hello: 'Hallo', World: 'Welt' } },
+        languagesJson: [
+          { code: '', name: 'Automatic', nativeName: 'Automatic' },
+          { code: 'de', name: 'German', nativeName: 'Deutsch' },
+        ],
+        sources: BASELINE_SOURCE,
+      });
+
+      const first = spawnScript(SCRIPT, ['--fix'], { cwd: fixture.dir });
+      expect(first.exitCode).toBe(0);
+      const enUsAfterFirst = readText(fixture.dir, 'locale/custom/en_US.json');
+      const langsAfterFirst = readText(fixture.dir, 'locale/languages.json');
+
+      const second = spawnScript(SCRIPT, ['--fix'], { cwd: fixture.dir });
+      expect(second.exitCode).toBe(0);
+      expect(readText(fixture.dir, 'locale/custom/en_US.json')).toBe(enUsAfterFirst);
+      expect(readText(fixture.dir, 'locale/languages.json')).toBe(langsAfterFirst);
+    });
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes

Closes the two heaviest non-plugin scripts that #536 deferred. 

- **`scripts/lint/update-translations.cjs`** — 13 scenarios covering all 8 lint rules (sort order, orphans, missing keys, hardcoded strings, malformed JSON, placeholder mismatches, plural completeness, languages.json sync) plus 4 `--fix`-mode behaviors including idempotency.
- **`scripts/changelog-syncer.js`** — 16 scenarios across `status`, `validate` (incl. `Keep a Changelog` and `unreleased commits but no [Unreleased]` rules), `sync-unreleased` (incl. conventional-commit categorization), and `sync-release` (compare URL with previous tag, release URL fallback, invalid-version error).
- Two new fixture-seeder helpers under `tests/scripts/unit/_helpers/` — `temp-locale-fixture.js` and `temp-git-fixture.js`. They compose with the existing `spawnScript()` rather than duplicating its child-process boilerplate.
- **Fix a latent bug surfaced by the new tests**: `validate()` called `getStatus()` before checking file existence, so a missing `CHANGELOG.md` crashed with `ENOENT` instead of emitting the intended `"CHANGELOG.md file missing"` issue. The existing existence check was dead code on that path.

Out of scope: merge-commit / `gh pr view` paths in `changelog-syncer.js`. Covering them would need a `gh` stub on `PATH`; current 16 scenarios cover every codepath that does not reach `gh`. Filed mentally as a follow-up rather than landing a half-done stub.

## Issues

<!-- none -->

## Docs / context updates

- [x] None — this PR doesn't change any of the above