### PR TITLE
feat(release): add local package:signed for Roku channel-store .pkg

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,5 @@ ROKU_PASSWORD=rokudev
 # Signing password used to encrypt the .pkg — only used by `npm run package:signed` (set when you first signed your channel).
 ROKU_SIGNING_PASSWORD=
 
-# Optional: expected Roku dev ID — when set, signing aborts if device cert produces a .pkg with a different ID (find on dev portal Utilities page).
+# Optional: expected keyed-developer-id (40-char SHA-1 hex from signing cert, NOT the numeric vendor/account ID on dev.roku.com). Get via: curl -s "http://${ROKU_IP}:8060/query/device-info" | grep keyed-developer-id
 ROKU_DEV_ID=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Copy to .env (gitignored) and fill in. chmod 600 .env to lock perms.
+
+# === For all contributors (running tests on a real Roku) ===
+
+# Roku device IP — used by `npm run test:*` (deploys test build) and `npm run package:signed`.
+ROKU_IP=192.168.1.50
+
+# Roku dev portal password (the one you set when enabling dev mode) — used by both test runner and signing script.
+ROKU_PASSWORD=rokudev
+
+# === For maintainers only (signing the app for Roku channel store upload) ===
+# Skip these unless you're shipping releases. The test runner doesn't need them.
+
+# Signing password used to encrypt the .pkg — only used by `npm run package:signed` (set when you first signed your channel).
+ROKU_SIGNING_PASSWORD=
+
+# Optional: expected Roku dev ID — when set, signing aborts if device cert produces a .pkg with a different ID (find on dev portal Utilities page).
+ROKU_DEV_ID=

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -343,7 +343,10 @@ dev-ID
 dev-mode
 dev-portal
 filesystem
+footgun
 portal-UI
+rekey
+SHA-1
 ES5
 ESLint
 ESLint's

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -335,7 +335,15 @@ CJS
 CLIs
 codegen
 CommonJS
+decrypting
 deps
+dev-id
+Dev-ID
+dev-ID
+dev-mode
+dev-portal
+filesystem
+portal-UI
 ES5
 ESLint
 ESLint's
@@ -345,6 +353,7 @@ formatter
 JS
 JSONC
 multiline
+runbook
 unprefixed
 validator
 validators

--- a/docs/admin/releases.md
+++ b/docs/admin/releases.md
@@ -83,7 +83,7 @@ If you don't have a `.env` yet, copy [`.env.example`](../../.env.example) to `.e
 
 ```sh
 ROKU_SIGNING_PASSWORD=...   # what you currently type into the dev portal
-ROKU_DEV_ID=...             # optional but recommended; from dev portal Utilities page
+ROKU_DEV_ID=...             # optional but recommended; see "Finding ROKU_DEV_ID" below
 ```
 
 `chmod 600 .env` to lock filesystem permissions. If you'd rather not store the signing password on disk, wrap with your preferred secret manager — the script just reads env vars:
@@ -92,11 +92,28 @@ ROKU_DEV_ID=...             # optional but recommended; from dev portal Utilitie
 ROKU_SIGNING_PASSWORD=$(pass show jellyrock/signing) npm run package:signed
 ```
 
+### Finding `ROKU_DEV_ID`
+
+Roku has three different "developer ID" concepts and the naming overlap is a known footgun:
+
+| What | Format | Where it appears |
+|---|---|---|
+| Vendor / Account ID | short numeric (e.g. `819325`) | dev.roku.com → My Account |
+| **Keyed Developer ID** | **40-char SHA-1 hex** | what we want; derived from signing cert |
+| Channel ID | 32-char hex | channel-store URL `details/<this>:<other>/jellyrock` |
+
+For `ROKU_DEV_ID` you want the **Keyed Developer ID**. Easiest way to find yours:
+
+```bash
+curl -s "http://${ROKU_IP}:8060/query/device-info" | grep keyed-developer-id
+```
+
+Provided your existing prod `.pkg` installs on this device via "Install from File" in the dev portal, that value IS the cert your published channel was signed with — copy it into `.env`. If install fails, the device is on a different cert than what's published, and you need to rekey it from the existing prod `.pkg` first.
+
 ### Safety guardrails
 
-The script refuses to run if `build/` contains source maps (a sign that a dev or test build is sitting there instead of a prod build). The composed npm script runs `build:prod` first, so the default invocation is always safe — the guard catches direct invocations of the `.cjs` against a stale build.
-
-`ROKU_DEV_ID`, when set, is passed to `deployAndSignPackage()` and the call aborts if the device's cert produces a `.pkg` with a different ID. Cheap insurance against a wrong-cert `.pkg` getting uploaded to Roku and rejected.
+- **Prod-build guard.** Refuses to sign if `build/` contains source maps outside `roku_modules/` (a sign that a dev or test build is sitting there). The composed `package:signed` runs `build:prod` first, so the default invocation is always safe — the guard catches direct `.cjs` invocations against a stale build. `roku_modules/` is excluded because vendored ropm packages ship their own `.brs.map` files regardless of our bsconfig.
+- **Dev-ID verification.** When `ROKU_DEV_ID` is set, the script queries the device's `keyed-developer-id` via ECP and aborts before signing if it doesn't match. Catches "wrong-cert .pkg" before manual upload to Roku.
 
 ### Why local instead of CI
 

--- a/docs/admin/releases.md
+++ b/docs/admin/releases.md
@@ -63,6 +63,45 @@ When you publish the draft release:
 - ✅ Converts `[Unreleased]` to versioned release in changelog
 - ✅ Release process is complete
 
+## Signed `.pkg` for Roku channel store
+
+Roku channel-store submission requires a **signed `.pkg`**, not the sideload zip. Roku has no submission API, so the upload itself is always manual — but the production of the `.pkg` is automated locally via `npm run package:signed`.
+
+### Run it
+
+Against your dev Roku, after the release PR has merged and you're ready to ship:
+
+```bash
+npm run package:signed
+```
+
+That composes `npm run build:prod` then `node scripts/create-signed-package.cjs`, which calls `roku-deploy.deployAndSignPackage()` against your local Roku. Output: `out/jellyrock.pkg`. Upload it to the [Roku Developer Portal](https://developer.roku.com/) manually.
+
+### One-time setup
+
+If you don't have a `.env` yet, copy [`.env.example`](../../.env.example) to `.env` and fill in the values. Otherwise just add the two new vars to your existing `.env`:
+
+```sh
+ROKU_SIGNING_PASSWORD=...   # what you currently type into the dev portal
+ROKU_DEV_ID=...             # optional but recommended; from dev portal Utilities page
+```
+
+`chmod 600 .env` to lock filesystem permissions. If you'd rather not store the signing password on disk, wrap with your preferred secret manager — the script just reads env vars:
+
+```bash
+ROKU_SIGNING_PASSWORD=$(pass show jellyrock/signing) npm run package:signed
+```
+
+### Safety guardrails
+
+The script refuses to run if `build/` contains source maps (a sign that a dev or test build is sitting there instead of a prod build). The composed npm script runs `build:prod` first, so the default invocation is always safe — the guard catches direct invocations of the `.cjs` against a stale build.
+
+`ROKU_DEV_ID`, when set, is passed to `deployAndSignPackage()` and the call aborts if the device's cert produces a `.pkg` with a different ID. Cheap insurance against a wrong-cert `.pkg` getting uploaded to Roku and rejected.
+
+### Why local instead of CI
+
+Solo-maintainer release ritual; the time saved by CI signing (a sideload + a portal-UI sign) is washed out by the friction of downloading + decrypting a CI-produced artifact. Local stays simpler. If JellyRock ever gets multiple ship-capable maintainers, this is the natural moment to revisit.
+
 ## Workflows
 
 ### `release-management.yml`

--- a/docs/admin/releases.md
+++ b/docs/admin/releases.md
@@ -75,7 +75,7 @@ Against your dev Roku, after the release PR has merged and you're ready to ship:
 npm run package:signed
 ```
 
-That composes `npm run build:prod` then `node scripts/create-signed-package.cjs`, which calls `roku-deploy.deployAndSignPackage()` against your local Roku. Output: `out/jellyrock.pkg`. Upload it to the [Roku Developer Portal](https://developer.roku.com/) manually.
+That composes `npm run build:prod` then `node scripts/create-signed-package.cjs`, which calls `roku-deploy.deployAndSignPackage()` against your local Roku. Output: `out/jellyrock-vX.Y.Z.pkg` (version pulled from `manifest`, so a missed version-bump shows up in the filename). Upload it to the [Roku Developer Portal](https://developer.roku.com/) manually.
 
 ### One-time setup
 

--- a/docs/architecture/build-and-tooling.md
+++ b/docs/architecture/build-and-tooling.md
@@ -6,6 +6,8 @@ related-files:
   - package.json
   - patches/
   - Makefile
+  - scripts/create-package.cjs
+  - scripts/create-signed-package.cjs
   - scripts/bsc-plugins/roku-log.cjs
   - scripts/bsc-plugins/translation-keys.cjs
   - scripts/bsc-plugins/jrscreen-on-destroy.cjs
@@ -164,6 +166,7 @@ Build:
 | `npm run build:tests-complete` | Complete suite |
 | `npm run build:tdd` | TDD watch mode (uses `bsconfig-tdd.json`) |
 | `npm run package` | Create installable .zip via `scripts/create-package.cjs` |
+| `npm run package:signed` | Compose `build:prod` then sign via `scripts/create-signed-package.cjs` — produces `out/jellyrock.pkg` for Roku channel-store upload. Local-only (no CI variant); requires a physical Roku in dev mode plus `ROKU_IP` / `ROKU_PASSWORD` / `ROKU_SIGNING_PASSWORD` in `.env`. Optional `ROKU_DEV_ID` enables dev-ID verification. Refuses to sign if `build/` contains source maps (dev/test build guard). See [`docs/admin/releases.md` → Signed `.pkg`](../admin/releases.md#signed-pkg-for-roku-channel-store) |
 | `npm run validate` | Type-check only (`bsc --noEmit`) |
 
 Run tests:
@@ -224,6 +227,20 @@ ropm + patches (post-install):
 | `npm run postinstall` | Runs `npm run ropm && npm run patches:apply` automatically after `npm install` |
 | `npm run ropm` | `ropm copy && node scripts/ropm-hook.cjs` — copies vendored Roku modules into `components/roku_modules/` and `source/roku_modules/` |
 | `npm run patches:apply` | `patch-package` — applies every diff in `patches/` to `node_modules/`. Lets us hold local fixes against upstream packages until the upstream change lands |
+
+## Roku signing pipeline (`.pkg` for channel store)
+
+Roku channel-store submission requires a signed `.pkg`, not the sideload `.zip`. Roku has no submission API — uploading the `.pkg` to the dev portal is always manual. The production of the `.pkg` is automated locally via [`scripts/create-signed-package.cjs`](../../scripts/create-signed-package.cjs) and `npm run package:signed`.
+
+**Why local, not CI.** Solo-maintainer ritual; the time CI signing would save (a sideload + a portal-UI sign) is washed out by the friction of a CI-produced artifact (download + auth + storage). Local stays simpler and matches the same `.env`-based credential pattern already used for `ROKU_IP` / `ROKU_PASSWORD` in `scripts/run-roku-tests.js`.
+
+**Why hardware is required.** `roku-deploy.deployAndSignPackage()` is a thin wrapper over `deploy()` + `signExistingPackage()`. The signing runs on the Roku itself: `roku-deploy` uploads the zip, hits the dev-portal sign endpoint with the signing password, and downloads the resulting `.pkg`. There is no offline signing path.
+
+**Prod-build guard.** The script refuses to sign a `build/` directory that contains source maps. `bsconfig-prod.json` has `sourceMap: false`; `bsconfig.json` and `bsconfig-tests*.json` both have `sourceMap: true`. Any `.map` file under `build/` means an unsafe build is sitting there. The composed npm script (`npm run build:prod && node scripts/create-signed-package.cjs`) makes the default invocation always safe; the in-script guard catches direct `.cjs` invocations against a stale build.
+
+**Dev-ID verification (optional).** When `ROKU_DEV_ID` is set, it's passed to `deployAndSignPackage()` and the call aborts if the device's cert produces a `.pkg` with a different ID. Roku channel-store updates must be signed with the same dev ID as prior versions, so this catches a wrong-cert `.pkg` before manual upload.
+
+Full operator runbook (env setup, when to run, manual upload): [`docs/admin/releases.md` → Signed `.pkg` for Roku channel store](../admin/releases.md#signed-pkg-for-roku-channel-store).
 
 ## ropm modules — Roku Package Manager
 

--- a/docs/architecture/build-and-tooling.md
+++ b/docs/architecture/build-and-tooling.md
@@ -166,7 +166,7 @@ Build:
 | `npm run build:tests-complete` | Complete suite |
 | `npm run build:tdd` | TDD watch mode (uses `bsconfig-tdd.json`) |
 | `npm run package` | Create installable .zip via `scripts/create-package.cjs` |
-| `npm run package:signed` | Compose `build:prod` then sign via `scripts/create-signed-package.cjs` — produces `out/jellyrock.pkg` for Roku channel-store upload. Local-only (no CI variant); requires a physical Roku in dev mode plus `ROKU_IP` / `ROKU_PASSWORD` / `ROKU_SIGNING_PASSWORD` in `.env`. Optional `ROKU_DEV_ID` enables dev-ID verification. Refuses to sign if `build/` contains source maps (dev/test build guard). See [`docs/admin/releases.md` → Signed `.pkg`](../admin/releases.md#signed-pkg-for-roku-channel-store) |
+| `npm run package:signed` | Compose `build:prod` then sign via `scripts/create-signed-package.cjs` — produces `out/jellyrock-vX.Y.Z.pkg` (version from `manifest`) for Roku channel-store upload. Local-only (no CI variant); requires a physical Roku in dev mode plus `ROKU_IP` / `ROKU_PASSWORD` / `ROKU_SIGNING_PASSWORD` in `.env`. Optional `ROKU_DEV_ID` enables dev-ID verification. Refuses to sign if `build/` contains source maps (dev/test build guard). See [`docs/admin/releases.md` → Signed `.pkg`](../admin/releases.md#signed-pkg-for-roku-channel-store) |
 | `npm run validate` | Type-check only (`bsc --noEmit`) |
 
 Run tests:

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "ropm": "ropm copy && node scripts/ropm-hook.cjs",
     "update-translations": "node scripts/lint/update-translations.cjs --fix",
     "package": "node scripts/create-package.cjs",
+    "package:signed": "npm run build:prod && node scripts/create-signed-package.cjs",
     "validate": "npx bsc --noEmit",
     "test:tdd": "npm run build:tdd && node scripts/run-roku-tests.js",
     "test:unit": "npm run build:tests-unit && node scripts/run-roku-tests.js",

--- a/scripts/create-signed-package.cjs
+++ b/scripts/create-signed-package.cjs
@@ -14,9 +14,9 @@
  *   ROKU_SIGNING_PASSWORD  signing password used to encrypt the .pkg
  *
  * Optional env var:
- *   ROKU_DEV_ID            expected dev ID — deployAndSignPackage()
- *                          aborts if the device's cert produces a .pkg
- *                          with a different ID. Recommended for channel-store
+ *   ROKU_DEV_ID            expected dev ID — script queries the device's
+ *                          actual keyed-developer-id and aborts before signing
+ *                          if it doesn't match. Recommended for channel-store
  *                          updates (must be stable across versions).
  *
  * Storage: easiest is a gitignored .env (chmod 600) — same pattern used by
@@ -130,12 +130,29 @@ async function createSignedPackage() {
     outDir,
     outFile,
   };
-  if (devId) options.devId = devId;
+  // Note: roku-deploy's `options.devId` is ONLY consulted inside rekeyDevice()
+  // (which we don't call). signExistingPackage/deployAndSignPackage silently
+  // ignore it. So we have to run the check ourselves before signing — fail
+  // fast on mismatch rather than producing a .pkg the channel store will
+  // reject.
+  if (devId) {
+    const actualDevId = await rokuDeploy.getDevId({ host, password });
+    if (actualDevId !== devId) {
+      console.error(`❌ Dev ID mismatch.`);
+      console.error(`   Device ${host} reports: ${actualDevId}`);
+      console.error(`   .env ROKU_DEV_ID expects: ${devId}`);
+      console.error(
+        '   Either correct ROKU_DEV_ID in .env, or rekey this device to the expected cert.',
+      );
+      process.exit(1);
+    }
+    console.log(`  • devId verified: ${actualDevId}`);
+  }
 
   console.log('🔐 Creating signed Roku package via deployAndSignPackage...');
   console.log(`  • host: ${host}`);
   console.log(`  • version: ${version}`);
-  console.log(`  • devId check: ${devId ? 'on' : 'off (skipped)'}`);
+  console.log(`  • devId check: ${devId ? 'on (passed)' : 'off (no ROKU_DEV_ID set)'}`);
 
   const result = await rokuDeploy.deployAndSignPackage(options);
   const pkgPath = typeof result === 'string' ? result : path.join(outDir, `${outFile}.pkg`);

--- a/scripts/create-signed-package.cjs
+++ b/scripts/create-signed-package.cjs
@@ -91,7 +91,16 @@ async function createSignedPackage() {
   // sourceMap=false (bsconfig-prod.json), dev sets sourceMap=true. Test
   // builds also have source maps. Any *.map under build/ means the build
   // came from bsconfig.json or bsconfig-tests*.json — both unsafe to ship.
-  const sourceMaps = await fg(['**/*.map'], { cwd: buildDir, onlyFiles: true });
+  //
+  // Exclude roku_modules/ — those are ropm-vendored upstream packages that
+  // ship with their own .brs.map files regardless of our bsconfig settings.
+  // We have no control over their build output and they're not what this
+  // guard is trying to catch.
+  const sourceMaps = await fg(['**/*.map'], {
+    cwd: buildDir,
+    onlyFiles: true,
+    ignore: ['**/roku_modules/**'],
+  });
   if (sourceMaps.length > 0) {
     console.error(
       '❌ build/ contains source maps — this is a dev or test build, not a prod build.',

--- a/scripts/create-signed-package.cjs
+++ b/scripts/create-signed-package.cjs
@@ -28,7 +28,9 @@
  *        node scripts/create-signed-package.cjs   (direct; signs whatever's
  *                                                  in build/ — see prod-build
  *                                                  guard below)
- * Output: out/jellyrock.pkg
+ * Output: out/jellyrock-vX.Y.Z.pkg   (version pulled from manifest — if the
+ *         filename's version doesn't match what you expect, the version bump
+ *         didn't land)
  */
 
 require('dotenv').config();
@@ -49,6 +51,28 @@ function requireEnv(name) {
     process.exit(1);
   }
   return v;
+}
+
+function readVersionFromManifest(manifestPath) {
+  if (!fs.existsSync(manifestPath)) {
+    console.error(`❌ Expected manifest at ${manifestPath}`);
+    process.exit(1);
+  }
+  const text = fs.readFileSync(manifestPath, 'utf8');
+  const get = (key) => {
+    const match = text.match(new RegExp(`^${key}=(.*)$`, 'm'));
+    return match ? match[1].trim() : null;
+  };
+  const major = get('major_version');
+  const minor = get('minor_version');
+  const build = get('build_version');
+  if (!major || !minor || !build) {
+    console.error(
+      `❌ Could not parse version from ${manifestPath}. Need major_version, minor_version, build_version.`,
+    );
+    process.exit(1);
+  }
+  return `${major}.${minor}.${build}`;
 }
 
 async function createSignedPackage() {
@@ -79,6 +103,11 @@ async function createSignedPackage() {
     process.exit(1);
   }
 
+  // Version goes in the filename so a missed version-bump is obvious at a
+  // glance — the manifest is the canonical on-device version source.
+  const version = readVersionFromManifest(path.join(buildDir, 'manifest'));
+  const outFile = `jellyrock-v${version}`;
+
   const outDir = path.join(rootDir, 'out');
   const stagingDir = path.join(outDir, '.staging-signed');
 
@@ -90,16 +119,17 @@ async function createSignedPackage() {
     files: ['**/*'],
     stagingDir,
     outDir,
-    outFile: 'jellyrock',
+    outFile,
   };
   if (devId) options.devId = devId;
 
   console.log('🔐 Creating signed Roku package via deployAndSignPackage...');
   console.log(`  • host: ${host}`);
+  console.log(`  • version: ${version}`);
   console.log(`  • devId check: ${devId ? 'on' : 'off (skipped)'}`);
 
   const result = await rokuDeploy.deployAndSignPackage(options);
-  const pkgPath = typeof result === 'string' ? result : path.join(outDir, 'jellyrock.pkg');
+  const pkgPath = typeof result === 'string' ? result : path.join(outDir, `${outFile}.pkg`);
   console.log(`✅ Signed package created: ${pkgPath}`);
 }
 

--- a/scripts/create-signed-package.cjs
+++ b/scripts/create-signed-package.cjs
@@ -1,0 +1,110 @@
+/**
+ * Creates a signed Roku .pkg from the compiled build directory using
+ * roku-deploy.deployAndSignPackage().
+ *
+ * Local-only by design — the signing operation requires a physical Roku
+ * device (the device performs the encryption using its on-device dev key),
+ * and a solo-maintainer release ritual doesn't benefit enough from CI to
+ * justify the secret-management overhead. Run this against your dev Roku
+ * after `npm run build:prod`.
+ *
+ * Required env vars (load via .env or your shell's preferred secret manager):
+ *   ROKU_IP                target Roku (must be in dev mode)
+ *   ROKU_PASSWORD          device dev portal password
+ *   ROKU_SIGNING_PASSWORD  signing password used to encrypt the .pkg
+ *
+ * Optional env var:
+ *   ROKU_DEV_ID            expected dev ID — deployAndSignPackage()
+ *                          aborts if the device's cert produces a .pkg
+ *                          with a different ID. Recommended for channel-store
+ *                          updates (must be stable across versions).
+ *
+ * Storage: easiest is a gitignored .env (chmod 600) — same pattern used by
+ * scripts/run-roku-tests.js for ROKU_IP/ROKU_PASSWORD. For encryption-at-rest,
+ * wrap with your preferred secret manager:
+ *   ROKU_SIGNING_PASSWORD=$(pass show jellyrock/signing) npm run package:signed
+ *
+ * Usage: npm run package:signed   (composes build:prod first — always safe)
+ *        node scripts/create-signed-package.cjs   (direct; signs whatever's
+ *                                                  in build/ — see prod-build
+ *                                                  guard below)
+ * Output: out/jellyrock.pkg
+ */
+
+require('dotenv').config();
+const { rokuDeploy } = require('roku-deploy');
+const fg = require('fast-glob');
+const fs = require('fs');
+const path = require('path');
+
+// Resolve from cwd, not __dirname. npm run scripts always cd to package.json
+// root, so production invocations land here correctly. Tests can override by
+// spawning with a different cwd.
+const rootDir = process.cwd();
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`❌ Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+async function createSignedPackage() {
+  const host = requireEnv('ROKU_IP');
+  const password = requireEnv('ROKU_PASSWORD');
+  const signingPassword = requireEnv('ROKU_SIGNING_PASSWORD');
+  const devId = process.env.ROKU_DEV_ID || undefined;
+
+  const buildDir = path.join(rootDir, 'build');
+  if (!fs.existsSync(buildDir)) {
+    console.error(`❌ Expected build/ at ${buildDir}. Run 'npm run build:prod' first.`);
+    process.exit(1);
+  }
+
+  // Refuse to sign anything that isn't a prod build. Detection: prod sets
+  // sourceMap=false (bsconfig-prod.json), dev sets sourceMap=true. Test
+  // builds also have source maps. Any *.map under build/ means the build
+  // came from bsconfig.json or bsconfig-tests*.json — both unsafe to ship.
+  const sourceMaps = await fg(['**/*.map'], { cwd: buildDir, onlyFiles: true });
+  if (sourceMaps.length > 0) {
+    console.error(
+      '❌ build/ contains source maps — this is a dev or test build, not a prod build.',
+    );
+    console.error(`   First offender: build/${sourceMaps[0]}`);
+    console.error(
+      "   Run 'npm run build:prod' (or just 'npm run package:signed', which composes it).",
+    );
+    process.exit(1);
+  }
+
+  const outDir = path.join(rootDir, 'out');
+  const stagingDir = path.join(outDir, '.staging-signed');
+
+  const options = {
+    host,
+    password,
+    signingPassword,
+    rootDir: buildDir,
+    files: ['**/*'],
+    stagingDir,
+    outDir,
+    outFile: 'jellyrock',
+  };
+  if (devId) options.devId = devId;
+
+  console.log('🔐 Creating signed Roku package via deployAndSignPackage...');
+  console.log(`  • host: ${host}`);
+  console.log(`  • devId check: ${devId ? 'on' : 'off (skipped)'}`);
+
+  const result = await rokuDeploy.deployAndSignPackage(options);
+  const pkgPath = typeof result === 'string' ? result : path.join(outDir, 'jellyrock.pkg');
+  console.log(`✅ Signed package created: ${pkgPath}`);
+}
+
+createSignedPackage().catch((err) => {
+  const msg = err && err.message ? err.message : String(err);
+  console.error('❌ Failed to create signed package:', msg);
+  process.exit(1);
+});

--- a/scripts/create-signed-package.cjs
+++ b/scripts/create-signed-package.cjs
@@ -14,10 +14,12 @@
  *   ROKU_SIGNING_PASSWORD  signing password used to encrypt the .pkg
  *
  * Optional env var:
- *   ROKU_DEV_ID            expected dev ID — script queries the device's
- *                          actual keyed-developer-id and aborts before signing
- *                          if it doesn't match. Recommended for channel-store
- *                          updates (must be stable across versions).
+ *   ROKU_DEV_ID            expected keyed-developer-id (40-char SHA-1 hex from
+ *                          your signing cert — NOT the numeric vendor ID on
+ *                          dev.roku.com, NOT the channel-store URL hash). Script
+ *                          queries device's actual keyed-developer-id and aborts
+ *                          before signing on mismatch. Recommended for channel-
+ *                          store updates (must be stable across versions).
  *
  * Storage: easiest is a gitignored .env (chmod 600) — same pattern used by
  * scripts/run-roku-tests.js for ROKU_IP/ROKU_PASSWORD. For encryption-at-rest,
@@ -141,9 +143,18 @@ async function createSignedPackage() {
       console.error(`❌ Dev ID mismatch.`);
       console.error(`   Device ${host} reports: ${actualDevId}`);
       console.error(`   .env ROKU_DEV_ID expects: ${devId}`);
+      console.error('');
       console.error(
-        '   Either correct ROKU_DEV_ID in .env, or rekey this device to the expected cert.',
+        '   ROKU_DEV_ID must be the 40-char keyed-developer-id (SHA-1 of your signing cert),',
       );
+      console.error(
+        '   NOT your numeric vendor/account ID from dev.roku.com and NOT the channel-store URL ID.',
+      );
+      console.error('');
+      console.error('   If your existing prod .pkg installs on this device via Install-from-File,');
+      console.error("   the device's reported value above is correct — copy it into .env:");
+      console.error(`     ROKU_DEV_ID=${actualDevId}`);
+      console.error('   Otherwise, this device is on a different cert than the published channel.');
       process.exit(1);
     }
     console.log(`  • devId verified: ${actualDevId}`);

--- a/tests/scripts/unit/create-signed-package.test.js
+++ b/tests/scripts/unit/create-signed-package.test.js
@@ -122,4 +122,48 @@ describe('create-signed-package', () => {
       ws.cleanup();
     }
   });
+
+  it('fails when build/manifest is missing (need version for filename)', () => {
+    // Prod build with no source maps but no manifest — script can't compute
+    // the version-tagged filename, so it must bail before signing rather than
+    // produce an unversioned .pkg.
+    const ws = freshWorkspace();
+    try {
+      const buildDir = join(ws.dir, 'build');
+      mkdirSync(buildDir, { recursive: true });
+      const { exitCode, stderr } = spawnScript('scripts/create-signed-package.cjs', [], {
+        cwd: ws.dir,
+        env: {
+          ROKU_IP: '1.2.3.4',
+          ROKU_PASSWORD: 'pw',
+          ROKU_SIGNING_PASSWORD: 'sp',
+        },
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toMatch(/manifest/);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it('fails when manifest is present but missing version fields', () => {
+    const ws = freshWorkspace();
+    try {
+      const buildDir = join(ws.dir, 'build');
+      mkdirSync(buildDir, { recursive: true });
+      writeFileSync(join(buildDir, 'manifest'), 'title=JellyRock\n');
+      const { exitCode, stderr } = spawnScript('scripts/create-signed-package.cjs', [], {
+        cwd: ws.dir,
+        env: {
+          ROKU_IP: '1.2.3.4',
+          ROKU_PASSWORD: 'pw',
+          ROKU_SIGNING_PASSWORD: 'sp',
+        },
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toMatch(/major_version/);
+    } finally {
+      ws.cleanup();
+    }
+  });
 });

--- a/tests/scripts/unit/create-signed-package.test.js
+++ b/tests/scripts/unit/create-signed-package.test.js
@@ -123,6 +123,41 @@ describe('create-signed-package', () => {
     }
   });
 
+  it('ignores source maps under roku_modules/ (vendored ropm packages ship with their own)', () => {
+    // Regression: ropm-vendored packages (log, rr, bslib) copy their own
+    // .brs.map files into build/{source,components}/roku_modules/ regardless
+    // of bsconfig sourceMap settings. These are NOT a sign of a dev build —
+    // a clean prod build still contains them. The guard must skip them and
+    // proceed past the source-map check (failing later at the manifest step
+    // here, since no manifest is created for this fixture).
+    const ws = freshWorkspace();
+    try {
+      const buildDir = join(ws.dir, 'build');
+      mkdirSync(join(buildDir, 'source', 'roku_modules', 'log'), { recursive: true });
+      mkdirSync(join(buildDir, 'components', 'roku_modules', 'log'), { recursive: true });
+      writeFileSync(join(buildDir, 'source', 'roku_modules', 'log', 'LogMixin.brs.map'), '{}');
+      writeFileSync(
+        join(buildDir, 'components', 'roku_modules', 'log', 'HTTPTransport.brs.map'),
+        '{}',
+      );
+      const { exitCode, stderr } = spawnScript('scripts/create-signed-package.cjs', [], {
+        cwd: ws.dir,
+        env: {
+          ROKU_IP: '1.2.3.4',
+          ROKU_PASSWORD: 'pw',
+          ROKU_SIGNING_PASSWORD: 'sp',
+        },
+      });
+      expect(exitCode).not.toBe(0);
+      // Must NOT have failed at the source-map check.
+      expect(stderr).not.toMatch(/source maps/);
+      // Must have progressed past it to the manifest check.
+      expect(stderr).toMatch(/manifest/);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
   it('fails when build/manifest is missing (need version for filename)', () => {
     // Prod build with no source maps but no manifest — script can't compute
     // the version-tagged filename, so it must bail before signing rather than

--- a/tests/scripts/unit/create-signed-package.test.js
+++ b/tests/scripts/unit/create-signed-package.test.js
@@ -1,0 +1,125 @@
+// Tests for scripts/create-signed-package.cjs.
+//
+// The script wraps roku-deploy.deployAndSignPackage(). Hardware-touching
+// behavior is out of scope here; we cover the surface the script owns:
+// env-var validation and fail-fast on missing prerequisites.
+
+import { describe, it, expect } from 'vitest';
+import { spawnScript } from './_helpers/spawn-script.js';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function freshWorkspace() {
+  const dir = mkdtempSync(join(tmpdir(), 'jellyrock-create-signed-pkg-'));
+  return {
+    dir,
+    cleanup() {
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe('create-signed-package', () => {
+  it('fails fast when ROKU_IP is missing', () => {
+    const ws = freshWorkspace();
+    try {
+      const { exitCode, stderr } = spawnScript('scripts/create-signed-package.cjs', [], {
+        cwd: ws.dir,
+        env: {
+          ROKU_IP: '',
+          ROKU_PASSWORD: 'pw',
+          ROKU_SIGNING_PASSWORD: 'sp',
+        },
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toMatch(/ROKU_IP/);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it('fails fast when ROKU_PASSWORD is missing', () => {
+    const ws = freshWorkspace();
+    try {
+      const { exitCode, stderr } = spawnScript('scripts/create-signed-package.cjs', [], {
+        cwd: ws.dir,
+        env: {
+          ROKU_IP: '1.2.3.4',
+          ROKU_PASSWORD: '',
+          ROKU_SIGNING_PASSWORD: 'sp',
+        },
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toMatch(/ROKU_PASSWORD/);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it('fails fast when ROKU_SIGNING_PASSWORD is missing', () => {
+    const ws = freshWorkspace();
+    try {
+      const { exitCode, stderr } = spawnScript('scripts/create-signed-package.cjs', [], {
+        cwd: ws.dir,
+        env: {
+          ROKU_IP: '1.2.3.4',
+          ROKU_PASSWORD: 'pw',
+          ROKU_SIGNING_PASSWORD: '',
+        },
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toMatch(/ROKU_SIGNING_PASSWORD/);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it("fails when build/ directory doesn't exist (env validated, build missing)", () => {
+    // All required env present but no build/ — script should reject with a
+    // clear "run npm run build:prod first" message BEFORE attempting any
+    // network call to the Roku.
+    const ws = freshWorkspace();
+    try {
+      const { exitCode, stderr } = spawnScript('scripts/create-signed-package.cjs', [], {
+        cwd: ws.dir,
+        env: {
+          ROKU_IP: '1.2.3.4',
+          ROKU_PASSWORD: 'pw',
+          ROKU_SIGNING_PASSWORD: 'sp',
+        },
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toMatch(/build:prod/);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it('refuses to sign a build/ that contains source maps (dev/test build guard)', () => {
+    // Source maps in build/ mean the build came from bsconfig.json or
+    // bsconfig-tests*.json (both have sourceMap=true). Only bsconfig-prod.json
+    // produces a signing-safe build (sourceMap=false). The script must
+    // refuse before reaching deployAndSignPackage.
+    const ws = freshWorkspace();
+    try {
+      const buildDir = join(ws.dir, 'build');
+      mkdirSync(join(buildDir, 'source'), { recursive: true });
+      writeFileSync(join(buildDir, 'source', 'main.brs'), 'sub Main()\nend sub\n');
+      writeFileSync(join(buildDir, 'source', 'main.brs.map'), '{}');
+      const { exitCode, stderr } = spawnScript('scripts/create-signed-package.cjs', [], {
+        cwd: ws.dir,
+        env: {
+          ROKU_IP: '1.2.3.4',
+          ROKU_PASSWORD: 'pw',
+          ROKU_SIGNING_PASSWORD: 'sp',
+        },
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toMatch(/source maps/);
+      expect(stderr).toMatch(/main\.brs\.map/);
+    } finally {
+      ws.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
# Overview

Replaces the manual sideload + dev-portal-sign ritual that maintainers go through every release with one command: `npm run package:signed`. The script wraps `roku-deploy.deployAndSignPackage()` and produces `out/jellyrock-vX.Y.Z.pkg` (version pulled from `manifest`), ready for manual upload to the Roku channel store. Local-only by design — for a solo-maintainer release ritual the time CI signing would save is washed out by the friction of a CI-produced artifact, and the .env-based credential pattern matches what `scripts/run-roku-tests.js` already uses for `ROKU_IP` / `ROKU_PASSWORD`. Three guardrails make the default invocation safe: composes `build:prod` first, refuses to sign if non-vendored source maps are present in `build/`, and (when `ROKU_DEV_ID` is set) verifies the device's `keyed-developer-id` against the env value before signing.

## Changes

- **New script** [`scripts/create-signed-package.cjs`](scripts/create-signed-package.cjs) — fail-fast env validation, manifest-driven version-tagged output filename, source-map prod-build guard (excludes `roku_modules/` since vendored ropm packages always ship `.brs.map`), and dev-ID verification via `rokuDeploy.getDevId()`. The script does the dev-ID check itself rather than passing `options.devId` to roku-deploy — `roku-deploy` only consults that option inside `rekeyDevice()`, which we don't call.
- **New npm script** `package:signed` in [package.json](package.json) — composes `npm run build:prod && node scripts/create-signed-package.cjs` so the default invocation always signs a fresh prod build.
- **New unit tests** [`tests/scripts/unit/create-signed-package.test.js`](tests/scripts/unit/create-signed-package.test.js) — 8 Vitest cases covering env validation, missing build/, the source-map guard, the `roku_modules/` exclusion regression, and the manifest version-parsing requirement.
- **New** [`.env.example`](.env.example) — labels which vars all contributors need (`ROKU_IP` / `ROKU_PASSWORD`) vs. maintainer-only (`ROKU_SIGNING_PASSWORD`, `ROKU_DEV_ID`); `ROKU_DEV_ID` comment explicitly disambiguates from the vendor ID and channel-store URL ID.
- **Docs** — new "Roku signing pipeline" section in [`docs/architecture/build-and-tooling.md`](docs/architecture/build-and-tooling.md) (with `related-files` updated for the two `create-*.cjs` scripts), and a "Signed `.pkg` for Roku channel store" section in [`docs/admin/releases.md`](docs/admin/releases.md) covering setup, runbook, the `pass`-wrapping pattern for encryption-at-rest, and a "Finding `ROKU_DEV_ID`" subsection that disambiguates Roku's three different "developer ID" concepts and recommends the install-from-file confidence test.
- **Dictionary** — spell-check entries for the terminology introduced (`decrypting`, `dev-id`/`Dev-ID`/`dev-ID`, `dev-mode`, `dev-portal`, `filesystem`, `footgun`, `portal-UI`, `rekey`, `runbook`, `SHA-1`).

## Follow-ups

None

## Issues

None

## Docs / context updates

- [x] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/decisions.md`** entry added if a non-obvious design choice was made
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [ ] None — this PR doesn't change any of the above