### PR TITLE
fix(playback): deprioritize commentary audio tracks; restore OSD switching

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -356,7 +356,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audioSt
     return
   end if
 
-  addAudioStreamsToVideo(video)
+  addAudioStreamsToVideo(video, meta, mediaSourceId)
 
   audioIndexList = []
   for each audioTrackEntry in video.fullAudioData
@@ -538,18 +538,48 @@ sub setupVideoContentWithAuth(video, mediaSourceId, audioStreamIdx)
   end if
 end sub
 
-' addAudioStreamsToVideo: Add audio stream data to video
+' addAudioStreamsToVideo: Populate video.fullAudioData with the item's audio tracks.
 '
-' @param {dynamic} video component to add fullAudioData to
-sub addAudioStreamsToVideo(video)
-  audioStreams = []
-  mediaStreams = m.playbackInfo.MediaSources[0].MediaStreams
+' Sources from the original item metadata (meta.mediaSourcesData) — NOT from the
+' PlaybackInfo response. The /PlaybackInfo response can return a transcode-shaped
+' MediaSource carrying only the chosen audio stream, which would shrink the OSD picker
+' to a single entry (issue #500). The OSD picker must always list every original track
+' so the user can switch.
+'
+' @param {object} video - video AA receiving the fullAudioData field
+' @param {dynamic} meta - item metadata (from ItemMetaData) holding mediaSourcesData
+' @param {dynamic} mediaSourceId - chosen MediaSource ID (matches one entry under meta.mediaSourcesData.mediaSources)
+sub addAudioStreamsToVideo(video as object, meta as dynamic, mediaSourceId as dynamic)
+  mediaStreams = invalid
 
-  for i = 0 to mediaStreams.Count() - 1
-    if LCase(mediaStreams[i].Type) = "audio"
-      audioStreams.push(mediaStreams[i])
+  if isValid(meta) and isValid(meta.mediaSourcesData) and isValid(meta.mediaSourcesData.mediaSources)
+    sources = meta.mediaSourcesData.mediaSources
+    if isValidAndNotEmpty(mediaSourceId)
+      for each source in sources
+        if isValid(source) and source.Id = mediaSourceId and isValid(source.MediaStreams)
+          mediaStreams = source.MediaStreams
+          exit for
+        end if
+      end for
     end if
-  end for
+    if not isValid(mediaStreams) and isValid(sources[0]) and isValid(sources[0].MediaStreams)
+      mediaStreams = sources[0].MediaStreams
+    end if
+  end if
+
+  ' Defensive fallback if metadata is unavailable (shouldn't happen — ItemMetaData ran above)
+  if not isValid(mediaStreams) and isValid(m.playbackInfo) and isValid(m.playbackInfo.MediaSources) and isValid(m.playbackInfo.MediaSources[0])
+    mediaStreams = m.playbackInfo.MediaSources[0].MediaStreams
+  end if
+
+  audioStreams = []
+  if isValid(mediaStreams)
+    for i = 0 to mediaStreams.Count() - 1
+      if LCase(mediaStreams[i].Type) = "audio"
+        audioStreams.push(mediaStreams[i])
+      end if
+    end for
+  end if
 
   video.fullAudioData = audioStreams
 end sub

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -605,12 +605,17 @@ end sub
 ' Event handler for when audioIndex changes.
 ' For direct play: switches audio track directly using Roku's availableAudioTracks
 ' (no stop/reload needed since all tracks are in the container).
-' For transcoded: must reload since the server needs to re-encode with the selected track.
+' For transcoded — or when the newly-selected stream exceeds the device's audio
+' capability (e.g. switching from stereo back to an 8ch track on a stereo Roku) —
+' must reload so the server transcodes the new selection.
 sub onAudioIndexChange()
   m.log.info("Audio index changed by user", "newIndex", m.top.audioIndex, "isTranscoded", m.top.isTranscoded, "position", m.top.position, "currentAudioTrack", m.top.audioTrack)
 
-  ' Direct play: all audio tracks are in the container — just switch the Roku track
-  if not m.top.isTranscoded and isValid(m.top.availableAudioTracks)
+  ' Direct play: all audio tracks are in the container — just switch the Roku track,
+  ' but only if the newly-selected stream is actually decodable by the device.
+  ' Roku's native audioTrack switch can't make an undecodable track playable, so
+  ' picking e.g. an 8ch track on a stereo device must go through the reload path.
+  if not m.top.isTranscoded and isValid(m.top.availableAudioTracks) and isSelectedAudioStreamDirectPlayable(m.top.audioIndex, m.top.fullAudioData)
     newTrack = getRokuAudioTrackPosition(m.top.audioIndex, m.top.fullAudioData, m.top.availableAudioTracks)
     m.log.info("Direct play audio switch", "jellyfinIndex", m.top.audioIndex, "rokuTrack", newTrack)
     m.top.audioTrack = newTrack
@@ -618,7 +623,7 @@ sub onAudioIndexChange()
     return
   end if
 
-  ' Transcoded or availableAudioTracks not available: must reload
+  ' Transcoded, availableAudioTracks not available, or stream not direct-playable: must reload
   m.log.info("Audio change requires reload", "isTranscoded", m.top.isTranscoded)
 
   ' Save the current video position

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -797,16 +797,18 @@ end function
 ' and also counts all track types, so Roku Track = Jellyfin Index + 1.
 '
 ' When availableAudioTracks is provided (populated by Roku during active playback),
-' matches by language for robustness against non-standard MKV track numbering.
-' Falls back to Index + 1 mapping when availableAudioTracks is not available
-' (e.g., before playback starts or for non-MKV containers).
+' matches by language with ordinal disambiguation: among same-language Jellyfin streams
+' (in original order), find the position N of the chosen index, then return the Nth
+' same-language Roku track. This avoids returning the wrong track when multiple streams
+' share a language (e.g. main + commentary, both English — issue #500).
+' Falls back to Index + 1 mapping when availableAudioTracks is not available or no
+' ordinal match can be found (e.g., before playback starts or for non-MKV containers).
 '
 ' @param {integer} jellyfinAudioIndex - The Jellyfin audio stream index
 ' @param {dynamic} audioStreamsArray - Jellyfin fullAudioData array (must have .index and .language fields)
 ' @param {dynamic} [availableAudioTracks=invalid] - Roku's availableAudioTracks array (has .track and .language)
 ' @returns {string} - Roku track identifier string for audioTrack field
 function getRokuAudioTrackPosition(jellyfinAudioIndex as integer, audioStreamsArray as dynamic, availableAudioTracks = invalid as dynamic) as string
-  ' When Roku's availableAudioTracks is populated, match by language for accuracy
   if isValid(availableAudioTracks) and isValid(audioStreamsArray)
     ' Find the language of the selected Jellyfin stream
     selectedLanguage = ""
@@ -820,13 +822,29 @@ function getRokuAudioTrackPosition(jellyfinAudioIndex as integer, audioStreamsAr
     end for
 
     if selectedLanguage <> ""
-      for each rokuTrack in availableAudioTracks
-        if isValid(rokuTrack.track) and isValid(rokuTrack.language)
-          if LCase(rokuTrack.language) = selectedLanguage
-            return rokuTrack.track
+      ' Position of the chosen stream among same-language Jellyfin streams
+      jfPosition = -1
+      jfSeen = 0
+      for each stream in audioStreamsArray
+        if isValid(stream.language) and LCase(stream.language) = selectedLanguage
+          if isValid(stream.index) and stream.index = jellyfinAudioIndex
+            jfPosition = jfSeen
+            exit for
           end if
+          jfSeen += 1
         end if
       end for
+
+      ' Take the Nth same-language Roku track
+      if jfPosition >= 0
+        rokuSeen = 0
+        for each rokuTrack in availableAudioTracks
+          if isValid(rokuTrack.track) and isValid(rokuTrack.language) and LCase(rokuTrack.language) = selectedLanguage
+            if rokuSeen = jfPosition then return rokuTrack.track
+            rokuSeen += 1
+          end if
+        end for
+      end if
     end if
   end if
 

--- a/source/utils/streamSelection.bs
+++ b/source/utils/streamSelection.bs
@@ -183,6 +183,43 @@ function mapRokuLocaleToJellyfinLanguage(rokuLocale as dynamic) as string
   return ""
 end function
 
+' isSelectedAudioStreamDirectPlayable: Whether the audio stream at jellyfinAudioIndex
+' inside audioStreams is decodable by the current device.
+'
+' Used by mid-playback audio switching to decide whether Roku's native track-switch is
+' viable, or whether a server reload is required (e.g. switching back to an 8ch track
+' on a stereo device — Roku can't decode it natively, so a transcode reload is needed).
+'
+' @param {integer} jellyfinAudioIndex - Jellyfin index of the chosen audio stream
+' @param {dynamic} audioStreams - Array of audio MediaStream objects (e.g. fullAudioData)
+' @returns {boolean} - true if the chosen stream can be direct-played on this device
+function isSelectedAudioStreamDirectPlayable(jellyfinAudioIndex as integer, audioStreams as dynamic) as boolean
+  if not isValid(audioStreams) then return false
+  selected = invalid
+  for each stream in audioStreams
+    if isValid(stream.index) and stream.index = jellyfinAudioIndex
+      selected = stream
+      exit for
+    end if
+  end for
+  if not isValid(selected) then return false
+  return isStreamDirectPlayable(selected, getDeviceAudioCapabilities())
+end function
+
+' isCommentaryAudioStream: Determine whether a stream is a commentary/secondary track.
+'
+' Detection: case-insensitive substring match for "commentary" in the stream Title.
+' Used by findBestAudioStreamIndex() to deprioritize commentary tracks during auto-selection
+' so a director's-commentary stereo track doesn't outrank the main multichannel track on a
+' stereo device (issue #500).
+'
+' @param {object} stream - MediaStream object from Jellyfin metadata
+' @returns {boolean} - true if the stream looks like a commentary track
+function isCommentaryAudioStream(stream as object) as boolean
+  if not isValid(stream) or not isValid(stream.Title) then return false
+  return inStr(1, LCase(stream.Title), "commentary") > 0
+end function
+
 ' findBestAudioStreamIndex: Primary function for selecting the best audio stream
 '
 ' Selection priority when playDefault = true (Jellyfin: "Play default audio track regardless of language"):
@@ -246,6 +283,23 @@ function findBestAudioStreamIndex(streams as dynamic, playDefault as dynamic, pr
       return audioStreams[0].index
     end if
     return 0
+  end if
+
+  ' Deprioritize commentary tracks (issue #500): when at least one non-commentary track
+  ' exists, hide commentary entries from all subsequent selection logic so a stereo
+  ' commentary track can't outrank the multichannel main track on a stereo device.
+  ' Files with only commentary tracks fall through with the original list.
+  mainStreams = []
+  for i = 0 to audioStreams.Count() - 1
+    if not isCommentaryAudioStream(audioStreams[i])
+      mainStreams.push(audioStreams[i])
+    end if
+  end for
+  if mainStreams.Count() > 0
+    audioStreams = mainStreams
+    if audioStreams.Count() = 1 and isValid(audioStreams[0].index)
+      return audioStreams[0].index
+    end if
   end if
 
   ' Multiple audio tracks - apply selection logic

--- a/tests/source/unit/utils/miscAudioStreams.spec.bs
+++ b/tests/source/unit/utils/miscAudioStreams.spec.bs
@@ -259,6 +259,66 @@ namespace tests
       m.assertEqual(getRokuAudioTrackPosition(2, audioStreams, rokuTracks), "3")
     end function
 
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("getRokuAudioTrackPosition() - same-language ordinal disambiguation (issue #500)")
+    ' When multiple streams share a language (e.g. main + commentary), match the Nth
+    ' same-language Jellyfin stream to the Nth same-language Roku track in original order.
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("picks the second English Roku track when the second English Jellyfin stream is selected")
+    function _()
+      ' Main English 8ch + commentary English 2ch — both eng.
+      audioStreams = [
+        { index: 1, language: "eng" },
+        { index: 2, language: "eng" }
+      ]
+      rokuTracks = [
+        { track: "2", language: "eng", name: "English Main" },
+        { track: "3", language: "eng", name: "English Commentary" }
+      ]
+      ' First English Jellyfin → first English Roku track
+      m.assertEqual(getRokuAudioTrackPosition(1, audioStreams, rokuTracks), "2")
+      ' Second English Jellyfin → second English Roku track (was returning "2" before fix)
+      m.assertEqual(getRokuAudioTrackPosition(2, audioStreams, rokuTracks), "3")
+    end function
+
+    @it("ordinal match still works with mixed languages interleaved")
+    function _()
+      ' eng-main, jpn, eng-commentary, spa — three different languages mixed.
+      audioStreams = [
+        { index: 1, language: "eng" },
+        { index: 2, language: "jpn" },
+        { index: 3, language: "eng" },
+        { index: 4, language: "spa" }
+      ]
+      rokuTracks = [
+        { track: "2", language: "eng", name: "English Main" },
+        { track: "3", language: "jpn", name: "Japanese" },
+        { track: "4", language: "eng", name: "English Commentary" },
+        { track: "5", language: "spa", name: "Spanish" }
+      ]
+      m.assertEqual(getRokuAudioTrackPosition(1, audioStreams, rokuTracks), "2")
+      m.assertEqual(getRokuAudioTrackPosition(3, audioStreams, rokuTracks), "4")
+      m.assertEqual(getRokuAudioTrackPosition(2, audioStreams, rokuTracks), "3")
+      m.assertEqual(getRokuAudioTrackPosition(4, audioStreams, rokuTracks), "5")
+    end function
+
+    @it("falls back to Index + 1 when fewer same-language Roku tracks than Jellyfin streams")
+    function _()
+      ' Two Jellyfin English streams, but Roku only sees one (e.g., transcode hid the other).
+      audioStreams = [
+        { index: 1, language: "eng" },
+        { index: 2, language: "eng" }
+      ]
+      rokuTracks = [
+        { track: "2", language: "eng", name: "English" }
+      ]
+      ' First eng → Roku track "2" by ordinal match
+      m.assertEqual(getRokuAudioTrackPosition(1, audioStreams, rokuTracks), "2")
+      ' Second eng has no Roku counterpart → fallback Index + 1 = "3"
+      m.assertEqual(getRokuAudioTrackPosition(2, audioStreams, rokuTracks), "3")
+    end function
+
   end class
 
 end namespace

--- a/tests/source/unit/utils/streamSelection.spec.bs
+++ b/tests/source/unit/utils/streamSelection.spec.bs
@@ -425,6 +425,99 @@ namespace tests
       m.assertEqual(result, 2)
     end function
 
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Commentary track deprioritization (issue #500)")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("issue reproducer: stereo device, English 8ch main + English stereo commentary, playDefault=false picks main")
+    function _()
+      streams = [
+        { Type: "audio", index: 1, Title: "English - AAC - 7.1 - Default", Language: "eng", channels: 8, codec: "aac", IsDefault: true },
+        { Type: "audio", index: 2, Title: "Commentary - English - AAC - Stereo", Language: "eng", channels: 2, codec: "aac", IsDefault: false }
+      ]
+      ' Without deprioritization the 2ch commentary would win on a stereo device.
+      result = findBestAudioStreamIndex(streams, false, "eng", m.createMockCapabilities(2, false))
+      m.assertEqual(result, 1)
+    end function
+
+    @it("ignores a commentary track even when it is marked IsDefault (playDefault=true)")
+    function _()
+      streams = [
+        { Type: "audio", index: 1, Title: "English - AAC - 5.1", Language: "eng", channels: 6, codec: "ac3", IsDefault: false },
+        { Type: "audio", index: 2, Title: "Director's Commentary - Stereo", Language: "eng", channels: 2, codec: "aac", IsDefault: true }
+      ]
+      ' Even with IsDefault on the commentary track, the main track should win.
+      result = findBestAudioStreamIndex(streams, true, "eng", m.createMockCapabilities(6, false))
+      m.assertEqual(result, 1)
+    end function
+
+    @it("falls back to commentary when no non-commentary tracks exist")
+    function _()
+      streams = [
+        { Type: "audio", index: 1, Title: "Director's Commentary - English", Language: "eng", channels: 2, codec: "aac", IsDefault: true },
+        { Type: "audio", index: 2, Title: "Cast Commentary - English", Language: "eng", channels: 2, codec: "aac", IsDefault: false }
+      ]
+      ' Commentary-only file: don't return 0; pick one of the commentary tracks.
+      result = findBestAudioStreamIndex(streams, false, "eng", m.createMockCapabilities(2, false))
+      m.assertTrue(result = 1 or result = 2)
+    end function
+
+    @it("recognizes commentary regardless of title casing or position")
+    function _()
+      streams = [
+        { Type: "audio", index: 1, Title: "DIRECTOR'S commentary track", Language: "eng", channels: 2, codec: "aac", IsDefault: false },
+        { Type: "audio", index: 2, Title: "English - AAC - Stereo", Language: "eng", channels: 2, codec: "aac", IsDefault: true }
+      ]
+      ' Commentary detection is case-insensitive substring match.
+      result = findBestAudioStreamIndex(streams, false, "eng", m.createMockCapabilities(2, false))
+      m.assertEqual(result, 2)
+    end function
+
+    @it("does not crash or misclassify streams with no Title field")
+    function _()
+      streams = [
+        { Type: "audio", index: 1, Language: "eng", channels: 2, codec: "aac", IsDefault: true },
+        { Type: "audio", index: 2, Language: "eng", channels: 6, codec: "ac3", IsDefault: false }
+      ]
+      ' Streams without Title field should not be treated as commentary.
+      result = findBestAudioStreamIndex(streams, false, "eng", m.createMockCapabilities(6, false))
+      m.assertEqual(result, 2)
+    end function
+
+    @it("isCommentaryAudioStream: true when Title contains 'commentary' (any case)")
+    function _()
+      m.assertTrue(isCommentaryAudioStream({ Title: "Commentary - English" }))
+      m.assertTrue(isCommentaryAudioStream({ Title: "DIRECTOR'S COMMENTARY" }))
+      m.assertTrue(isCommentaryAudioStream({ Title: "english audio with commentary mixed in" }))
+    end function
+
+    @it("isCommentaryAudioStream: false for non-commentary or missing titles")
+    function _()
+      m.assertFalse(isCommentaryAudioStream({ Title: "English - AAC - 5.1" }))
+      m.assertFalse(isCommentaryAudioStream({ Title: "" }))
+      m.assertFalse(isCommentaryAudioStream({}))
+      m.assertFalse(isCommentaryAudioStream(invalid))
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("isSelectedAudioStreamDirectPlayable() — production path uses real hardware caps")
+    ' Returns false when the chosen index is missing from the array; full coverage
+    ' of channel/codec gating lives in the isStreamDirectPlayable() tests.
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("returns false when audioStreams is invalid")
+    function _()
+      m.assertFalse(isSelectedAudioStreamDirectPlayable(1, invalid))
+    end function
+
+    @it("returns false when no stream matches the chosen index")
+    function _()
+      audioStreams = [
+        { index: 1, channels: 2, codec: "aac", language: "eng" }
+      ]
+      m.assertFalse(isSelectedAudioStreamDirectPlayable(99, audioStreams))
+    end function
+
   end class
 
 end namespace


### PR DESCRIPTION
# Overview
On a stereo Roku, a video with an 8ch English main track + a 2ch English commentary track would auto-select the commentary track, and the OSD audio menu listed only one entry with switching that didn't work. This PR fixes the auto-selection, restores the full track list in the OSD picker, makes mid-playback switching work for same-language tracks, and routes undecodable picks (e.g. switching back to 8ch on a stereo device) through the server-transcode reload path.

## Changes
- Add `isCommentaryAudioStream(stream)` and partition commentary tracks out of `findBestAudioStreamIndex`'s candidate list before all selection logic; commentary tracks are only chosen when no other track exists. Applies to both the `playDefault=true` and `playDefault=false` branches.
- Source `addAudioStreamsToVideo` from the original item's `mediaSourcesData.mediaSources[<id>].MediaStreams` instead of the PlaybackInfo response, so the OSD picker always lists every original audio track even when the response is transcode-shaped.
- Replace the language-only loop in `getRokuAudioTrackPosition` with an ordinal same-language match (Nth same-language Jellyfin → Nth same-language Roku track), with the `Index + 1` MKV fallback preserved.
- Add `isSelectedAudioStreamDirectPlayable` and gate the direct-play branch in `onAudioIndexChange` on it; switching to an undecodable stream now flows through the reload path so the server transcodes appropriately.
- New unit coverage in `streamSelection.spec.bs` (commentary deprioritization + helper) and `miscAudioStreams.spec.bs` (same-language ordinal disambiguation).

## Follow-ups
None

## Issues
Fixes #500
Fixes #545

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **\`docs/dev/\` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir \`CLAUDE.md\`** updated if a per-area rule / convention changed
- [ ] **\`docs/decisions.md\`** entry added if a non-obvious design choice was made
- [ ] **\`docs/architecture/tech-debt.md\`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

\`docs/architecture/playback.md\` lists \`components/ItemGrid/LoadVideoContentTask.bs\` and \`components/video/VideoPlayerView.bs\` in its related-files. Re-read; the changes are internal (different in-memory source for \`fullAudioData\`; an extra capability check before \`onAudioIndexChange\`'s direct-play branch). The subsystem's shape and why are unchanged, so the doc was not edited and \`last-reviewed\` was not bumped.