### PR TITLE
vscode: associate dotfiles to stop markdownlint false positives

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,11 @@
     ".claude/agents/*.md": "instructions",
     "CLAUDE.md": "instructions",
     ".github/copilot-instructions.md": "instructions",
+    // Stop the markdownlint extension from flagging dotfiles whose first line
+    // starts with '#'. None of these are markdown.
+    ".prettierignore": "ignore",
+    ".env": "properties",
+    ".env.example": "properties",
   },
   "[xml]": {
     "editor.defaultFormatter": "redhat.vscode-xml",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "lint:ci-workflow-sync": "node scripts/lint/validate-deps-workflow-sync.cjs",
     "lint:issue-templates": "node scripts/lint/issue-templates-check.cjs",
     "lint:js": "eslint .",
-    "lint:json": "jshint --extra-ext .json --verbose --exclude node_modules,scripts,tasks,build,out,locale,tests/scripts,eslint.config.js,vitest.config.js ./",
+    "lint:json": "jshint --extra-ext .json --verbose --exclude node_modules,scripts,tasks,build,out,locale,tests/scripts,.vscode,eslint.config.js,vitest.config.js ./",
     "lint:language-coverage": "node scripts/lint/language-coverage.cjs",
     "lint:markdown": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"!**/CLAUDE.md\" \"!**/AGENTS.md\" \"!out/\" \"!build/\" \"!**/copilot-instructions.md\" \"!.claude/**/*.md\" \"!tasks/\" \"!.opencode/**/*.md\"",
     "lint:spelling": "spellchecker -d dictionary.txt -p spell indefinite-article repeated-words syntax-mentions syntax-urls frontmatter --files \"**/*.md\" \"**/.*/**/*.md\" \"!node_modules/**/*.md\" \"!docs/user/app-settings.md\" \"!CHANGELOG.md\" \"!**/CLAUDE.md\" \"!**/AGENTS.md\" \"!**/copilot-instructions.md\" \"!.claude/**/*.md\" \"!.opencode/**/*.md\"",

--- a/scripts/lib/lint-excludes.cjs
+++ b/scripts/lib/lint-excludes.cjs
@@ -45,6 +45,12 @@ const JSON_PREFIXES = [
   'build/',
   'out/',
   'locale/',
+  // VSCode's *.json files (settings.json, launch.json, tasks.json,
+  // extensions.json, *.code-workspace) are JSONC by convention — they
+  // permit // comments and trailing commas. jshint flags those as W094
+  // ("Unexpected comma") errors and would block commits. VSCode itself
+  // parses these files correctly; nothing else lints them.
+  '.vscode/',
 ];
 
 function _matches(file, exact, prefixes, suffixes = []) {


### PR DESCRIPTION
## Summary

VSCode's markdownlint extension flags dotfiles whose first line starts with `#` (gitignore/properties comments) as malformed markdown. The fix is `files.associations` entries in `.vscode/settings.json` for the affected dotfiles in this repo: `.prettierignore` → `ignore`, `.env`/`.env.example` → `properties`.

## Latent lint bug fixed along the way

Adding the entries to `.vscode/settings.json` surfaced a long-standing pre-commit hook bug: `jshint --extra-ext .json` runs on `.vscode/settings.json`, which is **JSONC** by VSCode convention (permits `//` comments + trailing commas). jshint flags those as `W094 "Unexpected comma"` errors — the existing file already had 13 such warnings, and any commit that touched it (including this one) would be blocked.

Fix: add `.vscode/` to:
1. `JSON_PREFIXES` in `scripts/lib/lint-excludes.cjs` (used by lint-staged)
2. The `--exclude` list in `package.json`'s `lint:json` script (used by `npm run lint`)

VSCode parses `.vscode/*.json` correctly; nothing else needs to lint these files.

## Part of

Org-wide IDE-hygiene followup to the Renovate consolidation. Mirrors [`jellyrock/docs#1`](https://github.com/jellyrock/docs/pull/1), [`jellyrock/jellyrock.app#4`](https://github.com/jellyrock/jellyrock.app/pull/4), [`jellyrock/shared-ui#2`](https://github.com/jellyrock/shared-ui/pull/2).

## Test plan

- [x] Pre-commit hook now passes when committing `.vscode/settings.json` (verified locally)
- [ ] `npm run lint:json` no longer scans `.vscode/`
- [ ] Reopening the workspace in VSCode: no markdownlint warnings on `.prettierignore`, `.env`, `.env.example`