### PR TITLE
renovate: strip rules now covered by org default

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>jellyrock/.github//renovate/default"],
-  "separateMinorPatch": true,
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "packageRules": [
@@ -34,19 +33,6 @@
       "addLabels": ["roku-runtime"]
     },
     {
-      "description": "JS lint & format tooling",
-      "matchPackageNames": [
-        "eslint",
-        "@eslint/js",
-        "eslint-config-prettier",
-        "eslint-plugin-n",
-        "prettier",
-        "jshint"
-      ],
-      "groupName": "linting",
-      "addLabels": ["javascript"]
-    },
-    {
       "description": "Docs quality tooling",
       "matchPackageNames": ["markdownlint-cli2", "spellchecker-cli"],
       "groupName": "docs lint",
@@ -73,16 +59,6 @@
         "xml2js"
       ],
       "addLabels": ["javascript"]
-    },
-    {
-      "description": "Patch automerge — _validate-dependencies.yml runs full lint + test on every dep PR, so a passing CI is sufficient validation",
-      "matchUpdateTypes": ["patch"],
-      "automerge": true
-    },
-    {
-      "description": "Minor + major — weekly Monday review batch",
-      "matchUpdateTypes": ["minor", "major"],
-      "schedule": ["before 6am on monday"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

**Final PR (7 of 7)** in the org-wide Renovate consolidation. Now that [`jellyrock/.github#1`](https://github.com/jellyrock/.github/pull/1) promoted shared policy into `github>jellyrock/.github//renovate/default`, the per-repo rules here are redundant — removing them keeps the per-repo config minimal (the goal of the consolidation).

## Removed (now in org default)

- `separateMinorPatch: true`
- **JS lint & format tooling** packageRule — the org default uses glob patterns (`eslint-config-*`, `eslint-plugin-*`, `@eslint/*`) that are a strict superset of the enumerated list here. Removing the enum doesn't drop any grouping.
- **Patch automerge** packageRule — org default now automerges patches org-wide on green CI. The original description ("`_validate-dependencies.yml` runs full lint + test on every dep PR") moved to [`renovate/README.md`'s "Patch automerge contract"](https://github.com/jellyrock/.github/blob/main/renovate/README.md#patch-automerge-contract) as the canonical statement.
- **Minor + major weekly Monday batch** schedule.

## Kept (still genuinely jellyrock-only)

- `prConcurrentLimit: 0` / `prHourlyLimit: 0` — this repo's ~50 deps warrants no caps. Other repos use the recommended preset's defaults (10 concurrent / 2/hour).
- **BrighterScript / ropm / Roku-runtime / Roku-deploy** groupings — BS and Roku ecosystem packages don't apply to other repos.
- **Docs lint** (`markdownlint-cli2`, `spellchecker-cli`) — only used here.
- **Git hooks** (`husky`, `lint-staged`) — only used here.
- **Remaining JS dev utilities** (`vitest`, `ajv`, `dotenv`, `fast-glob`, `js-yaml`, `patch-package`, `rimraf`, `sharp`, `undent`, `xml2js`) — labels only, jellyrock-specific dev surface.

Net: -24 lines.

## Part of

Sequential org-wide Renovate consolidation:

1. ✅ `github-runner`: add PR CI
2. ✅ `infra`: add CI + renovate.json + group_vars annotations
3. ✅ `docs`: renovate.json + brighterscript grammar + frontmatter fix + auto-sync workflow
4. ✅ `jellyrock.app`: add renovate.json
5. ✅ `shared-ui`: add renovate.json
6. ✅ `.github`: promote org default + SOP README
7. **`jellyrock`: remove duplicates** ← this PR

## Test plan

- [ ] CI passes
- [ ] After merge: Renovate's next scan picks up the slimmer config — verify patch automerge still fires (now from the org default rule, not the local one), JS lint grouping still applies, Monday schedule still applies to minor+major
- [ ] No regression in BS-stack grouping (BrighterScript, ropm, Roku-runtime, Roku-deploy)