### PR TITLE
Fix server-upgrade tracker issue writes (REST) + digest legend & nudge

### DIFF
--- a/.github/workflows/server-upgrade-tracker.yml
+++ b/.github/workflows/server-upgrade-tracker.yml
@@ -129,12 +129,19 @@ jobs:
         if: steps.detect.outputs.action == 'triage'
         run: |
           set -euo pipefail
-          # Body edits go through REST `gh api` (not `gh issue edit`, which routes
-          # through GraphQL's updateIssue — blocked for the App installation token).
+          # All issue writes go through REST `gh api`, not `gh issue create/edit`.
+          # `gh issue create --label` silently dropped the label under the App
+          # installation token (it resolves + attaches labels via a GraphQL mutation
+          # the token can't call), leaving the digest unlabelled and therefore
+          # invisible to the label-keyed dedup in "Find this version's digest" — the
+          # next run would then create a DUPLICATE. The REST POST attaches labels
+          # atomically at creation and returns the number directly (no URL parsing).
           if [ -z "$NUM" ]; then
             echo "Opening new triage digest"
-            gh issue create --title "$TITLE" \
-              --body-file /tmp/digest-body.md --label server-upgrade:tracker
+            gh api "repos/$GITHUB_REPOSITORY/issues" \
+              -f "title=$TITLE" \
+              -F "body=@/tmp/digest-body.md" \
+              -f "labels[]=server-upgrade:tracker" >/dev/null
           elif [ "$TRIAGED" = "true" ]; then
             echo "Digest #$NUM already triaged (server-upgrade:triaging) — CI hands off, leaving it to /server-upgrade."
           elif [ "$STATE" = "OPEN" ]; then
@@ -156,16 +163,19 @@ jobs:
         run: |
           set -euo pipefail
           CLOSE_MSG="Mechanically clean — nothing JellyRock uses changed in this release, and every post-floor endpoint we call is a known, handled case. Closing automatically as a record (a judgment-free claim)."
-          # Issue writes go through the REST API (`gh api`), not `gh issue close/edit/comment`.
-          # The latter route the comment + state change through GraphQL's `addComment`
-          # mutation, which the GitHub App installation token can't call ("Resource not
-          # accessible by integration"). The REST endpoints ride the same issues:write
-          # scope that `gh issue create` already proves works under this token.
+          # All issue writes go through the REST API (`gh api`), not `gh issue
+          # create/close/edit/comment`. Those route create-with-label + the comment +
+          # the state change through GraphQL mutations the GitHub App installation
+          # token can't call ("Resource not accessible by integration"); the REST
+          # endpoints ride the same issues:write scope. REST POST also attaches the
+          # label atomically (so the digest is dedup-visible) and returns the number.
           if [ -z "$NUM" ]; then
             echo "Opening clean record digest"
-            URL=$(gh issue create --title "$TITLE" \
-              --body-file /tmp/digest-body.md --label server-upgrade:tracker)
-            NEW_NUM=$(echo "$URL" | sed -E 's#.*/issues/([0-9]+).*#\1#')
+            NEW_NUM=$(gh api "repos/$GITHUB_REPOSITORY/issues" \
+              -f "title=$TITLE" \
+              -F "body=@/tmp/digest-body.md" \
+              -f "labels[]=server-upgrade:tracker" \
+              --jq '.number')
             gh api "repos/$GITHUB_REPOSITORY/issues/$NEW_NUM/comments" -f "body=$CLOSE_MSG" >/dev/null
             gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/$NEW_NUM" -f state=closed >/dev/null
           elif [ "$TRIAGED" = "true" ]; then

--- a/.github/workflows/server-upgrade-tracker.yml
+++ b/.github/workflows/server-upgrade-tracker.yml
@@ -129,6 +129,8 @@ jobs:
         if: steps.detect.outputs.action == 'triage'
         run: |
           set -euo pipefail
+          # Body edits go through REST `gh api` (not `gh issue edit`, which routes
+          # through GraphQL's updateIssue — blocked for the App installation token).
           if [ -z "$NUM" ]; then
             echo "Opening new triage digest"
             gh issue create --title "$TITLE" \
@@ -137,7 +139,7 @@ jobs:
             echo "Digest #$NUM already triaged (server-upgrade:triaging) — CI hands off, leaving it to /server-upgrade."
           elif [ "$STATE" = "OPEN" ]; then
             echo "Refreshing untriaged digest #$NUM"
-            gh issue edit "$NUM" --body-file /tmp/digest-body.md
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/$NUM" -F "body=@/tmp/digest-body.md" >/dev/null
           else
             echo "Digest #$NUM is closed and untriaged — respecting the human close (a candidate-bearing digest is closed only by a human)."
           fi
@@ -154,18 +156,25 @@ jobs:
         run: |
           set -euo pipefail
           CLOSE_MSG="Mechanically clean — nothing JellyRock uses changed in this release, and every post-floor endpoint we call is a known, handled case. Closing automatically as a record (a judgment-free claim)."
+          # Issue writes go through the REST API (`gh api`), not `gh issue close/edit/comment`.
+          # The latter route the comment + state change through GraphQL's `addComment`
+          # mutation, which the GitHub App installation token can't call ("Resource not
+          # accessible by integration"). The REST endpoints ride the same issues:write
+          # scope that `gh issue create` already proves works under this token.
           if [ -z "$NUM" ]; then
             echo "Opening clean record digest"
             URL=$(gh issue create --title "$TITLE" \
               --body-file /tmp/digest-body.md --label server-upgrade:tracker)
             NEW_NUM=$(echo "$URL" | sed -E 's#.*/issues/([0-9]+).*#\1#')
-            gh issue close "$NEW_NUM" --comment "$CLOSE_MSG"
+            gh api "repos/$GITHUB_REPOSITORY/issues/$NEW_NUM/comments" -f "body=$CLOSE_MSG" >/dev/null
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/$NEW_NUM" -f state=closed >/dev/null
           elif [ "$TRIAGED" = "true" ]; then
             echo "Digest #$NUM already triaged — CI hands off."
           elif [ "$STATE" = "OPEN" ]; then
             echo "Untriaged digest #$NUM went clean — updating + closing as a record"
-            gh issue edit "$NUM" --body-file /tmp/digest-body.md
-            gh issue close "$NUM" --comment "$CLOSE_MSG"
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/$NUM" -F "body=@/tmp/digest-body.md" >/dev/null
+            gh api "repos/$GITHUB_REPOSITORY/issues/$NUM/comments" -f "body=$CLOSE_MSG" >/dev/null
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/$NUM" -f state=closed >/dev/null
           else
             echo "Clean digest #$NUM already closed — nothing to do."
           fi

--- a/scripts/server-upgrade.js
+++ b/scripts/server-upgrade.js
@@ -603,6 +603,26 @@ function digestCountsLine(counts) {
   );
 }
 
+// Glyph legend for the counts line. Collapsible so the digest stays compact while
+// every category in digestCountsLine is self-documenting (the glyphs are otherwise
+// opaque to a maintainer seeing their first digest).
+function digestLegend() {
+  return [
+    '<details><summary>What the counts mean</summary>',
+    '',
+    '| Glyph | Category | Meaning |',
+    '| --- | --- | --- |',
+    '| 🔴 | breaking | A spec change to an endpoint / field / enum JellyRock uses that could break a call (endpoint or param removed, field retyped, request/response shape changed). |',
+    '| 🟢 | opportunity | A newly-added endpoint or field JellyRock could adopt — additive, never breaking. |',
+    '| 🟡 | coverage-gap | An endpoint we call that is absent from the supported **floor** spec — may 404 on the oldest supported server unless guarded. |',
+    '| 🔵 | symmetry | A floor-coverage advisory: an endpoint wired tier-≥2-only whose lower-tier sibling / fallback should be confirmed to cover the floor. |',
+    '| 🔎 | to investigate | Candidates needing a human verdict via `/server-upgrade` (excludes floor-known + suppressed — those need no action). |',
+    '| ✅ | floor-known | Post-floor endpoints already recorded as handled in the endpoint-availability ledger (`docs/dev/jellyfin-endpoint-availability.yml`). |',
+    '| 🔇 | suppressed | Findings muted via `.api-watch/suppressions.yml`. |',
+    '</details>',
+  ].join('\n');
+}
+
 // The MECHANICAL digest body the CI tracker opens with (zero judgment). A clean
 // report (0 needsInvestigation) renders the "nothing touches us" record — the
 // open-then-close audit trail. Otherwise renders the candidate checklist.
@@ -625,9 +645,17 @@ export function renderDigestBody({ version, acknowledged, floor, report }) {
     lines.push('');
     lines.push(digestCountsLine(counts));
     lines.push('');
+    lines.push(digestLegend());
+    lines.push('');
     lines.push(
       '_This is a judgment-free claim (0 candidates touch us), so CI closes this issue ' +
         'automatically as a record. No triage needed._',
+    );
+    lines.push('');
+    lines.push(
+      '> 🧰 **Maintainers**: this release auto-closed as clean, but you can still run ' +
+        '**`/server-upgrade`** to double-check the mechanical call against real app usage ' +
+        '(and to acknowledge the new spec). Optional — no action is required.',
     );
   } else {
     lines.push(
@@ -636,13 +664,16 @@ export function renderDigestBody({ version, acknowledged, floor, report }) {
     lines.push('');
     lines.push(digestCountsLine(counts));
     lines.push('');
+    lines.push(digestLegend());
+    lines.push('');
     lines.push('### Candidates to triage');
     for (const c of candidates) lines.push(digestCandidateLine(c));
     lines.push('');
     lines.push(
-      '> Run **`/server-upgrade`** to investigate each against real app usage. It edits this ' +
-        'issue with verdicts (skip / file / monitor), files the ones worth standalone tracking ' +
-        'as **sub-issues**, and inline-notes the rest.',
+      '> 🧰 **Maintainers — action needed**: run **`/server-upgrade`** to investigate each ' +
+        'candidate against real app usage. It edits this issue with verdicts (skip / file / ' +
+        'monitor), files the ones worth standalone tracking as **sub-issues**, and inline-notes ' +
+        'the rest.',
     );
   }
 


### PR DESCRIPTION
# Overview

The `server-upgrade-tracker` workflow authenticates as the JellyRock GitHub App, whose installation token cannot call GraphQL's `addComment` / `updateIssue` mutations (`Resource not accessible by integration`). `gh issue close --comment` and `gh issue edit` route through those mutations, so they fail at runtime — while `gh issue create` (REST) works. A live `workflow_dispatch` smoke-test surfaced this: the clean-record path created the per-version digest, then died trying to close-with-comment, leaving an orphan **open** digest (#599) that should have been an opened-then-closed clean record.

This converts the tracker's issue-mutation calls to the REST API (`gh api`), which rides the same `issues: write` scope the App token already proves works. A second, related symptom surfaced during cleanup: `gh issue create --label` *also* silently dropped the label under the App token (label attach goes through a GraphQL mutation too), so the digest landed unlabelled — and the per-version dedup lists by that label, so a follow-up run wouldn't find it and would create a duplicate. So issue **creation** moves to REST too. It also makes the digest issue more self-explanatory: a collapsible legend for the counts glyphs, and an explicit maintainer call-to-action to run `/server-upgrade`.

## Changes

- **REST issue writes** in `server-upgrade-tracker.yml`: replace `gh issue close --comment` / `gh issue edit` with `gh api` (`PATCH …/issues/N` for state + body, `POST …/issues/N/comments` for the comment) in both the `clean` and `triage` branches. Inline comments document why GraphQL is avoided.
- **REST issue creation with labels**: replace `gh issue create --label …` (which dropped the label under the App token, leaving the digest invisible to the label-keyed dedup) with `gh api POST …/issues` carrying `labels[]` inline — atomic create+label, and it returns `.number` directly (drops the fragile URL-`sed` parsing).
- **Counts legend**: a collapsible `<details>` block mapping every digest glyph (🔴 breaking · 🟢 opportunity · 🟡 coverage-gap · 🔵 symmetry · 🔎 to-investigate · ✅ floor-known · 🔇 suppressed) to its category and meaning, rendered on both the clean and candidate digest bodies.
- **Maintainer nudge**: the candidate body now carries an explicit "Maintainers — action needed: run `/server-upgrade`" call-to-action; the clean/auto-closed body gets a softer optional nudge (honoring its "no triage needed" framing).
- **Tests**: assert the legend and both nudge variants render.

## Follow-ups

None

## Issues

None

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/decisions.md`** entry added if a non-obvious design choice was made
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=93872b72b2aff8712522a6fe6241fbac832fb400 ts=2026-05-31T12:13:00Z -->