### PR TITLE
Fix server-upgrade digest counts + harden CI command injection

### DIFF
--- a/.github/workflows/device-unit-tests.yml
+++ b/.github/workflows/device-unit-tests.yml
@@ -57,9 +57,18 @@ jobs:
 
       - name: Check if push is from PR merge
         id: merge_check
+        # COMMIT_MSG is passed via env, NOT interpolated into the shell. A commit
+        # message is attacker-controllable; `${{ github.event.head_commit.message }}`
+        # expanded directly into a `run:` line lets backticks / $(...) in the message
+        # execute as the line is parsed (GitHub Actions script-injection — a real
+        # backtick-heavy merge commit tripped exactly this). env values are not
+        # shell-parsed, so the quoted "$COMMIT_MSG" is inert. (event_name/ref are
+        # controlled values, safe to interpolate.)
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            if echo "${{ github.event.head_commit.message }}" | grep -q "Merge pull request"; then
+            if printf '%s' "$COMMIT_MSG" | grep -q "Merge pull request"; then
               echo "This is a PR merge to main - tests already ran on PR"
               echo "skip=true" >> $GITHUB_OUTPUT
             else

--- a/.github/workflows/server-upgrade-tracker.yml
+++ b/.github/workflows/server-upgrade-tracker.yml
@@ -129,13 +129,15 @@ jobs:
         if: steps.detect.outputs.action == 'triage'
         run: |
           set -euo pipefail
-          # All issue writes go through REST `gh api`, not `gh issue create/edit`.
-          # `gh issue create --label` silently dropped the label under the App
-          # installation token (it resolves + attaches labels via a GraphQL mutation
-          # the token can't call), leaving the digest unlabelled and therefore
-          # invisible to the label-keyed dedup in "Find this version's digest" — the
-          # next run would then create a DUPLICATE. The REST POST attaches labels
-          # atomically at creation and returns the number directly (no URL parsing).
+          # ROOT CAUSE (resolved): the GitHub App installation lacked the Issues
+          # permission, so the token could create an issue but not comment, attach a
+          # label, or list — every non-create write returned HTTP 403 "Resource not
+          # accessible by integration" (REST *and* GraphQL alike — REST is not a
+          # workaround for the 403; the permission grant is the fix). Granting the App
+          # Issues: read & write fixed it. We use REST `gh api` here regardless because
+          # it creates + labels atomically (so the digest is immediately visible to
+          # the label-keyed dedup in "Find this version's digest", avoiding a
+          # duplicate) and returns the number directly (no URL parsing).
           if [ -z "$NUM" ]; then
             echo "Opening new triage digest"
             gh api "repos/$GITHUB_REPOSITORY/issues" \
@@ -163,12 +165,11 @@ jobs:
         run: |
           set -euo pipefail
           CLOSE_MSG="Mechanically clean — nothing JellyRock uses changed in this release, and every post-floor endpoint we call is a known, handled case. Closing automatically as a record (a judgment-free claim)."
-          # All issue writes go through the REST API (`gh api`), not `gh issue
-          # create/close/edit/comment`. Those route create-with-label + the comment +
-          # the state change through GraphQL mutations the GitHub App installation
-          # token can't call ("Resource not accessible by integration"); the REST
-          # endpoints ride the same issues:write scope. REST POST also attaches the
-          # label atomically (so the digest is dedup-visible) and returns the number.
+          # See the ROOT CAUSE note in the triage step above: the App installation
+          # was missing the Issues permission (HTTP 403 on every non-create write,
+          # REST and GraphQL alike); granting Issues: read & write fixed it. REST
+          # `gh api` is used here because the create call attaches the label
+          # atomically (dedup-visible) and returns the number directly.
           if [ -z "$NUM" ]; then
             echo "Opening clean record digest"
             NEW_NUM=$(gh api "repos/$GITHUB_REPOSITORY/issues" \

--- a/scripts/server-upgrade.js
+++ b/scripts/server-upgrade.js
@@ -592,23 +592,60 @@ function digestHeader(version, acknowledged, floor) {
   ].join('\n');
 }
 
-function digestCountsLine(counts) {
+// The digest counts mix THREE different axes, which a single line conflates into
+// an apparent contradiction ("4 coverage-gap … 5 floor-known" reads like 9 things
+// or a paradox). They are split here into the two questions a maintainer actually
+// asks:
+//
+//   1. What changed in THIS release?  → breaking + opportunity (the acknowledged→
+//      latest diff). Both zero means the release itself touched nothing we use.
+//   2. What standing FLOOR findings exist?  → coverage-gap + symmetry. These are
+//      recomputed from manifest×floor every run and recur forever regardless of
+//      the release; each is independently either `floor-known` (handled, recorded
+//      in the ledger) or still needs investigation.
+//
+// coverage-gap/symmetry is the TYPE of a finding; floor-known is its DISPOSITION —
+// the same finding is counted under both, by design, not double-counting.
+
+// Line for axis 1: what the release delta touched.
+function digestReleaseLine(counts) {
   if (!counts) return '';
-  return (
-    `🔴 **${counts.breaking ?? 0}** breaking · 🟢 **${counts.opportunity ?? 0}** opportunit(y/ies) · ` +
-    `🟡 **${counts['coverage-gap'] ?? 0}** coverage-gap(s) · 🔵 **${counts['symmetry-advisory'] ?? 0}** symmetry · ` +
-    `🔎 **${counts.needsInvestigation ?? 0}** to investigate` +
-    (counts.floorKnown ? ` · ✅ ${counts.floorKnown} floor-known (handled)` : '') +
-    (counts.suppressed ? ` · 🔇 ${counts.suppressed} suppressed` : '')
-  );
+  return `🔴 **${counts.breaking ?? 0}** breaking · 🟢 **${counts.opportunity ?? 0}** new endpoint(s)`;
 }
 
-// Glyph legend for the counts line. Collapsible so the digest stays compact while
-// every category in digestCountsLine is self-documenting (the glyphs are otherwise
-// opaque to a maintainer seeing their first digest).
+// Lines for axis 2: standing floor findings + their disposition. Returns an array
+// (may be empty when there are no floor findings at all).
+function digestFloorLines(counts) {
+  if (!counts) return [];
+  const gap = counts['coverage-gap'] ?? 0;
+  const sym = counts['symmetry-advisory'] ?? 0;
+  const floorTotal = gap + sym;
+  if (floorTotal === 0) return [];
+  const handled = counts.floorKnown ?? 0;
+  const investigate = counts.needsInvestigation ?? 0;
+  const lines = [];
+  lines.push(
+    `**Standing floor findings**: ${floorTotal} total` +
+      (handled === floorTotal ? ', all handled ✅' : '') +
+      (counts.suppressed ? ` · 🔇 ${counts.suppressed} suppressed` : ''),
+  );
+  lines.push(
+    `  └ 🟡 ${gap} coverage-gap + 🔵 ${sym} symmetry — ` +
+      `✅ ${handled} recorded in the endpoint-availability ledger, ` +
+      `🔎 ${investigate} need investigation. These are floor facts (recur every ` +
+      'run), not changes in this release.',
+  );
+  return lines;
+}
+
+// Glyph legend for the counts. Collapsible so the digest stays compact while every
+// category is self-documenting (the glyphs are otherwise opaque to a maintainer
+// seeing their first digest).
 function digestLegend() {
   return [
     '<details><summary>What the counts mean</summary>',
+    '',
+    "_Two axes: **what changed in this release** (breaking / opportunity) vs. **standing floor findings** (coverage-gap / symmetry, recomputed every run). A floor finding's TYPE is coverage-gap or symmetry; its DISPOSITION is floor-known or needs-investigation — the same finding appears under both, by design._",
     '',
     '| Glyph | Category | Meaning |',
     '| --- | --- | --- |',
@@ -616,8 +653,8 @@ function digestLegend() {
     '| 🟢 | opportunity | A newly-added endpoint or field JellyRock could adopt — additive, never breaking. |',
     '| 🟡 | coverage-gap | An endpoint we call that is absent from the supported **floor** spec — may 404 on the oldest supported server unless guarded. |',
     '| 🔵 | symmetry | A floor-coverage advisory: an endpoint wired tier-≥2-only whose lower-tier sibling / fallback should be confirmed to cover the floor. |',
-    '| 🔎 | to investigate | Candidates needing a human verdict via `/server-upgrade` (excludes floor-known + suppressed — those need no action). |',
-    '| ✅ | floor-known | Post-floor endpoints already recorded as handled in the endpoint-availability ledger (`docs/dev/jellyfin-endpoint-availability.yml`). |',
+    '| 🔎 | to investigate | Findings still needing a human verdict via `/server-upgrade` (excludes floor-known + suppressed — those need no action). |',
+    '| ✅ | floor-known | Floor findings already recorded as handled in the endpoint-availability ledger (`docs/dev/jellyfin-endpoint-availability.yml`). |',
     '| 🔇 | suppressed | Findings muted via `.api-watch/suppressions.yml`. |',
     '</details>',
   ].join('\n');
@@ -640,15 +677,22 @@ export function renderDigestBody({ version, acknowledged, floor, report }) {
   } else if (candidates.length === 0) {
     lines.push(
       `✅ **Mechanically clean** — nothing JellyRock uses changed in \`${acknowledged} → ${version}\`, ` +
-        'and every post-floor endpoint we call is a known, handled case.',
+        'and every standing floor finding is a known, handled case.',
     );
     lines.push('');
-    lines.push(digestCountsLine(counts));
+    lines.push(
+      `**This release's changes** (\`${acknowledged} → ${version}\`): ${digestReleaseLine(counts)}`,
+    );
+    const floorLines = digestFloorLines(counts);
+    if (floorLines.length) {
+      lines.push('');
+      lines.push(...floorLines);
+    }
     lines.push('');
     lines.push(digestLegend());
     lines.push('');
     lines.push(
-      '_This is a judgment-free claim (0 candidates touch us), so CI closes this issue ' +
+      '_This is a judgment-free claim (0 findings need investigation), so CI closes this issue ' +
         'automatically as a record. No triage needed._',
     );
     lines.push('');
@@ -662,7 +706,14 @@ export function renderDigestBody({ version, acknowledged, floor, report }) {
       '**Mechanical candidates** — a first pass over what intersects code we ship. NOT verdicts:',
     );
     lines.push('');
-    lines.push(digestCountsLine(counts));
+    lines.push(
+      `**This release's changes** (\`${acknowledged} → ${version}\`): ${digestReleaseLine(counts)}`,
+    );
+    const floorLines = digestFloorLines(counts);
+    if (floorLines.length) {
+      lines.push('');
+      lines.push(...floorLines);
+    }
     lines.push('');
     lines.push(digestLegend());
     lines.push('');

--- a/tests/scripts/unit/server-upgrade.test.js
+++ b/tests/scripts/unit/server-upgrade.test.js
@@ -632,8 +632,8 @@ describe('digest identity + render', () => {
     const report = {
       counts: {
         breaking: 1,
-        'coverage-gap': 0,
-        'symmetry-advisory': 0,
+        'coverage-gap': 4,
+        'symmetry-advisory': 1,
         needsInvestigation: 1,
         floorKnown: 5,
       },
@@ -659,12 +659,57 @@ describe('digest identity + render', () => {
     });
     expect(body).toContain('### Candidates to triage');
     expect(body).toContain('- [ ] **endpoint removed: GET /Items/{itemId}**');
-    expect(body).toContain('✅ 5 floor-known');
     expect(body).toContain(TRIAGING_LABEL);
+    // Two-axis split: release-delta line + standing-floor block (subset framing).
+    expect(body).toContain("**This release's changes**");
+    expect(body).toContain('🔴 **1** breaking');
+    expect(body).toContain('**Standing floor findings**: 5 total');
+    expect(body).toContain('🟡 4 coverage-gap + 🔵 1 symmetry');
+    expect(body).toContain('🔎 1 need investigation');
+    // Collapsible glyph legend + the maintainer action-needed nudge.
+    expect(body).toContain('<details><summary>What the counts mean</summary>');
+    expect(body).toContain('Maintainers — action needed');
+    expect(body).toContain('`/server-upgrade`');
   });
 
   it('renderDigestBody renders the mechanically-clean record when 0 candidates', () => {
-    const report = { counts: { needsInvestigation: 0, floorKnown: 5 }, candidates: [] };
+    const report = {
+      counts: {
+        breaking: 0,
+        opportunity: 0,
+        'coverage-gap': 4,
+        'symmetry-advisory': 1,
+        needsInvestigation: 0,
+        floorKnown: 5,
+      },
+      candidates: [],
+    };
+    const body = renderDigestBody({
+      version: '10.11.10',
+      acknowledged: '10.11.8',
+      floor: '10.7.0',
+      report,
+    });
+    expect(body).toContain('Mechanically clean');
+    expect(body).toContain('CI closes this issue');
+    expect(body).not.toContain('### Candidates to triage');
+    // Two-axis split, subset framing: the 4+1 ARE the 5 handled, 0 to investigate.
+    expect(body).toContain("**This release's changes**");
+    expect(body).toContain('🔴 **0** breaking');
+    expect(body).toContain('**Standing floor findings**: 5 total, all handled ✅');
+    expect(body).toContain('🟡 4 coverage-gap + 🔵 1 symmetry');
+    expect(body).toContain('🔎 0 need investigation');
+    // Legend renders on the clean body too; the maintainer nudge is SOFT here.
+    expect(body).toContain('<details><summary>What the counts mean</summary>');
+    expect(body).toContain('auto-closed as clean');
+    expect(body).toContain('Optional — no action is required');
+  });
+
+  it('renderDigestBody omits the floor block when there are no floor findings', () => {
+    const report = {
+      counts: { breaking: 0, opportunity: 0, needsInvestigation: 0, floorKnown: 0 },
+      candidates: [],
+    };
     const body = renderDigestBody({
       version: '10.11.11',
       acknowledged: '10.11.10',
@@ -672,8 +717,7 @@ describe('digest identity + render', () => {
       report,
     });
     expect(body).toContain('Mechanically clean');
-    expect(body).toContain('CI closes this issue');
-    expect(body).not.toContain('### Candidates to triage');
+    expect(body).not.toContain('Standing floor findings');
   });
 
   it('renderDigestVerdicts checks off each disposition with its link/rationale', () => {


### PR DESCRIPTION
# Overview

Three fixes surfaced by the first live `server-upgrade-tracker` run on the 10.11.10 release. The headline one is UX: the auto-opened digest issue's counts line conflated three different axes onto one row, so a mechanically-clean release read as a self-contradiction ("🟡 4 coverage-gap … ✅ 5 floor-known"). The other two are correctness/hygiene: a misleading code comment from the prior fix, and a commit-message command-injection in a sibling workflow that a backtick-heavy merge commit tripped this session.

## Changes

- **Digest counts display** (`scripts/server-upgrade.js`): split the single conflated counts line into two labeled groups — **"This release's changes"** (🔴 breaking / 🟢 opportunity — the acknowledged→latest delta) and **"Standing floor findings"** (🟡 coverage-gap + 🔵 symmetry, recomputed every run) — with explicit subset framing so it's clear the floor findings *are* the handled set (e.g. "5 total, all handled ✅ … 🔎 0 need investigation"). Reworked the collapsible legend to name the two axes and clarify that a finding's TYPE (coverage-gap/symmetry) and DISPOSITION (floor-known/needs-investigation) are orthogonal — the same finding is counted under both by design, not double-counted.
- **Honest root-cause comments** (`.github/workflows/server-upgrade-tracker.yml`): the previous fix's comments claimed "REST rides issues:write where GraphQL is blocked." That was wrong — REST hit the identical HTTP 403. The real cause was the GitHub App installation lacking the Issues permission entirely (every non-create write 403'd, REST and GraphQL alike); granting Issues: read & write fixed it. Corrected both comment blocks. The REST `gh api` calls are kept (they create+label atomically, so the digest is immediately dedup-visible, and return the number directly) — but no longer misrepresented as a 403 workaround.
- **Commit-message injection** (`.github/workflows/device-unit-tests.yml`): the merge-detection step interpolated `${{ github.event.head_commit.message }}` directly into a shell `echo … | grep`. A commit message is attacker-controllable, so backticks / `$(…)` in it execute as the line is parsed — a real backtick-heavy merge commit tripped exactly this. Pass the message via `env:` and `grep "$COMMIT_MSG"` so it's never shell-parsed.
- **Tests** (`tests/scripts/unit/server-upgrade.test.js`): updated the two digest-body assertions for the new two-axis layout and added a case asserting the floor block is omitted when there are no floor findings.

## Follow-ups

None

## Issues

None

## Docs / context updates

<!-- server-upgrade-automation.md lists the two touched files in related-files; the
display/comment changes are presentation + accuracy, not a subsystem shape/why change,
so the doc is left untouched and last-reviewed is not bumped. -->

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/decisions.md`** entry added if a non-obvious design choice was made
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=1a76c4172fe66bebd1cffa11a328a26197ac981e ts=2026-05-31T13:52:59Z -->