### PR TITLE
chore(ci): harden journal-sync workflow against PR-title injection

### DIFF
--- a/.github/workflows/journal-sync.yml
+++ b/.github/workflows/journal-sync.yml
@@ -68,11 +68,15 @@ jobs:
       # Using the event payload directly avoids an extra `gh pr view` call.
       - name: Run journal-sync
         id: sync
+        # All PR-controlled values come in via env, NOT interpolated into the shell.
+        # A `${{ ...title }}` expanded into a `run:` line lets a `'` end the quote
+        # (and backticks / $(...) execute) as the line is parsed — GitHub Actions
+        # script-injection. env values are not shell-parsed, so "$PR_TITLE" is inert.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
-          PR_TITLE='${{ github.event.pull_request.title }}'
-          PR_AUTHOR='${{ github.event.pull_request.user.login }}'
-          PR_LABELS='${{ join(github.event.pull_request.labels.*.name, ',') }}'
-
           echo "PR title: $PR_TITLE"
           echo "PR author: $PR_AUTHOR"
           echo "PR labels: $PR_LABELS"
@@ -95,8 +99,14 @@ jobs:
 
       - name: Commit and push
         if: steps.check_changes.outputs.has_changes == 'true'
+        # PR title via env (same injection reason as the Run journal-sync step) so a
+        # title with a quote/backtick can't break or inject into git commit -m. The
+        # number is a controlled integer, safe to interpolate.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           git pull --rebase --autostash origin main
           git add docs/progress.md
-          git commit -m "chore(journal): sync ${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})"
+          git commit -m "chore(journal): sync ${PR_TITLE} (#${PR_NUMBER})"
           git push origin main

--- a/docs/architecture/tech-debt.md
+++ b/docs/architecture/tech-debt.md
@@ -250,12 +250,6 @@ The `npm run lint:docs` checker validates every `tech-debt.md#<anchor>` referenc
 - **issue**: `tokenize()` and the 50-word `STOPWORDS` set are copy-pasted between the two files. `journal-sync.js` is ESM; `progress-cursor-nudge.cjs` is CJS — CJS cannot `require()` ESM, which forced the copy at write time. A stopword addition or tokenizer fix must be applied in both places.
 - **direction**: Extract to `scripts/lib/tokenize.cjs`. Both callers `require()` it: `progress-cursor-nudge.cjs` via its existing `require()` chain; `journal-sync.js` via `createRequire(import.meta.url)` (same pattern it already uses for `frontmatter.cjs` and `signals-fetch.cjs`). Then remove the inline copies.
 
-#### `journal-sync-workflow-injection`
-
-- **area**: `.github/workflows/journal-sync.yml` (lines 72, 101)
-- **issue**: PR title + number are interpolated into shell strings via `${{ github.event.pull_request.title }}` inside a `run:` block. A title containing `'` breaks the single-quoted shell assignment on line 72; a title containing `"` or backticks breaks the `git commit -m "..."` on line 101. GitHub Actions docs classify this as script injection.
-- **direction**: Move the interpolations into `env:` fields on the step and reference them as `$PR_TITLE` / `$PR_NUMBER` inside the shell. The `env:` block is not shell-parsed, so no quoting escape is needed.
-
 #### `hd-native-layout-refactor`
 
 - **area**: every `.bs` / `.brs` / `.xml` file with hardcoded `1920` or `1080` layout coordinates (~223 sites at last count), plus [`manifest`](../../manifest)


### PR DESCRIPTION
# Overview

The `journal-sync` workflow interpolated PR-controlled values (title, author, labels, number) directly into `run:` shell lines — both the `PR_TITLE='${{ ... }}'` assignment and the `git commit -m "..."`. A PR title is attacker-controllable, so a `'`/`"`/backtick in it ends the quoting and `$(...)`/backticks execute as the line is parsed (GitHub Actions script-injection). This moves every PR-controlled value into `env:` (which is not shell-parsed) and references the quoted shell vars. Resolves the tracked `journal-sync-workflow-injection` tech-debt entry.

## Changes

- `journal-sync.yml`: pass `title` / `author` / `labels` to the "Run journal-sync" step and `title` / `number` to the "Commit and push" step via `env:`, and reference `"$PR_TITLE"` etc. in the scripts. The PR number stays inline (controlled integer).
- Removed the resolved `journal-sync-workflow-injection` entry from `docs/architecture/tech-debt.md` (per that file's "fixing an entry? remove it in the same PR" rule).

## Follow-ups

None

## Issues

None

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/decisions.md`** entry added if a non-obvious design choice was made
- [x] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [ ] None — this PR doesn't change any of the above

<!-- /pr render: sha=eb5c4888b7e38756c8347fef2ff4787535aa115a ts=2026-05-31T21:01:44Z -->
