### PR TITLE
Version-guard the Lyrics request on Jellyfin 10.9+

### DIFF
--- a/docs/architecture/server-upgrade-automation.md
+++ b/docs/architecture/server-upgrade-automation.md
@@ -750,6 +750,12 @@ in Layer 2, not an `ApiClient` version branch.
    tooling-only PR. The ledger clears all 5 with no app/behavior change. A
    followup tracks a proactive PR-time floor lint (catch a *new* floor gap from our
    own commits without waiting for a Jellyfin release).
+   **Update (post-Phase-6):** Lyrics was subsequently given a real
+   `supportsLyrics()` version-guard (`source/api/items.bs`), so its ledger entry is
+   now `version-guard` (CI-validated), not `graceful-degradation` — leaving
+   `QuickConnect` ×2 as the remaining deliberate graceful/fail-open cases (their
+   handling is correct as-is; see the Quick Connect analysis in
+   [`jellyfin-server-versioning.md`](../dev/jellyfin-server-versioning.md)).
 
 ### (2) The per-version release-triage digest model
 

--- a/docs/dev/jellyfin-endpoint-availability.yml
+++ b/docs/dev/jellyfin-endpoint-availability.yml
@@ -67,12 +67,14 @@ endpoints:
     method: GET
     minServer: "10.9.0"
     handling:
-      type: graceful-degradation
+      type: version-guard
+      symbol: supportsLyrics
       note: >-
-        Unguarded; on 10.7/10.8 the request 404s, fetchJson() returns invalid,
-        and the caller (components/home/LoadItemsTask.bs) checks
-        `isValid(lyricsData) and isValid(lyricsData.Lyrics)` before indexing — no
-        lyrics shown, no crash.
+        GetItemLyrics() (source/api/items.bs) early-returns invalid unless
+        supportsLyrics() (source/api/items.bs, versionChecker >=10.9.0) passes, so
+        the request is never built on older servers. Belt-and-suspenders: the
+        caller (components/home/LoadItemsTask.bs) still checks
+        `isValid(lyricsData) and isValid(lyricsData.Lyrics)` before indexing.
 
   - path: /quickconnect/enabled
     method: GET

--- a/source/api/items.bs
+++ b/source/api/items.bs
@@ -476,7 +476,20 @@ end function
 ' @param {string} itemId - The Audio item ID
 ' @returns {dynamic} LyricDto: { Metadata: {...}, Lyrics: [{Start: ticks, Text: string}] }, or invalid
 function GetItemLyrics(itemId as string) as dynamic
+  if not supportsLyrics() then return invalid
   return fetchJson(GetApi().BuildGetItemLyricsRequest(itemId), "lyrics")
+end function
+
+' supportsLyrics: Checks if the connected Jellyfin server supports the Lyrics API.
+'
+' The /Audio/{itemId}/Lyrics endpoint was introduced in Jellyfin 10.9.0.
+' Servers below 10.9.0 do not have this endpoint and will return 404. Guarding
+' the request mirrors supportsMediaSegments() (source/utils/mediaSegments.bs) and
+' lets the endpoint-availability ledger record this as a validated version-guard.
+'
+' @returns {boolean} - true if server supports lyrics
+function supportsLyrics() as boolean
+  return versionChecker(m.global.server.version, "10.9.0")
 end function
 
 function BackdropImage(id as string)

--- a/tests/source/unit/api/items-supportsLyrics.spec.bs
+++ b/tests/source/unit/api/items-supportsLyrics.spec.bs
@@ -1,0 +1,41 @@
+import "pkg:/source/api/items.bs"
+
+namespace tests
+
+  @suite("items.bs - supportsLyrics()")
+  class SupportsLyricsTests extends tests.BaseTestSuite
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("version boundary detection")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("returns false for server below 10.9.0")
+    @params("10.8.13")
+    @params("10.8.0")
+    @params("10.7.0")
+    @params("10.0.0")
+    function _(version)
+      m.global.server.version = version
+      m.assertFalse(supportsLyrics())
+    end function
+
+    @it("returns true for server at or above 10.9.0")
+    @params("10.9.0")
+    @params("10.9.1")
+    @params("10.10.0")
+    @params("10.11.0")
+    @params("11.0.0")
+    function _(version)
+      m.global.server.version = version
+      m.assertTrue(supportsLyrics())
+    end function
+
+    @it("returns false for empty version string")
+    function _()
+      m.global.server.version = ""
+      m.assertFalse(supportsLyrics())
+    end function
+
+  end class
+
+end namespace


### PR DESCRIPTION
# Overview

`GetItemLyrics()` built the `/Audio/{itemId}/Lyrics` request unconditionally. On Jellyfin 10.7/10.8 (the endpoint landed in 10.9) it 404s and the caller's `isValid()` checks degrade gracefully — no crash, no lyrics. That worked, but it was an **unvalidated** disposition in the endpoint-availability ledger: nothing proved the handling still held, so a future refactor could silently reintroduce a real 404 path. This adds an explicit version-guard mirroring the `supportsMediaSegments()` reference pattern, which lets CI enforce the handling.

## Changes

- **`source/api/items.bs`**: add `supportsLyrics()` (`versionChecker(m.global.server.version, "10.9.0")`) and early-return `invalid` from `GetItemLyrics()` before the request is built — structurally identical to the `supportsMediaSegments()` guard at line 428.
- **`docs/dev/jellyfin-endpoint-availability.yml`**: flip the Lyrics entry from `graceful-degradation` to `version-guard` with `symbol: supportsLyrics`, so `lint:endpoint-availability` now CI-validates that the guard exists (a removed guard fails CI and resurfaces the floor finding). The caller's `isValid()` checks stay as belt-and-suspenders.
- **`tests/source/unit/api/items-supportsLyrics.spec.bs`**: new Rooibos spec covering the version boundary (false below 10.9.0, true at/above, false on empty version), mirroring `mediaSegments-supportsMediaSegments.spec.bs`. **Run on Roku hardware via `npm run test:tdd` — 10/10 pass.**
- **`docs/architecture/server-upgrade-automation.md`**: post-Phase-6 note that Lyrics is now version-guarded (no shape/why change; `last-reviewed` unchanged).

No behavior change on supported servers: lyrics still don't render on <10.9, the request is just skipped earlier instead of 404ing. `npm run validate` (BSC) passes; `npm run lint:endpoint-availability` passes (5/5 claims validated).

## Follow-ups

None

## Issues

None

## Docs / context updates

- [x] **Architecture doc** updated → `docs/architecture/server-upgrade-automation.md` (post-Phase-6 note: Lyrics now version-guarded; no shape/why change, `last-reviewed` unchanged)
- [x] **`docs/dev/` how-to** updated → `docs/dev/jellyfin-endpoint-availability.yml` (Lyrics entry → version-guard)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/decisions.md`** entry added if a non-obvious design choice was made
- [ ] **`docs/architecture/tech-debt.md`** entry removed/added
- [ ] None — this PR doesn't change any of the above

## Test status

- **Unit (hardware-verified)**: `supportsLyrics()` version-boundary logic — 10/10 pass on a real Roku via `npm run test:tdd`.
- **Integration (manual, not automated)**: the new test exercises the boolean guard, not the full `GetItemLyrics()` early-return end-to-end (that needs a live server + an audio item with lyrics). Suggested on-device checks:
  1. **10.9+ server (regression)**: play an Audio item with synced lyrics → lyrics still load/display.
  2. **<10.9 server (guarded path)**: connect to a 10.7/10.8 server, play an Audio item → no lyrics, **no crash**, and the `/Audio/{}/Lyrics` request is never sent (no 404 for that path in the console).

<!-- /pr render: sha=821a518c4f9af73066ec394928f89a4af3848e6b ts=2026-06-01T11:30:38Z -->
