### PR TITLE
Fix photo selection opening the viewer behind `ItemDetails`

### DIFF
--- a/components/ItemGrid/BaseGridView.bs
+++ b/components/ItemGrid/BaseGridView.bs
@@ -954,24 +954,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
     m.voiceBox.setFocus(false)
   end if
 
-  ' Handle OK key for photo items - launch PhotoDetails viewer
-  if key = "OK" and m.itemGrid.isinFocusChain()
-    focusedItem = m.itemGrid.content.getChild(m.itemGrid.itemFocused)
-    if isValid(focusedItem) and LCase(focusedItem.type) = "photo"
-      photoPlayer = CreateObject("roSgNode", "PhotoDetails")
-      photoPlayer.itemsNode = m.itemGrid.content
-      photoPlayer.itemIndex = m.itemGrid.itemFocused
-
-      ' Set slideshow/random flags based on current view if using PhotoPresenter
-      if m.top.presenterType = "photo" and isValid(m.presenter)
-        photoPlayer.isSlideshow = m.presenter.isSlideshow()
-        photoPlayer.isRandom = m.presenter.isRandom()
-      end if
-
-      m.global.sceneManager.callfunc("pushScene", photoPlayer)
-      return true
-    end if
-  end if
+  ' Photos go to ItemDetails like any other item (OK → itemSelected → onItemSelected).
+  ' The fullscreen viewer opens from ItemDetails' "View" button (viewPhotoButton →
+  ' quickplay.photo), not directly from the grid — launching PhotoDetails here bypassed
+  ' ItemDetails and double-pushed (viewer + ItemDetails stacked).
 
   if key = "options"
     if m.options.visible = true


### PR DESCRIPTION
# Overview

Selecting a photo in a library grid pushed **two** screens at once: the `onKeyEvent` OK handler launched the `PhotoDetails` fullscreen viewer directly, while the grid's `itemSelected` (fired by the same OK press) routed `selectedItem` to an `ItemDetails` screen. Both stacked, so Back from the viewer landed on ItemDetails instead of the library.

A photo should behave like every other grid item: OK opens **ItemDetails**, and the fullscreen viewer opens from ItemDetails' **View** button (`viewPhotoButton` → `quickplay.photo`). This removes the grid's direct viewer launch.

## Changes

- Remove the BaseGridView `onKeyEvent` OK handler that launched `PhotoDetails` directly for photos. OK on a photo now flows through `itemSelected` → `onItemSelected` → `selectedItem` → `ItemDetails` (`main.bs`), like other item types. The fullscreen viewer is reached from ItemDetails' existing **View** button.

## Follow-ups
None

## Issues
None

## Docs / context updates

- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=48e850b8b699c2cb92ff73818f9a9ed94f311c15 ts=2026-06-03T15:31:24Z -->