### PR TITLE
Auto-prune the shipped log and backtick code identifiers in PR titles

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -93,6 +93,8 @@ Start from the template literally. Keep all section headings and HTML comments i
 ### Title
 Imperative mood, < 70 chars. Synthesize from commits, not just the latest. Passed via `--title`, not in the body.
 
+**Backtick every code identifier in the title** — class/component/file names like `` `GridItem` ``, `` `BaseGridView.bs` ``, `` `ItemDetails` ``. The post-merge journal-sync writes the title verbatim into `docs/progress.md` and the PR-time precheck ([`journal-sync-precheck.yml`](../../../.github/workflows/journal-sync-precheck.yml)) spell-checks it; a bare identifier fails that check. Synthesizing from commit subjects (which don't backtick) yields a bare title, so add the backticks yourself. When the precheck fails, **backtick the identifier — never rephrase the title to drop the reference** (that's the wrong fix, even though the old error message led with it). Backticks render as code in `progress.md`; GitHub shows them literally in the title, which is the accepted trade-off.
+
 ### Overview
 1–5 sentences describing *what* changed and *why*. Synthesize from the full commit log, not the last commit.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -9,7 +9,7 @@ Live state cursor — repo-scoped, ~14-day rolling. The "where did I leave off, 
 Sections:
 
 - **Currently running** — 1-2 sentences on what's actively in flight
-- **Recently shipped** — newest first; items older than ~14 days are pruned during weekly cleanup
+- **Recently shipped** — newest first; bullets older than 14 days are pruned automatically by the post-merge journal-sync
 - **Open followups** — grouped by area; deferred work that's not yet issue-shaped or tech-debt-shaped
 
 This file is updated through skills, not raw markdown edits:
@@ -24,7 +24,7 @@ Drift is gated by `npm run lint:docs` — **FAILs** when `last-updated` is >7 da
 
 ## Recently shipped
 
-Newest first. Prepended by `/done`. Items older than ~14 days are pruned manually during the next `/catchup`.
+Newest first. Prepended by the post-merge journal-sync (and `/done`). Bullets older than 14 days are pruned automatically by that same sync; `/catchup` is only a backstop.
 
 - 2026-06-03 — Unify `GridItem`/`GridItemSmall` and fix genre grid rendering
 - 2026-06-03 — Fix photo selection opening the viewer behind `ItemDetails`

--- a/scripts/journal-sync.js
+++ b/scripts/journal-sync.js
@@ -539,24 +539,31 @@ function checkCommand(args) {
   // identifiers (PascalCase class/component names etc.). Adding an identifier
   // to dictionary.txt would pass THIS check but then fail `lint:dictionary`,
   // whose dictionary-audit rejects identifier-shaped entries — a dead end.
-  // For those, the only real fix is rephrasing the title. Reuse the audit's
-  // own `classify` so the two gates can't drift on what counts as identifier-
-  // shaped.
+  // For those the fix is to BACKTICK them in the PR title: the spellchecker
+  // skips backticked tokens and the title renders as code when the post-merge
+  // sync writes it into docs/progress.md. Rephrasing to drop the reference is a
+  // fallback, not the goal. Reuse the audit's own `classify` so the two gates
+  // can't drift on what counts as identifier-shaped.
   const flagged = extractFlaggedWords(spell.output);
   const identifierShaped = flagged.filter((w) => classify(w) !== null);
 
   console.error('Fix one of:');
   if (identifierShaped.length > 0) {
+    const backticked = identifierShaped.map((w) => '`' + w + '`').join(', ');
     console.error(
-      `  1. Rephrase the PR title to avoid: ${identifierShaped.join(', ')}. ` +
-        'These are code identifiers (class/component names) — they belong in ' +
-        'backticks in prose, and adding them to dictionary.txt would be ' +
-        'rejected by `lint:dictionary`.',
+      `  1. Backtick them in the PR title: ${backticked}. ` +
+        'They are code identifiers (class/component/file names); backticking lets ' +
+        'the spellchecker skip them and renders them as code in docs/progress.md. ' +
+        'Keep the reference — do NOT rephrase the title to remove it.',
+    );
+    console.error(
+      '  2. (Fallback) rephrase the title to avoid them. Do not add them to ' +
+        'dictionary.txt — `lint:dictionary` rejects identifier-shaped entries.',
     );
     const realWords = flagged.filter((w) => classify(w) === null);
     if (realWords.length > 0) {
       console.error(
-        `  2. For the non-identifier word(s) (${realWords.join(', ')}), either ` +
+        `  3. For the non-identifier word(s) (${realWords.join(', ')}), either ` +
           'rephrase or add them to dictionary.txt alphabetically.',
       );
     }

--- a/scripts/journal-sync.js
+++ b/scripts/journal-sync.js
@@ -10,6 +10,9 @@
 //   2. Clears ## Currently running when its text overlaps the PR title
 //      (>=2 shared content tokens). Otherwise leaves the cursor alone.
 //   3. Bumps frontmatter last-updated: to today.
+//   4. Prunes ## Recently shipped bullets older than the retention window
+//      (RECENTLY_SHIPPED_PRUNE_DAYS) — so the section stays bounded without a
+//      manual /catchup sweep.
 //
 // What it skips (exit 0, prints "skipped: <reason>"):
 //   - PRs labeled dependencies / documentation / ci / automated
@@ -300,6 +303,12 @@ export function applyShipEdit(content, { prTitle, today }) {
   // 3. Bump frontmatter last-updated.
   next = next.replace(/^(---\s*\nlast-updated:\s*)\d{4}-\d{2}-\d{2}/, `$1${today}`);
 
+  // 4. Prune Recently shipped bullets older than the retention window. This runs
+  //    in the same post-merge commit that prepends the new bullet, so the section
+  //    stays bounded automatically instead of relying on a manual /catchup sweep.
+  //    The just-prepended bullet is dated `today`, so it is always retained.
+  next = pruneRecentlyShipped(next, today, RECENTLY_SHIPPED_PRUNE_DAYS);
+
   return {
     content: next,
     changed: true,
@@ -307,6 +316,40 @@ export function applyShipEdit(content, { prTitle, today }) {
     cursorCleared: clearCursor,
     cursorOverlap,
   };
+}
+
+// Retention window for the "Recently shipped" list. Bullets older than this are
+// pruned by applyShipEdit (post-merge). ~2 weeks keeps the section a useful
+// "what shipped lately" glance without unbounded growth.
+const RECENTLY_SHIPPED_PRUNE_DAYS = 14;
+
+// Returns the ISO date (YYYY-MM-DD) `days` before `isoDate`.
+function isoDaysBefore(isoDate, days) {
+  const d = new Date(`${isoDate}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+// Removes "- YYYY-MM-DD — …" bullets older than `maxAgeDays` from the Recently
+// shipped section ONLY. Scoped by the section regex so dated bullets elsewhere
+// (e.g. Open followups) are untouched. ISO dates compare lexically = chrono, so
+// a string >= is a correct date comparison. Non-bullet lines (heading intro,
+// blanks) and bullets within the window are kept verbatim. Exported for tests.
+export function pruneRecentlyShipped(content, today, maxAgeDays) {
+  const cutoff = isoDaysBefore(today, maxAgeDays);
+  return content.replace(
+    /(##\s+Recently shipped[^\n]*\n)([\s\S]*?)(?=\n##\s|$)/,
+    (_match, header, body) => {
+      const kept = body
+        .split('\n')
+        .filter((line) => {
+          const m = line.match(/^- (\d{4}-\d{2}-\d{2}) /);
+          return !m || m[1] >= cutoff;
+        })
+        .join('\n');
+      return header + kept;
+    },
+  );
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/tests/scripts/unit/journal-sync.test.js
+++ b/tests/scripts/unit/journal-sync.test.js
@@ -18,6 +18,7 @@ import {
   tokenOverlap,
   shouldSkip,
   applyShipEdit,
+  pruneRecentlyShipped,
   extractCurrentlyRunning,
   checkBulletAgainstDictionary,
   extractFlaggedWords,
@@ -180,6 +181,19 @@ describe('applyShipEdit', () => {
     expect(oldIdx).toBeGreaterThan(newIdx);
   });
 
+  it('prunes Recently shipped bullets older than the retention window', () => {
+    const before = progressTemplate({
+      lastUpdated: '2026-05-01',
+      running: '',
+      shipped: ['2026-05-20 — recent shipment', '2026-05-01 — ancient shipment'],
+    });
+    // today 2026-05-21, 14-day window → cutoff 2026-05-07: recent kept, ancient pruned.
+    const r = applyShipEdit(before, { prTitle: 'feat: new thing', today: '2026-05-21' });
+    expect(r.content).toContain('- 2026-05-21 — feat: new thing'); // just-prepended, always kept
+    expect(r.content).toContain('- 2026-05-20 — recent shipment');
+    expect(r.content).not.toContain('ancient shipment');
+  });
+
   it('clears Currently running when cursor overlaps PR title', () => {
     const before = progressTemplate({
       running: 'Reshaping the journal pillar system into four-pillar pattern.',
@@ -227,6 +241,38 @@ describe('applyShipEdit', () => {
 
   it('throws on empty content (refuses to write blind)', () => {
     expect(() => applyShipEdit('', { prTitle: 'x', today: TODAY })).toThrow(/empty/);
+  });
+});
+
+describe('pruneRecentlyShipped', () => {
+  it('drops bullets older than the window, keeps within-window + edge + non-bullet lines', () => {
+    const before = progressTemplate({
+      shipped: ['2026-05-20 — keep recent', '2026-05-07 — keep edge', '2026-05-06 — drop old'],
+    });
+    // today 2026-05-21, window 14 → cutoff 2026-05-07 (kept via >=).
+    const out = pruneRecentlyShipped(before, '2026-05-21', 14);
+    expect(out).toContain('- 2026-05-20 — keep recent');
+    expect(out).toContain('- 2026-05-07 — keep edge');
+    expect(out).not.toContain('drop old');
+    expect(out).toContain('Newest first'); // intro line preserved
+  });
+
+  it('only prunes the Recently shipped section — dated bullets elsewhere survive', () => {
+    const before = `---
+last-updated: 2026-05-01
+---
+
+## Recently shipped
+
+- 2026-05-01 — old ship
+
+## Open followups
+
+- 2026-05-01 — an old but still-open followup
+`;
+    const out = pruneRecentlyShipped(before, '2026-05-21', 14);
+    expect(out).not.toContain('old ship'); // pruned from Recently shipped
+    expect(out).toContain('an old but still-open followup'); // untouched elsewhere
   });
 });
 


### PR DESCRIPTION
# Overview

Two gaps in the journal-sync maintenance of `docs/progress.md`:

1. **PR titles strip code references instead of backticking them.** The post-merge sync writes the PR title into `docs/progress.md`, and the PR-time precheck spell-checks it — so a bare class/component/file name fails. This surfaced (again) on #613 and #614, whose `Journal Sync Precheck` failed on `GridItem`, `GridItemSmall`, `ItemDetails`. The recurring "fix" was to rephrase the title to drop the reference — the wrong outcome.
2. **The shipped log was never auto-pruned.** The sync prepended a bullet but left removing stale ones as a manual `/catchup` chore, so the section grew unbounded.

## Changes

**Backtick code identifiers in PR titles (not strip them)**
- `/pr` SKILL.md Title rule now mandates backticking code identifiers, cites the precheck, and says never to rephrase the title to drop the reference.
- `scripts/journal-sync.js` — the precheck failure message and its code comment now lead with "Backtick them in the PR title: …" (identifiers pre-wrapped); rephrasing demoted to a fallback. So an agent that misses the skill rule is still steered correctly by the failure.

**Auto-prune Recently shipped (close the manual gap)**
- `applyShipEdit` now prunes `## Recently shipped` bullets older than `RECENTLY_SHIPPED_PRUNE_DAYS` (14) in the same post-merge edit that prepends the new bullet — scoped to that section (dated bullets elsewhere untouched); the just-prepended bullet is always retained.
- `docs/progress.md` header updated (`/catchup` is now only a backstop); 3 new unit tests (prune in `applyShipEdit`, window/edge behavior, section-scoping).

## Follow-ups
None

## Issues
None

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/decisions.md`** entry added if a non-obvious design choice was made
- [ ] **`docs/architecture/tech-debt.md`** entry removed/added
- [x] None — skill + journal-sync tooling + the progress.md header it maintains

<!-- /pr render: sha=7a12c2d28e617cb66ce7f47b4388f9b43c2015b4 ts=2026-06-03T16:15:35Z -->