### PR TITLE
Skip Roku device tests when only Node tests change

### DIFF
--- a/.github/workflows/device-unit-tests.yml
+++ b/.github/workflows/device-unit-tests.yml
@@ -84,10 +84,12 @@ jobs:
         id: path_check
         uses: ./.github/actions/changed-paths
         with:
-          # Mirrors the previous event-time paths filter:
-          #   tests/**, source/**, components/**, settings/settings.json,
-          #   bsconfig.json, bsconfig-tests*.json, package.json, package-lock.json
-          pattern: '^(tests/|source/|components/|settings/settings\.json$|bsconfig\.json$|bsconfig-tests[^/]*\.json$|package(-lock)?\.json$)'
+          # Files whose changes can affect the Roku-device test run:
+          #   tests/source/** (the BrightScript suites — NOT tests/scripts/**,
+          #   which are Node/Vitest tests run by the separate `vitest` job),
+          #   source/**, components/**, settings/settings.json, bsconfig.json,
+          #   bsconfig-tests*.json, package.json, package-lock.json
+          pattern: '^(tests/source/|source/|components/|settings/settings\.json$|bsconfig\.json$|bsconfig-tests[^/]*\.json$|package(-lock)?\.json$)'
 
       - name: Combine skip reasons
         id: combined


### PR DESCRIPTION
# Overview

The Roku-device test job (`device-unit-tests.yml` → `all-tests`, on the self-hosted `roku-device` runner) is gated by a `check-skip` job whose `changed-paths` pattern matched `^tests/`. But `tests/` contains two unrelated trees:

- `tests/source/**` — the on-device **BrightScript** suites (what that job runs).
- `tests/scripts/**` — **Node/Vitest** tests, run by the separate `vitest` job on `ubuntu-latest`.

So a PR that touched only Node tests (e.g. #615, which edited `tests/scripts/unit/journal-sync.test.js` and zero `.bs` files) matched `^tests/` and spun up the physical Roku runner for ~7 min — wasted device I/O, power, and CI wall-clock for tests that can't be affected by the change.

## Changes

- Narrow the `changed-paths` pattern in `device-unit-tests.yml` from `tests/` to `tests/source/`. The on-device suites all live under `tests/source/` (including `tests/source/unit/components/**`), so they still trigger; `tests/scripts/**` no longer does. `source/`, `components/`, `settings/settings.json`, and the bsconfig/package files are unchanged.

Verified by matching the new regex against representative paths: `tests/source/unit/components/...`, `source/`, `components/` still match; `tests/scripts/...`, `scripts/`, `docs/`, `.claude/` do not.

## Follow-ups
None

## Issues
None

## Docs / context updates

- [x] None — CI workflow path-filter only

<!-- /pr render: sha=aac1360d72e032bb2e3863bb2aa8c70f1f76c4e9 ts=2026-06-03T16:23:36Z -->