### PR TITLE
fix(playback): restore ts-first transcode container order in `getTranscodingProfiles`

### DIFF
--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -445,14 +445,21 @@ function getTranscodingProfiles() as object
   ' VIDEO CODEC DETECTION (per container)
   ' ========================================
   '
-  ' Container preference order: mp4 (HLS-fmp4) first, then ts (HLS-mpegts). This
-  ' matches the official Jellyfin Roku app and the original jellyfin-roku fork parent.
-  ' The order matters because Jellyfin's StreamBuilder picks FirstOrDefault when
-  ' profile ranks tie — mp4-first unlocks the wider HLS audio target set
-  ' (alac/flac/opus/dts/truehd in addition to aac/ac3/eac3/mp3) for surround
-  ' transcoding scenarios where the user's hardware passthrough is detected only
-  ' for a codec that's TS-incompatible (issue #573).
-  transcodingContainers = ["mp4", "ts"]
+  ' Container preference order: ts (HLS-mpegts) first, then mp4 (HLS-fmp4). One
+  ' video transcoding profile is emitted PER container, in this array order, just
+  ' below — so this order IS the emitted profile order, and Jellyfin's StreamBuilder
+  ' picks FirstOrDefault when profile ranks tie. ts-first => the server prefers an
+  ' mpegts-HLS transcode, which is what Roku reliably plays audio for.
+  '
+  ' Do NOT flip this to mp4-first. fmp4-HLS transcodes produce silent audio on some
+  ' Roku hardware (issue #573 regression: stereo files that played under mpegts went
+  ' silent under fmp4). Upstream jellyfin-roku declares ["mp4","ts"] but only uses
+  ' that loop to accumulate per-container codec strings — it emits its ts video
+  ' profile BEFORE its mp4 one, i.e. ts-first, the same as here. The #573 empty-codec
+  ' fix lives in buildVideoTranscodingAudioCodecsForContainer (always leads with aac,
+  ' never empty) and optimizeAudioCodecListForSource — it does not depend on container
+  ' order, so this stays ts-first.
+  transcodingContainers = ["ts", "mp4"]
   containerVideoCodecs = {}
 
   for each container in transcodingContainers

--- a/tests/source/unit/utils/deviceCapabilities-transcodingProfile.spec.bs
+++ b/tests/source/unit/utils/deviceCapabilities-transcodingProfile.spec.bs
@@ -370,6 +370,34 @@ namespace tests
       m.assertEqual(result[1], "truehd")
     end function
 
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Issue #573 regression — video transcoding profile emission order (ts before mp4)")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    ' One video profile is emitted PER container in getTranscodingProfiles(), in the
+    ' order of the local transcodingContainers array. That order is the server's
+    ' StreamBuilder tie-break preference (FirstOrDefault), so it decides whether the
+    ' server transcodes to mpegts-HLS or fmp4-HLS. fmp4-first regressed stereo files
+    ' to silent audio on some Roku hardware (the #574 follow-up); ts must lead.
+    @it("emits the ts HLS-video profile before the mp4 HLS-video profile")
+    function _()
+      profiles = getTranscodingProfiles()
+
+      tsIndex = -1
+      mp4Index = -1
+      for i = 0 to profiles.count() - 1
+        p = profiles[i]
+        if p.Type = "Video" and p.Protocol = "hls"
+          if p.Container = "ts" and tsIndex = -1 then tsIndex = i
+          if p.Container = "mp4" and mp4Index = -1 then mp4Index = i
+        end if
+      end for
+
+      m.assertTrue(tsIndex >= 0, "Expected a ts HLS-video transcoding profile to be present")
+      m.assertTrue(mp4Index >= 0, "Expected an mp4 HLS-video transcoding profile to be present")
+      m.assertTrue(tsIndex < mp4Index, "ts HLS-video profile must be emitted before mp4 — mp4-first regresses fmp4 transcodes to silent audio on Roku (issue #573 follow-up)")
+    end function
+
   end class
 
 end namespace


### PR DESCRIPTION
# Overview

#574 fixed the original issue #573 crash (`-codec:a:0 m3u8`, ffmpeg exit 8 on surround transcodes) but bundled an unrelated change beside the real fix: it flipped `transcodingContainers` from `["ts", "mp4"]` to `["mp4", "ts"]` in `getTranscodingProfiles()`. JellyRock emits one video transcoding profile **per container, in array order**, and that order is the server's StreamBuilder tie-break (`FirstOrDefault`) — so mp4-first made Jellyfin prefer **fmp4-HLS** transcodes. Those play **silent** on some Roku hardware: @willxie reported stereo files that previously played under mpegts went silent after upgrading to 2.19. This reverts just the container order, keeping #574's genuine empty-codec fix intact.

## Changes
- Revert `transcodingContainers` to `["ts", "mp4"]` in `source/utils/deviceCapabilities.bs` (ts-first emitted profile order → server prefers mpegts-HLS, which Roku reliably plays audio for).
- Rewrite the surrounding comment to explain *why* ts must lead and warn against re-flipping. The prior comment claimed mp4-first "matches the official Jellyfin Roku app" — a misread: upstream declares `["mp4","ts"]` but only uses that loop to build per-container codec strings; it emits its `ts` video profile **before** its `mp4` one. JellyRock builds the profile inside the loop, so the array literal is load-bearing here in a way it isn't upstream.
- Add a regression test asserting the `ts` HLS-video profile is emitted before the `mp4` one (`getTranscodingProfiles()`, verified on hardware).

The #573 empty-codec fix is container-independent and untouched: `buildVideoTranscodingAudioCodecsForContainer` always leads with `aac` (list never empty), and `optimizeAudioCodecListForSource` prepends a server-encodeable surround target for >2ch sources.

## Follow-ups
None

## Issues
Fixes #573

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/decisions.md`** entry added if a non-obvious design choice was made
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=0a6c9a5ae8e3516681f6ca61b14e4fa2e79f1c83 ts=2026-06-05T11:17:15Z -->