### PR TITLE
ci: notify jellyrock.app to redeploy on screenshot changes

### DIFF
--- a/.github/workflows/notify-homepage.yml
+++ b/.github/workflows/notify-homepage.yml
@@ -1,0 +1,34 @@
+name: Notify Homepage of Content Changes
+
+# When content the jellyrock.app marketing site renders at build time changes
+# here, tell it to rebuild. The site fetches docs/screenshots fresh on every
+# build (gitignored there), so a redeploy is all that's needed to pick them up.
+# Mirrors build-docs.yml (-> api-docs). See jellyrock/jellyrock.app#1.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/screenshots/**"
+
+jobs:
+  notify-homepage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: jellyrock
+          repositories: jellyrock.app
+
+      - name: Trigger homepage redeploy
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: jellyrock/jellyrock.app
+          event-type: content-update
+          client-payload: '{"reason": "screenshots updated upstream", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## What

New workflow `notify-homepage.yml` that fires a `repository_dispatch` (`content-update`) to **jellyrock/jellyrock.app** on push to `main` touching `docs/screenshots/**`.

## Why

The marketing site (jellyrock.app) renders these screenshots, fetched fresh at build time. Until now nothing told it to rebuild when they changed here, so the live site's screenshots went stale until an unrelated commit happened to redeploy it. See jellyrock/jellyrock.app#1.

## How

Mirrors the existing `build-docs.yml` → api-docs pattern exactly: org GitHub App token (`APP_ID` / `APP_PRIVATE_KEY`), scoped to `jellyrock.app`, same pinned action SHAs. The companion `content-update` trigger is added in jellyrock/jellyrock.app#31.

## Scope note

Path filter is `docs/screenshots/**` only — the only thing the site currently renders live from this repo. (`resources/branding` is fetched but not yet wired to the homepage logo; that'll be added to the filter when the logo work lands.)