### PR TITLE
fix(quickplay): key `Play All` dispatch on canonical Jellyfin item type

### DIFF
--- a/components/tasks/QuickPlayTask.bs
+++ b/components/tasks/QuickPlayTask.bs
@@ -1,5 +1,6 @@
 import "pkg:/source/api/ApiClient.bs"
 import "pkg:/source/api/apiPool.bs"
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 import "pkg:/source/utils/misc.bs"
 
 ' QuickPlayTask: Orchestrator task for all quickplay, Play All, Instant Mix,
@@ -24,6 +25,7 @@ import "pkg:/source/utils/misc.bs"
 
 sub init()
   m.top.functionName = "executeQuickPlay"
+  m.log = new log.Logger("QuickPlayTask")
 end sub
 
 sub executeQuickPlay()
@@ -83,9 +85,9 @@ sub executeQuickPlay()
     doPlayAllSeason(input, items)
   else if action = "playallboxset"
     doPlayAllBoxset(input, items)
-  else if action = "playallalbum"
+  else if action = "playallmusicalbum"
     doPlayAllAlbum(input, items)
-  else if action = "playallartist"
+  else if action = "playallmusicartist"
     doPlayAllArtist(input, items)
   else if action = "playallplaylist"
     doPlayAllPlaylist(input, items)
@@ -97,6 +99,12 @@ sub executeQuickPlay()
   else if action = "loadphotoalbum"
     doPhotoAlbum(input, items)
     outputAction = "photo"
+  else
+    ' No dispatch branch matched. This is the failure mode behind #629: a caller
+    ' builds an action string (e.g. "playAll" + itemType) that no handler key
+    ' matches, so items stays empty and the UI just stops the spinner silently.
+    ' Surface it loudly so a future type mismatch is debuggable, not invisible.
+    m.log.error("unhandled action — no dispatch branch matched", input.action)
   end if
 
   m.top.output = {

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -121,6 +121,7 @@ CommonJS
 config
 Config
 configs
+const
 ContentNode
 coord
 coords
@@ -196,6 +197,7 @@ ESM-native
 fader
 fallbacks
 Fallbacks
+fallthrough
 fast-decay
 ffmpeg
 ffmpeg-tagged
@@ -273,6 +275,7 @@ JSONL
 Keep-a-Changelog
 last-checked
 last-updated
+lowercased
 lifecycle
 lifecycle.
 Lifecycle
@@ -394,6 +397,7 @@ refetching
 regen
 Re-init
 rekey
+rekeying
 remuxing
 renderer
 renderers

--- a/docs/architecture/tech-debt.md
+++ b/docs/architecture/tech-debt.md
@@ -98,6 +98,12 @@ The `npm run lint:docs` checker validates every `tech-debt.md#<anchor>` referenc
 - **area**: `components/ItemDetails.bs`, `source/main.bs`
 - **issue**: Single-shot event idiom — unfamiliar to first-time readers. See `user-journey.md` for the canonical explanation.
 
+#### `quickplay-action-vocabulary`
+
+- **area**: [`components/tasks/QuickPlayTask.bs`](../../components/tasks/QuickPlayTask.bs) (`executeQuickPlay` dispatch), [`source/main.bs`](../../source/main.bs) (`quickPlayNode` + `playButton` action construction).
+- **issue**: The `QuickPlayTask` action is an ad-hoc magic string overloading operation (`playAll`) + item type, built by call-site concatenation (`"playAll" + itemContent.type`) and `LCase(itemNode.type)`. Both producers emit the raw lowercased Jellyfin type, but the dispatch was hand-keyed in an invented "friendly" vocabulary (`album`/`artist`, `playallalbum`/`playallartist`) that **nothing produces** — Jellyfin has no `Album`/`Artist` type, only `MusicAlbum`/`MusicArtist`. The Play All path matched none of its keys and silently failed (#629, fixed by rekeying the two Play All branches to the canonical `playallmusic*` spelling). The quickplay path still carries the dead `album`/`artist` aliases at `executeQuickPlay` (alongside the live `musicalbum`/`musicartist`), so the divergent vocabulary persists where it's currently harmless.
+- **direction**: Collapse the remaining dead `album`/`artist` aliases to the canonical vocabulary and document the convention — **dispatch key = `LCase(item.type)`; the operation prefix (`playAll`) is a literal**. A `// no bare Album/Artist type exists in Jellyfin` note at the dispatch keeps it from being reinvented. Structured-action (separate `operation` + `itemType` fields with a 2-D lookup) and enum/const keys were **considered and rejected**: the failure mode is producer/consumer vocabulary *mismatch*, not call-site *divergence* (both call sites already agree), so a canonical-vocabulary convention plus the existing unmatched-action runtime guard (`m.log.error` fallthrough) covers it without the coordination machinery — convention over mechanism. Kept out of #629's PR because it touches the working quickplay path.
+
 #### `loginflow-goto-retry`
 
 - **area**: `source/showScenes.bs`


### PR DESCRIPTION
# Overview
`Play All` did nothing for Music Album and Music Artist items — the spinner started, then stopped a split second later (#629). Root cause: `main.bs` builds the `QuickPlayTask` action by concatenating the operation and the raw item type (`"playAll" + itemContent.type` → `playAllMusicAlbum` / `playAllMusicArtist`, lowercased), but the dispatch was hand-keyed in an invented "friendly" vocabulary (`playallalbum` / `playallartist`) that **nothing produces** — Jellyfin has no `Album` / `Artist` type, only `MusicAlbum` / `MusicArtist`. No branch matched, `items` stayed empty, the output fired empty, and the UI just stopped the spinner. An audit of all six `Play All`-eligible types confirmed only the two `Music*` types were affected — the rest (Series, Season, BoxSet, Playlist) work because their lowercased Jellyfin type already equals the handler key.

## Changes
- Key the two `Play All` dispatch branches on the **canonical** lowercased Jellyfin type (`playallmusicalbum` / `playallmusicartist`) — what both producers actually emit — and drop the dead `playallalbum` / `playallartist` keys.
- Add a fallthrough `else` in the dispatch that logs `m.log.error` on any unmatched action, so a future type-name/key drift surfaces loudly instead of failing silently as a dead spinner (the underlying class of bug behind #629).
- Wire a `log.Logger` into `QuickPlayTask.init()` (matching the sibling `GetPlaybackInfoTask` pattern) to back the new guard.

## Follow-ups
- [`quickplay-action-vocabulary`](../docs/architecture/tech-debt.md#quickplay-action-vocabulary) — collapse the remaining dead `album` / `artist` aliases on the (working) quickplay path to the canonical vocabulary and document the convention; kept out of this PR to avoid touching a working flow.

## Issues
Fixes #629

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/decisions.md`** entry added if a non-obvious design choice was made
- [x] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [ ] None — this PR doesn't change any of the above

<!-- /pr render: sha=fbde1b31c978b54f818679a9d4db825f96cd90d4 ts=2026-06-07T03:39:50Z -->