### PR TITLE
refactor(quickplay): drop dead `album`/`artist` dispatch aliases

### DIFF
--- a/components/tasks/QuickPlayTask.bs
+++ b/components/tasks/QuickPlayTask.bs
@@ -7,7 +7,7 @@ import "pkg:/source/utils/misc.bs"
 ' Trailer, and Photo Album flows that require API calls.
 '
 ' Input AA fields:
-'   action (string)       - dispatch key (e.g. "album", "playAllSeries", "instantMix", etc.)
+'   action (string)       - dispatch key (e.g. "musicalbum", "playAllSeries", "instantMix", etc.)
 '   id (string)           - primary item ID
 '   seriesId (string)     - optional, for season/episode context
 '   collectionType (string) - optional, for collection/userView dispatch
@@ -38,9 +38,15 @@ sub executeQuickPlay()
   outputAction = "queue"
   firstItemStartingPoint = 0& ' LongInteger
 
-  if action = "musicalbum" or action = "album"
+  ' Dispatch convention: the action key is the lowercased Jellyfin item type
+  ' (e.g. "musicalbum", "boxset"), optionally with a literal operation prefix
+  ' ("playall..."). Producers build it from the raw type (main.bs: LCase(type)
+  ' and "playAll" + type), so keys must match Jellyfin's BaseItemKind exactly —
+  ' there is no bare "album"/"artist" type, only "MusicAlbum"/"MusicArtist".
+  ' The else branch below logs any unmatched action so drift can't fail silently.
+  if action = "musicalbum"
     doAlbum(input, items)
-  else if action = "musicartist" or action = "artist"
+  else if action = "musicartist"
     doArtist(input, items)
     shouldShuffle = true
   else if action = "boxset"

--- a/docs/architecture/tech-debt.md
+++ b/docs/architecture/tech-debt.md
@@ -98,12 +98,6 @@ The `npm run lint:docs` checker validates every `tech-debt.md#<anchor>` referenc
 - **area**: `components/ItemDetails.bs`, `source/main.bs`
 - **issue**: Single-shot event idiom — unfamiliar to first-time readers. See `user-journey.md` for the canonical explanation.
 
-#### `quickplay-action-vocabulary`
-
-- **area**: [`components/tasks/QuickPlayTask.bs`](../../components/tasks/QuickPlayTask.bs) (`executeQuickPlay` dispatch), [`source/main.bs`](../../source/main.bs) (`quickPlayNode` + `playButton` action construction).
-- **issue**: The `QuickPlayTask` action is an ad-hoc magic string overloading operation (`playAll`) + item type, built by call-site concatenation (`"playAll" + itemContent.type`) and `LCase(itemNode.type)`. Both producers emit the raw lowercased Jellyfin type, but the dispatch was hand-keyed in an invented "friendly" vocabulary (`album`/`artist`, `playallalbum`/`playallartist`) that **nothing produces** — Jellyfin has no `Album`/`Artist` type, only `MusicAlbum`/`MusicArtist`. The Play All path matched none of its keys and silently failed (#629, fixed by rekeying the two Play All branches to the canonical `playallmusic*` spelling). The quickplay path still carries the dead `album`/`artist` aliases at `executeQuickPlay` (alongside the live `musicalbum`/`musicartist`), so the divergent vocabulary persists where it's currently harmless.
-- **direction**: Collapse the remaining dead `album`/`artist` aliases to the canonical vocabulary and document the convention — **dispatch key = `LCase(item.type)`; the operation prefix (`playAll`) is a literal**. A `// no bare Album/Artist type exists in Jellyfin` note at the dispatch keeps it from being reinvented. Structured-action (separate `operation` + `itemType` fields with a 2-D lookup) and enum/const keys were **considered and rejected**: the failure mode is producer/consumer vocabulary *mismatch*, not call-site *divergence* (both call sites already agree), so a canonical-vocabulary convention plus the existing unmatched-action runtime guard (`m.log.error` fallthrough) covers it without the coordination machinery — convention over mechanism. Kept out of #629's PR because it touches the working quickplay path.
-
 #### `loginflow-goto-retry`
 
 - **area**: `source/showScenes.bs`


### PR DESCRIPTION
# Overview
Follow-up to #630, which fixed Play All for Music items by keying the `QuickPlayTask` dispatch on the canonical lowercased Jellyfin type. The quickplay (non-playAll) path still carried dead "friendly" aliases — `action = "musicalbum" or action = "album"` — even though **nothing produces the bare `album` / `artist` spelling** (Jellyfin has no `Album` / `Artist` `BaseItemKind`, only `MusicAlbum` / `MusicArtist`, and both producers emit the raw lowercased type). This collapses the dispatch to a single canonical vocabulary and documents the convention so it can't be reinvented. Resolves the `quickplay-action-vocabulary` tech-debt slug.

## Changes
- Drop the dead `or action = "album"` / `or action = "artist"` clauses from the quickplay dispatch — the canonical `musicalbum` / `musicartist` keys remain (behavior-preserving; the bare spellings never matched at runtime).
- Add a dispatch-convention comment: the action key is `LCase(item.type)` with a literal operation prefix; keys must match Jellyfin's `BaseItemKind` exactly, and the unmatched-action guard from #630 catches drift.
- Fix the stale `"album"` example in the `input.action` header doc comment.
- Remove the resolved `quickplay-action-vocabulary` entry from `tech-debt.md` (the structured-action / enum alternatives recorded there were considered and rejected as mechanism over convention).

## Follow-ups
None

## Issues
Ref #630

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/decisions.md`** entry added if a non-obvious design choice was made
- [x] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [ ] None — this PR doesn't change any of the above

<!-- /pr render: sha=332ee6c734c5d8cf91d5e8160a6f03850c6b12c8 ts=2026-06-07T03:50:32Z -->