### PR TITLE
docs(readme): split About and History sections, refresh lead

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![API docs](https://img.shields.io/badge/API%20docs-purple "API docs")](https://jellyrock.github.io/api-docs/)
 <!-- [![Translation Status](https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-roku/svg-badge.svg "Translation Status")](https://translate.jellyfin.org/projects/jellyfin/jellyfin-roku/?utm_source=widget) -->
 
-JellyRock is a Jellyfin client for Roku devices with a focus on stability and UX. Originally forked from jellyfin-roku [v2.2.5](https://github.com/jellyfin-archive/jellyfin-roku-legacy/releases/tag/v2.2.5).
+JellyRock is a fast, fluid Jellyfin client for Roku, focused on stability, performance, and a polished UX. Direct Play in original quality, a redesigned playback OSD, deep theming with custom hex colors, and 99 built-in language translations. Free and open-source, no ads, no tracking. Bring your own Jellyfin server.
 
 ## Changelog
 
@@ -50,6 +50,14 @@ All notable changes to this project are documented in [CHANGELOG.md](CHANGELOG.m
   <a href="docs/screenshots/trickplay.png" target="_blank" title="Trickplay">
     <img src="docs/screenshots/trickplay.png" width="400" alt="Trickplay" />
   </a>
+
+## History
+
+From 2019 to 2025, I worked on the original Jellyfin client for Roku as a member of the Jellyfin team, and was its sole maintainer for part of that time.
+
+That client is now archived as [jellyfin-roku-legacy](https://github.com/jellyfin-archive/jellyfin-roku-legacy). For its [v3 release](https://github.com/jellyfin/jellyfin-roku/releases/tag/3.0.0), the [official client](https://github.com/jellyfin/jellyfin-roku) adopted a different fork as its new base, one that had branched from the original back at v2.1.4.
+
+JellyRock continues the original's own line. I forked it at [v2.2.5](https://github.com/jellyfin-archive/jellyfin-roku-legacy/releases/tag/v2.2.5), the last release I'd personally vetted as stable, and have rebuilt and refined it independently ever since, cherry-picking select fixes from later commits along the way.
 
 ## Sideload / Beta Test
 

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -258,6 +258,7 @@ JavaScript
 jellyfin
 Jellyfin
 jellyfin-roku
+jellyfin-roku-legacy
 Jellyfin-pool
 Jellyfin's
 jellyfin-server-versioning


### PR DESCRIPTION
# Overview

Splits the README's opening into a product-focused **About** lead and a separate **History** section. The old lead mixed "what JellyRock is" with origin/fork detail; separating them means readers who just want to know what the app is don't have to read the backstory first. The new History section tells the project's lineage and is placed after Screenshots, so it sits in the natural reading flow without leading with it.

## Changes

- Replace the opening lead blurb with a product-focused About paragraph (speed, stability, Direct Play, theming, 99 languages, open-source); drop the inline "originally forked from v2.2.5" detail (now in History).
- Add a `## History` section after `## Screenshots` covering the original-client lineage and JellyRock's fork point, with links to the legacy repo, the official client, the v3 release, and the v2.2.5 release. All fork-point claims were verified against public git history (contribution span 2019-2025, viv fork point v2.1.4, JellyRock fork point v2.2.5).
- Add `jellyfin-roku-legacy` to `dictionary.txt` so the spellchecker accepts the archived repo name.

## Follow-ups

None

## Issues

Ref #622

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/decisions.md`** entry added if a non-obvious design choice was made
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=b0e1cb5dd94121135f77de440f5849e3ef22ddeb ts=2026-06-07T14:25:02Z -->