### PR TITLE
Localize search result-row headers

### DIFF
--- a/components/search/SearchRow.bs
+++ b/components/search/SearchRow.bs
@@ -10,6 +10,7 @@ import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
 import "pkg:/source/utils/textureManager.bs"
+import "pkg:/source/utils/translate.bs"
 
 sub init()
   m.top.itemComponentName = "BrowseRowItem"
@@ -43,23 +44,25 @@ function getData()
   ' Ordering follows itemTypeOrder.SEARCH (web-client section sort order).
   ' AssocArrays have no guaranteed order, so a separate array drives row creation.
   typeArray = itemTypeOrder.SEARCH
+  ' Row-header labels are translated (translationKeys already exist for every type);
+  ' previously these were hardcoded English and showed untranslated in every locale.
   contentTypes = {
-    "Movie": { "label": "Movies", "count": 0 },
-    "Series": { "label": "Shows", "count": 0 },
-    "Episode": { "label": "Episodes", "count": 0 },
-    "Person": { "label": "People", "count": 0 },
-    "Playlist": { "label": "Playlists", "count": 0 },
-    "MusicArtist": { "label": "Artists", "count": 0 },
-    "MusicAlbum": { "label": "Albums", "count": 0 },
-    "Audio": { "label": "Songs", "count": 0 },
-    "Video": { "label": "Videos", "count": 0 },
-    "MusicVideo": { "label": "Music Videos", "count": 0 },
-    "Program": { "label": "Programs", "count": 0 },
-    "TvChannel": { "label": "Channels", "count": 0 },
-    "Recording": { "label": "Recordings", "count": 0 },
-    "PhotoAlbum": { "label": "Photo Albums", "count": 0 },
-    "Photo": { "label": "Photos", "count": 0 },
-    "BoxSet": { "label": "Collections", "count": 0 }
+    "Movie": { "label": translate(translationKeys.LabelMovies), "count": 0 },
+    "Series": { "label": translate(translationKeys.LabelShows), "count": 0 },
+    "Episode": { "label": translate(translationKeys.LabelEpisodes), "count": 0 },
+    "Person": { "label": translate(translationKeys.LabelPeople), "count": 0 },
+    "Playlist": { "label": translate(translationKeys.LabelPlaylists), "count": 0 },
+    "MusicArtist": { "label": translate(translationKeys.LabelArtists), "count": 0 },
+    "MusicAlbum": { "label": translate(translationKeys.LabelAlbums), "count": 0 },
+    "Audio": { "label": translate(translationKeys.LabelSongs), "count": 0 },
+    "Video": { "label": translate(translationKeys.LabelVideos), "count": 0 },
+    "MusicVideo": { "label": translate(translationKeys.LabelMusicVideos), "count": 0 },
+    "Program": { "label": translate(translationKeys.LabelPrograms), "count": 0 },
+    "TvChannel": { "label": translate(translationKeys.LabelChannels), "count": 0 },
+    "Recording": { "label": translate(translationKeys.LabelRecordings), "count": 0 },
+    "PhotoAlbum": { "label": translate(translationKeys.LabelPhotoAlbums), "count": 0 },
+    "Photo": { "label": translate(translationKeys.LabelPhotos), "count": 0 },
+    "BoxSet": { "label": translate(translationKeys.LabelCollections), "count": 0 }
   }
 
   for each item in itemData.Items


### PR DESCRIPTION
# Overview

The search results screen groups matches into typed sections — Movies, Shows, Episodes, People, Playlists, Artists, Albums, Songs, etc. Those section headers were **hardcoded English string literals** in `components/search/SearchRow.bs`, so they rendered in English for every user regardless of language, even though the rest of the screen (including the localized "Search:" overhang title) translates correctly.

Surfaced by the per-language screenshots added in #621: the localized search shots showed an English row header above otherwise-translated content.

## Changes

- Run each search-section header through `translate(translationKeys.Label*)` instead of a hardcoded string. Every key (`LabelMovies`, `LabelShows`, `LabelEpisodes`, …) and its `fr`/`de`/`pt`/`es` translations already exist, so no new strings were added.
- Added the `pkg:/source/utils/translate.bs` import to `SearchRow.bs`.

## Follow-ups

None.

## Issues

Ref #621

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/decisions.md`** entry added if a non-obvious design choice was made
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=cef4511e9b245e563106988b49013a2e601e95ff ts=2026-06-11T04:17:13Z -->