### PR TITLE
Add Renovate update-soak windows; create soaking PRs immediately

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-11
+last-updated: 2026-06-12
 ---
 
 # Progress
@@ -63,6 +63,7 @@ Grouped by area. Append via `/log followup "<text>" --area=<name>`. Close via `/
 ### scripts
 
 - Expand automated store screenshots from the 5 marketing languages to ALL ~99 locale files, to surface the default Roku OS font's blast radius — boxes/tofu for scripts the system font doesn't cover are EXPECTED and the point of capturing them. From #642.
+- Remove the duplicated generic Renovate soak tiers (patch/minor/major) from `renovate.json` once the canonical org preset (jellyrock/.github#6) is live + propagated — keep only the repo-scoped `sgRouter` carve-out.
 
 ### components
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -63,7 +63,7 @@ Grouped by area. Append via `/log followup "<text>" --area=<name>`. Close via `/
 ### scripts
 
 - Expand automated store screenshots from the 5 marketing languages to ALL ~99 locale files, to surface the default Roku OS font's blast radius — boxes/tofu for scripts the system font doesn't cover are EXPECTED and the point of capturing them. From #642.
-- Remove the duplicated generic Renovate soak tiers (patch/minor/major) from `renovate.json` once the canonical org preset (jellyrock/.github#6) is live + propagated — keep only the repo-scoped `sgRouter` carve-out.
+- Remove the entire mirrored Renovate soak block (`internalChecksFilter` + patch/minor/major tiers) from `renovate.json` once the canonical org preset (jellyrock/.github#6) is live + propagated — JellyRock then inherits it all from the preset, leaving only the genuinely repo-scoped package-grouping rules.
 
 ### components
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["github>jellyrock/.github//renovate/default"],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
+  "internalChecksFilter": "none",
   "packageRules": [
     {
       "description": "BrighterScript compiler/lint/format stack — coordinated rokucommunity releases",
@@ -61,14 +62,16 @@
       "addLabels": ["javascript"]
     },
     {
-      "description": "Soak window before patch/digest automerge — catches yanked or hotfixed releases before they land unattended. Mirrors the org preset (github>jellyrock/.github//renovate/default); kept here too so JellyRock is covered immediately without waiting on preset propagation. Remove once the canonical preset is live everywhere (see docs/progress.md followup).",
+      "description": "Soak window before patch/digest automerge — catches yanked or hotfixed releases before they land unattended. PRs are created immediately while soaking (internalChecksFilter:none above) so a hotfix can be merged manually early; the soak only gates automerge. Mirrors the org preset (github>jellyrock/.github//renovate/default); kept here too so JellyRock is covered immediately without waiting on preset propagation. Remove once the canonical preset is live everywhere (see docs/progress.md followup).",
       "matchUpdateTypes": ["patch", "digest"],
-      "minimumReleaseAge": "2 days"
+      "minimumReleaseAge": "2 days",
+      "automerge": true
     },
     {
-      "description": "Minor updates soak 5 days; stay human-reviewed (no automerge). Mirror of org preset — remove once canonical propagates.",
+      "description": "Minor updates automerge after a 5-day soak + green CI. JellyRock's CI exercises runtime behavior (on-device BS unit tests + RTA functional pass), which clears the raised bar for minor automerge. Mirror of org preset — remove once canonical propagates.",
       "matchUpdateTypes": ["minor"],
-      "minimumReleaseAge": "5 days"
+      "minimumReleaseAge": "5 days",
+      "automerge": true
     },
     {
       "description": "Major updates soak 7 days and NEVER automerge — always human-reviewed. Mirror of org preset — remove once canonical propagates.",

--- a/renovate.json
+++ b/renovate.json
@@ -59,6 +59,29 @@
         "xml2js"
       ],
       "addLabels": ["javascript"]
+    },
+    {
+      "description": "Soak window before patch/digest automerge — catches yanked or hotfixed releases before they land unattended. Mirrors the org preset (github>jellyrock/.github//renovate/default); kept here too so JellyRock is covered immediately without waiting on preset propagation. Remove once the canonical preset is live everywhere (see docs/progress.md followup).",
+      "matchUpdateTypes": ["patch", "digest"],
+      "minimumReleaseAge": "2 days"
+    },
+    {
+      "description": "Minor updates soak 5 days; stay human-reviewed (no automerge). Mirror of org preset — remove once canonical propagates.",
+      "matchUpdateTypes": ["minor"],
+      "minimumReleaseAge": "5 days"
+    },
+    {
+      "description": "Major updates soak 7 days and NEVER automerge — always human-reviewed. Mirror of org preset — remove once canonical propagates.",
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "7 days",
+      "automerge": false
+    },
+    {
+      "description": "sgRouter is pre-1.0 and is JellyRock's entire navigation layer — a breaking bump takes down all nav. Never automerge; soak 5 days; label for manual review. Repo-local by nature (only JellyRock depends on sgRouter), so this rule stays here permanently, not in the org preset.",
+      "matchPackageNames": ["@rokucommunity/sgrouter", "sgRouter"],
+      "minimumReleaseAge": "5 days",
+      "automerge": false,
+      "addLabels": ["sgrouter"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -78,13 +78,6 @@
       "matchUpdateTypes": ["major"],
       "minimumReleaseAge": "7 days",
       "automerge": false
-    },
-    {
-      "description": "sgRouter is pre-1.0 and is JellyRock's entire navigation layer — a breaking bump takes down all nav. Never automerge; soak 5 days; label for manual review. Repo-local by nature (only JellyRock depends on sgRouter), so this rule stays here permanently, not in the org preset.",
-      "matchPackageNames": ["@rokucommunity/sgrouter", "sgRouter"],
-      "minimumReleaseAge": "5 days",
-      "automerge": false,
-      "addLabels": ["sgrouter"]
     }
   ]
 }


### PR DESCRIPTION
# Overview

Renovate auto-merge currently fires the instant CI is green with **zero** minimum-release-age, so a yanked or hotfixed release can land unattended. This adds soak windows and makes soaking PRs visible immediately (so a hotfix can be merged manually early), ahead of the `sgRouter` navigation migration (#550).

Mirrors a parallel change to the canonical org preset ([jellyrock/.github#6](https://github.com/jellyrock/.github/pull/6)); kept here too so JellyRock is covered immediately rather than waiting on preset propagation. The whole block is removed once the preset propagates (tracked as a followup).

## Changes

- **`internalChecksFilter: "none"`** — soaking PRs are created immediately (not suppressed by Renovate's default `strict`), so every update is visible and a hotfix can be **manually merged early**; the soak only gates automerge.
- **Soak + automerge tiers**: patch/digest 2 days, minor 5 days — both automerge after soak + green CI (JellyRock's on-device unit tests + RTA clear the minor-automerge bar). Major 7 days, **never automerge**.

No `sgRouter`-specific rule: a breaking sgRouter bump is caught by `bsc validate`/build + the RTA nav specs, same as our other alpha deps (brighterscript), so it rides the general policy.

## Follow-ups

- Remove the entire mirrored soak block from `renovate.json` once the canonical org preset is live + propagated — tracked in `docs/progress.md` Open followups (scripts).

## Issues

Ref #550

## Docs / context updates

- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=c7db62588b7db0aa7b942a78976fa54f35e1ea5b ts=2026-06-12T16:56:49Z -->