### PR TITLE
chore(lint): make `markdownlint` respect `.gitignore`

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,13 @@
+{
+  // Respect .gitignore when linting markdown. Gitignored trees are local-only agent-continuity or
+  // build artifacts (docs/projects/ PLANs, tasks/, build/, out/, build-analysis/, node_modules/) —
+  // never committed, so a style nit in one must NOT fail an unrelated push or CI run. This is the
+  // durable fix for "a sibling project's PLAN.md broke my push": any gitignored .md is now skipped
+  // automatically, so the manual exclude list in the lint:markdown glob can't drift behind a new
+  // gitignored directory again.
+  //
+  // Tracked-but-intentionally-unlinted files (CLAUDE.md / AGENTS.md / copilot-instructions.md /
+  // .claude) are NOT gitignored, so their exclusions stay in the lint:markdown glob in package.json.
+  // Rule config continues to live in .markdownlint.yml (cli2 loads both files).
+  "gitignore": true
+}


### PR DESCRIPTION
# Overview

markdownlint-cli2 lints on-disk `**/*.md`, which includes **gitignored** agent-continuity trees — most notably the per-project `docs/projects/<slug>/PLAN.md` files. A markdown-style nit in *any* local PLAN (even a sibling project's, untouched by your change) fails the pre-push `lint:markdown` step and blocks an unrelated push. The manual exclude list in the `lint:markdown` glob (`!tasks/`, `!out/`, …) had simply drifted behind `docs/projects/` when that gitignored directory was added.

This adds `.markdownlint-cli2.jsonc` with `gitignore: true` so markdownlint skips every gitignored `.md` automatically — the durable fix for the whole class, not just `docs/projects/`. The manual list can no longer drift behind a new gitignored directory.

## Changes

- Add `.markdownlint-cli2.jsonc` enabling `gitignore: true`. Gitignored `.md` files (project PLANs, `tasks/`, build artifacts) are no longer linted.
- Tracked-but-intentionally-unlinted files (`CLAUDE.md` / `AGENTS.md` / `copilot-instructions.md` / `.claude`) stay excluded via the existing `lint:markdown` glob; rule config stays in `.markdownlint.yml` (cli2 loads both).

## Follow-ups

None

## Issues

None

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=7c17fe2741fcea4b5bfee341db211c06669fe12f ts=2026-06-23T11:46:43Z -->