### PR TITLE
fix(settings): point keyboard submit-key `KDFs` at the icon assets that exist

### DIFF
--- a/components/keyboards/AlphaKeyboardKDF.json
+++ b/components/keyboards/AlphaKeyboardKDF.json
@@ -55,8 +55,8 @@
                   "strOut": "backspace"
                 },
                 {
-                  "icon": "pkg:/images/icons/check-white.png",
-                  "focusIcon": "pkg:/images/icons/check-black.png",
+                  "icon": "pkg:/images/icons/check-white_$$RES$$.png",
+                  "focusIcon": "pkg:/images/icons/check-black_$$RES$$.png",
                   "strOut": "submit"
                 }
               ]

--- a/components/keyboards/HexKeyboardKDF.json
+++ b/components/keyboards/HexKeyboardKDF.json
@@ -73,8 +73,8 @@
                   "strOut": "backspace"
                 },
                 {
-                  "icon": "pkg:/images/icons/check-white.png",
-                  "focusIcon": "pkg:/images/icons/check-black.png",
+                  "icon": "pkg:/images/icons/check-white_$$RES$$.png",
+                  "focusIcon": "pkg:/images/icons/check-black_$$RES$$.png",
                   "strOut": "submit"
                 }
               ]

--- a/components/keyboards/IntegerKeyboardKDF.json
+++ b/components/keyboards/IntegerKeyboardKDF.json
@@ -59,8 +59,8 @@
                   "label": "0"
                 },
                 {
-                  "icon": "pkg:/images/icons/check-white.png",
-                  "focusIcon": "pkg:/images/icons/check-black.png",
+                  "icon": "pkg:/images/icons/check-white_$$RES$$.png",
+                  "focusIcon": "pkg:/images/icons/check-black_$$RES$$.png",
                   "strOut": "submit"
                 }
               ]


### PR DESCRIPTION
# Overview

Fixes a pre-existing bug where the **Submit key on the on-screen keyboards rendered blank**, leaving no way to commit a value typed into a numeric / hex / alpha settings field. The Alpha, Hex, and Integer keyboard KDFs pointed their submit-key icon at `pkg:/images/icons/check-white.png` / `check-black.png`, but only the resolution-tokenized `check-*_$$RES$$` variants exist on disk — so Roku couldn't resolve the asset and drew nothing.

This is independent of any in-flight feature work; it was extracted into its own PR so it can be reviewed and merged on its own.

## Changes

- Repoint the submit-key `icon` / `focusIcon` in `AlphaKeyboardKDF.json`, `HexKeyboardKDF.json`, and `IntegerKeyboardKDF.json` at the real `check-white_$$RES$$.png` / `check-black_$$RES$$.png` assets.

## Follow-ups

None

## Issues

None

## Docs / context updates

- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=8166413e994ae5294db29a3f95c9b9d9306eb173 ts=2026-06-28T13:45:56Z -->

## Screenshots

### Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3a13533e-010c-465c-9104-b4f9fe263b5b" />

### After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d5677e96-7cf6-46a2-b215-1a7b29756e1b" />
