### PR TITLE
fix(format): pin `brighterscript-formatter` to 1.7.27 (revert 1.7.28 indent regression)

### DIFF
--- a/components/GetPlaybackInfoTask.bs
+++ b/components/GetPlaybackInfoTask.bs
@@ -22,144 +22,144 @@ sub getPlaybackInfoTask()
   else
     ' No cached data available - this represents an unexpected error condition
     m.log.warn("cachedPlaybackInfo is invalid - Stream Information will not be displayed", {
-        videoID: m.top.videoID
-      })
-      m.playbackInfo = invalid
+      videoID: m.top.videoID
+    })
+    m.playbackInfo = invalid
+  end if
+
+  if isValid(sessions) and sessions.Count() > 0
+    m.top.data = { playbackInfo: GetTranscodingStats(sessions[0]) }
+  else
+    m.top.data = { playbackInfo: [translate(translationKeys.ErrorUnableToGetPlaybackInformation)] }
+  end if
+end sub
+
+function GetTranscodingStats(deviceSession)
+  sessionStats = { data: [] }
+
+  if isValid(deviceSession.TranscodingInfo) and deviceSession.TranscodingInfo.Count() > 0
+    transcodingReasons = deviceSession.TranscodingInfo.TranscodeReasons
+    videoCodec = deviceSession.TranscodingInfo.VideoCodec
+    audioCodec = deviceSession.TranscodingInfo.AudioCodec
+    totalBitrate = deviceSession.TranscodingInfo.Bitrate
+    audioChannels = deviceSession.TranscodingInfo.AudioChannels
+
+    if isValid(transcodingReasons) and transcodingReasons.Count() > 0
+      sessionStats.data.push("<header>" + translate(translationKeys.LabelTranscodingInformation) + "</header>")
+      for each item in transcodingReasons
+        sessionStats.data.push("<b>• " + translate(translationKeys.LabelReason) + ":</b> " + item)
+      end for
     end if
 
-    if isValid(sessions) and sessions.Count() > 0
-      m.top.data = { playbackInfo: GetTranscodingStats(sessions[0]) }
-    else
-      m.top.data = { playbackInfo: [translate(translationKeys.ErrorUnableToGetPlaybackInformation)] }
-    end if
-  end sub
-
-  function GetTranscodingStats(deviceSession)
-    sessionStats = { data: [] }
-
-    if isValid(deviceSession.TranscodingInfo) and deviceSession.TranscodingInfo.Count() > 0
-      transcodingReasons = deviceSession.TranscodingInfo.TranscodeReasons
-      videoCodec = deviceSession.TranscodingInfo.VideoCodec
-      audioCodec = deviceSession.TranscodingInfo.AudioCodec
-      totalBitrate = deviceSession.TranscodingInfo.Bitrate
-      audioChannels = deviceSession.TranscodingInfo.AudioChannels
-
-      if isValid(transcodingReasons) and transcodingReasons.Count() > 0
-        sessionStats.data.push("<header>" + translate(translationKeys.LabelTranscodingInformation) + "</header>")
-        for each item in transcodingReasons
-          sessionStats.data.push("<b>• " + translate(translationKeys.LabelReason) + ":</b> " + item)
-        end for
+    if isValid(videoCodec)
+      data = "<b>• " + translate(translationKeys.LabelVideoCodec) + ":</b> " + videoCodec
+      if deviceSession.TranscodingInfo.IsVideoDirect
+        data = data + " (" + translate(translationKeys.LabelDirect) + ")"
       end if
-
-      if isValid(videoCodec)
-        data = "<b>• " + translate(translationKeys.LabelVideoCodec) + ":</b> " + videoCodec
-        if deviceSession.TranscodingInfo.IsVideoDirect
-          data = data + " (" + translate(translationKeys.LabelDirect) + ")"
-        end if
-        sessionStats.data.push(data)
-      end if
-
-      if isValid(audioCodec)
-        data = "<b>• " + translate(translationKeys.LabelAudioCodec) + ":</b> " + audioCodec
-        if deviceSession.TranscodingInfo.IsAudioDirect
-          data = data + " (" + translate(translationKeys.LabelDirect) + ")"
-        end if
-        sessionStats.data.push(data)
-      end if
-
-      if isValid(totalBitrate)
-        data = "<b>• " + translate(translationKeys.LabelTotalBitrate) + ":</b> " + getDisplayBitrate(totalBitrate)
-        sessionStats.data.push(data)
-      end if
-
-      if isValid(audioChannels)
-        data = "<b>• " + translate(translationKeys.LabelAudioChannels) + ":</b> " + Str(audioChannels)
-        sessionStats.data.push(data)
-      end if
-    else
-      sessionStats.data.push("<header>" + translate(translationKeys.LabelDirectPlaying) + "</header>")
-      sessionStats.data.push("<b>" + translate(translationKeys.MessageTheSourceFileIsEntirelyCompatible) + "</b>")
+      sessionStats.data.push(data)
     end if
 
-    if havePlaybackInfo()
-      ' Find the first video stream (MediaStreams[0] might be subtitle/audio)
-      videoStream = getFirstVideoStream(m.playbackInfo.mediaSources[0].MediaStreams)
-      if not isValid(videoStream)
-        ' No video stream found - skip Stream Information section
-        return sessionStats
+    if isValid(audioCodec)
+      data = "<b>• " + translate(translationKeys.LabelAudioCodec) + ":</b> " + audioCodec
+      if deviceSession.TranscodingInfo.IsAudioDirect
+        data = data + " (" + translate(translationKeys.LabelDirect) + ")"
       end if
-
-      stream = videoStream
-      sessionStats.data.push("<header>" + translate(translationKeys.LabelStreamInformation) + "</header>")
-      if isValid(stream.Container)
-        data = "<b>• " + translate(translationKeys.LabelContainer) + ":</b> " + stream.Container
-        sessionStats.data.push(data)
-      end if
-      if isValid(stream.Size)
-        data = "<b>• " + translate(translationKeys.LabelSize) + ":</b> " + stream.Size
-        sessionStats.data.push(data)
-      end if
-      if isValid(stream.BitRate)
-        data = "<b>• " + translate(translationKeys.LabelBitRate) + ":</b> " + getDisplayBitrate(stream.BitRate)
-        sessionStats.data.push(data)
-      end if
-      if isValid(stream.Codec)
-        data = "<b>• " + translate(translationKeys.LabelCodec) + ":</b> " + stream.Codec
-        sessionStats.data.push(data)
-      end if
-      if isValid(stream.CodecTag)
-        data = "<b>• " + translate(translationKeys.LabelCodecTag) + ":</b> " + stream.CodecTag
-        sessionStats.data.push(data)
-      end if
-      if isValid(stream.VideoRangeType)
-        data = "<b>• " + translate(translationKeys.LabelVideoRangeType) + ":</b> " + stream.VideoRangeType
-        sessionStats.data.push(data)
-      end if
-      if isValid(stream.PixelFormat)
-        data = "<b>• " + translate(translationKeys.LabelPixelFormat) + ":</b> " + stream.PixelFormat
-        sessionStats.data.push(data)
-      end if
-      if isValid(stream.Width) and isValid(stream.Height)
-        data = "<b>• " + translate(translationKeys.LabelWxh) + ":</b> " + Str(stream.Width) + " x " + Str(stream.Height)
-        sessionStats.data.push(data)
-      end if
-      if isValid(stream.Level)
-        data = "<b>• " + translate(translationKeys.LabelLevel) + ":</b> " + Str(stream.Level)
-        sessionStats.data.push(data)
-      end if
+      sessionStats.data.push(data)
     end if
 
-    return sessionStats
-  end function
-
-  function havePlaybackInfo()
-    if not isValid(m.playbackInfo)
-      return false
+    if isValid(totalBitrate)
+      data = "<b>• " + translate(translationKeys.LabelTotalBitrate) + ":</b> " + getDisplayBitrate(totalBitrate)
+      sessionStats.data.push(data)
     end if
 
-    if not isValid(m.playbackInfo.mediaSources)
-      return false
+    if isValid(audioChannels)
+      data = "<b>• " + translate(translationKeys.LabelAudioChannels) + ":</b> " + Str(audioChannels)
+      sessionStats.data.push(data)
+    end if
+  else
+    sessionStats.data.push("<header>" + translate(translationKeys.LabelDirectPlaying) + "</header>")
+    sessionStats.data.push("<b>" + translate(translationKeys.MessageTheSourceFileIsEntirelyCompatible) + "</b>")
+  end if
+
+  if havePlaybackInfo()
+    ' Find the first video stream (MediaStreams[0] might be subtitle/audio)
+    videoStream = getFirstVideoStream(m.playbackInfo.mediaSources[0].MediaStreams)
+    if not isValid(videoStream)
+      ' No video stream found - skip Stream Information section
+      return sessionStats
     end if
 
-    if m.playbackInfo.mediaSources.Count() <= 0
-      return false
+    stream = videoStream
+    sessionStats.data.push("<header>" + translate(translationKeys.LabelStreamInformation) + "</header>")
+    if isValid(stream.Container)
+      data = "<b>• " + translate(translationKeys.LabelContainer) + ":</b> " + stream.Container
+      sessionStats.data.push(data)
     end if
-
-    if not isValid(m.playbackInfo.mediaSources[0].MediaStreams)
-      return false
+    if isValid(stream.Size)
+      data = "<b>• " + translate(translationKeys.LabelSize) + ":</b> " + stream.Size
+      sessionStats.data.push(data)
     end if
-
-    if m.playbackInfo.mediaSources[0].MediaStreams.Count() <= 0
-      return false
+    if isValid(stream.BitRate)
+      data = "<b>• " + translate(translationKeys.LabelBitRate) + ":</b> " + getDisplayBitrate(stream.BitRate)
+      sessionStats.data.push(data)
     end if
-
-    return true
-  end function
-
-  function getDisplayBitrate(bitrate)
-    if bitrate > 1000000
-      return Str(Fix(bitrate / 1000000)) + " Mbps"
-    else
-      return Str(Fix(bitrate / 1000)) + " Kbps"
+    if isValid(stream.Codec)
+      data = "<b>• " + translate(translationKeys.LabelCodec) + ":</b> " + stream.Codec
+      sessionStats.data.push(data)
     end if
-  end function
+    if isValid(stream.CodecTag)
+      data = "<b>• " + translate(translationKeys.LabelCodecTag) + ":</b> " + stream.CodecTag
+      sessionStats.data.push(data)
+    end if
+    if isValid(stream.VideoRangeType)
+      data = "<b>• " + translate(translationKeys.LabelVideoRangeType) + ":</b> " + stream.VideoRangeType
+      sessionStats.data.push(data)
+    end if
+    if isValid(stream.PixelFormat)
+      data = "<b>• " + translate(translationKeys.LabelPixelFormat) + ":</b> " + stream.PixelFormat
+      sessionStats.data.push(data)
+    end if
+    if isValid(stream.Width) and isValid(stream.Height)
+      data = "<b>• " + translate(translationKeys.LabelWxh) + ":</b> " + Str(stream.Width) + " x " + Str(stream.Height)
+      sessionStats.data.push(data)
+    end if
+    if isValid(stream.Level)
+      data = "<b>• " + translate(translationKeys.LabelLevel) + ":</b> " + Str(stream.Level)
+      sessionStats.data.push(data)
+    end if
+  end if
+
+  return sessionStats
+end function
+
+function havePlaybackInfo()
+  if not isValid(m.playbackInfo)
+    return false
+  end if
+
+  if not isValid(m.playbackInfo.mediaSources)
+    return false
+  end if
+
+  if m.playbackInfo.mediaSources.Count() <= 0
+    return false
+  end if
+
+  if not isValid(m.playbackInfo.mediaSources[0].MediaStreams)
+    return false
+  end if
+
+  if m.playbackInfo.mediaSources[0].MediaStreams.Count() <= 0
+    return false
+  end if
+
+  return true
+end function
+
+function getDisplayBitrate(bitrate)
+  if bitrate > 1000000
+    return Str(Fix(bitrate / 1000000)) + " Mbps"
+  else
+    return Str(Fix(bitrate / 1000)) + " Kbps"
+  end if
+end function

--- a/components/GetShuffleItemsTask.bs
+++ b/components/GetShuffleItemsTask.bs
@@ -24,59 +24,59 @@ sub getShuffleItems()
   else if input.type = "Person"
     ' Movies featuring this person (rewatching is fine)
     moviesData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-        personIds: input.id,
-        recursive: true,
-        includeItemTypes: "Movie",
-        Limit: 250
+      personIds: input.id,
+      recursive: true,
+      includeItemTypes: "Movie",
+      Limit: 250
     }), "shufflePersonMovies")
     ' Watched episodes/recordings only — avoids spoiling in-progress shows
     episodesData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-        personIds: input.id,
-        recursive: true,
-        includeItemTypes: "Episode,Recording",
-        isPlayed: true,
-        Limit: 250
+      personIds: input.id,
+      recursive: true,
+      includeItemTypes: "Episode,Recording",
+      isPlayed: true,
+      Limit: 250
     }), "shufflePersonEpisodes")
     if isValid(moviesData) and isValid(moviesData.Items) then items.append(moviesData.Items)
     if isValid(episodesData) and isValid(episodesData.Items) then items.append(episodesData.Items)
 
   else if input.type = "BoxSet"
     data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-        "ParentId": input.id,
-        "SortBy": "Random",
-        "Limit": 200,
-        "EnableTotalRecordCount": false
+      "ParentId": input.id,
+      "SortBy": "Random",
+      "Limit": 200,
+      "EnableTotalRecordCount": false
     }), "shuffleBoxSet")
     if isValid(data) and isValid(data.Items) then items = data.Items
 
   else if input.type = "MusicArtist"
     data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-        "ArtistIds": input.id,
-        "includeitemtypes": "Audio",
-        "SortBy": "Random",
-        "Recursive": true,
-        "Limit": 200,
-        "EnableTotalRecordCount": false
+      "ArtistIds": input.id,
+      "includeitemtypes": "Audio",
+      "SortBy": "Random",
+      "Recursive": true,
+      "Limit": 200,
+      "EnableTotalRecordCount": false
     }), "shuffleArtist")
     if isValid(data) and isValid(data.Items) then items = data.Items
 
   else if input.type = "MusicAlbum"
     data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-        "parentId": input.id,
-        "includeitemtypes": "Audio",
-        "SortBy": "SortName",
-        "Limit": 200,
-        "EnableTotalRecordCount": false
+      "parentId": input.id,
+      "includeitemtypes": "Audio",
+      "SortBy": "SortName",
+      "Limit": 200,
+      "EnableTotalRecordCount": false
     }), "shuffleAlbum")
     if isValid(data) and isValid(data.Items) then items = data.Items
 
   else if input.type = "Playlist"
     data = fetchJson(GetApi().BuildGetPlaylistItemsRequest(input.id, {
-          "Limit": 500,
-          "EnableTotalRecordCount": false
-      }), "shufflePlaylist")
-      if isValid(data) and isValid(data.Items) then items = data.Items
-    end if
+      "Limit": 500,
+      "EnableTotalRecordCount": false
+    }), "shufflePlaylist")
+    if isValid(data) and isValid(data.Items) then items = data.Items
+  end if
 
-    m.top.shuffleItems = items
-  end sub
+  m.top.shuffleItems = items
+end sub

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -679,14 +679,14 @@ sub addNextEpisodesToQueue(showID)
   end if
 
   data = fetchJson(GetApi().BuildGetEpisodesRequest(showID, {
-        "StartItemId": videoID,
-        "Limit": 50
-    }), "nextEpisodes")
+    "StartItemId": videoID,
+    "Limit": 50
+  }), "nextEpisodes")
 
-    if isValid(data) and data.Items.Count() > 1
-      ' Start at index 1 to skip the current episode
-      for i = 1 to data.Items.Count() - 1
-        queueManager.callFunc("push", nodeHelpers.createQueueItem(data.Items[i]))
-      end for
-    end if
-  end sub
+  if isValid(data) and data.Items.Count() > 1
+    ' Start at index 1 to skip the current episode
+    for i = 1 to data.Items.Count() - 1
+      queueManager.callFunc("push", nodeHelpers.createQueueItem(data.Items[i]))
+    end for
+  end if
+end sub

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -136,10 +136,10 @@ sub loadItems()
 
     ' People — favorited persons are not returned by /Items; requires /Persons endpoint.
     personData = fetchJson(GetApi().BuildGetPersonsRequest({
-        "IsFavorite": true,
-        "SortBy": "SortName",
-        "SortOrder": "Ascending",
-        "EnableTotalRecordCount": false
+      "IsFavorite": true,
+      "SortBy": "SortName",
+      "SortOrder": "Ascending",
+      "EnableTotalRecordCount": false
     }), "favoritePeople")
     if isValid(personData) and isValid(personData.Items)
       for each item in personData.Items
@@ -241,189 +241,189 @@ sub loadItems()
       return
     end if
     data = fetchJson(GetApi().BuildGetEpisodesRequest(m.top.itemId, {
-          SeasonId: m.top.metadata.seasonId,
-          Fields: "PrimaryImageAspectRatio,Overview",
-          EnableImages: true
-      }), "seasonEpisodes")
-      if isValid(data) and isValid(data.Items)
-        for each item in data.Items
-          node = m.transformer.transformBaseItem(item)
-          if isValid(node) then results.push(node)
-        end for
-      end if
-    else if m.top.itemsToLoad = "seriesFirstEpisode"
-      data = fetchJson(GetApi().BuildGetEpisodesRequest(m.top.itemId, { Limit: 1, SortBy: "IndexNumber,SortName", SortOrder: "Ascending" }), "seriesFirstEpisode")
-      if isValid(data) and isValid(data.Items) and data.Items.count() > 0
-        node = m.transformer.transformBaseItem(data.Items[0])
+      SeasonId: m.top.metadata.seasonId,
+      Fields: "PrimaryImageAspectRatio,Overview",
+      EnableImages: true
+    }), "seasonEpisodes")
+    if isValid(data) and isValid(data.Items)
+      for each item in data.Items
+        node = m.transformer.transformBaseItem(item)
+        if isValid(node) then results.push(node)
+      end for
+    end if
+  else if m.top.itemsToLoad = "seriesFirstEpisode"
+    data = fetchJson(GetApi().BuildGetEpisodesRequest(m.top.itemId, { Limit: 1, SortBy: "IndexNumber,SortName", SortOrder: "Ascending" }), "seriesFirstEpisode")
+    if isValid(data) and isValid(data.Items) and data.Items.count() > 0
+      node = m.transformer.transformBaseItem(data.Items[0])
+      if isValid(node) then results.push(node)
+    end if
+  else if m.top.itemsToLoad = "seriesResume"
+    ' For the series Resume button, prefer an in-progress (resumable) episode and fall back to the next unstarted episode.
+    ' Uses the same endpoint as the Continue Watching home row so the Resume button is consistent with it.
+    resumeData = fetchJson(GetApi().BuildGetResumeItemsRequest({
+      ParentId: m.top.itemId,
+      Filters: "IsResumable",
+      SortBy: "DatePlayed",
+      SortOrder: "Descending",
+      Limit: 1,
+      recursive: true,
+      Fields: "PrimaryImageAspectRatio",
+      EnableTotalRecordCount: false
+    }), "seriesResume")
+    if isValid(resumeData) and isValid(resumeData.Items) and resumeData.Items.Count() > 0
+      node = m.transformer.transformBaseItem(resumeData.Items[0])
+      if isValid(node) then results.push(node)
+    else
+      ' No resumable episode — fall back to next unstarted episode.
+      ' DisableFirstEpisode: true so a Resume button never appears for a completely unwatched series.
+      nextUpData = fetchJson(GetApi().BuildGetNextUpRequest({ SeriesId: m.top.itemId, Limit: 1, DisableFirstEpisode: true, Fields: "PrimaryImageAspectRatio" }), "seriesNextUp")
+      if isValid(nextUpData) and isValid(nextUpData.Items) and nextUpData.Items.Count() > 0
+        node = m.transformer.transformBaseItem(nextUpData.Items[0])
         if isValid(node) then results.push(node)
       end if
-    else if m.top.itemsToLoad = "seriesResume"
-      ' For the series Resume button, prefer an in-progress (resumable) episode and fall back to the next unstarted episode.
-      ' Uses the same endpoint as the Continue Watching home row so the Resume button is consistent with it.
-      resumeData = fetchJson(GetApi().BuildGetResumeItemsRequest({
-          ParentId: m.top.itemId,
-          Filters: "IsResumable",
-          SortBy: "DatePlayed",
-          SortOrder: "Descending",
-          Limit: 1,
-          recursive: true,
-          Fields: "PrimaryImageAspectRatio",
-          EnableTotalRecordCount: false
-      }), "seriesResume")
-      if isValid(resumeData) and isValid(resumeData.Items) and resumeData.Items.Count() > 0
-        node = m.transformer.transformBaseItem(resumeData.Items[0])
+    end if
+  else if m.top.itemsToLoad = "metaData"
+    results.push(ItemMetaData(m.top.itemId))
+  else if m.top.itemsToLoad = "metaDataDetails"
+    results.push(ItemDetailsMetaData(m.top.itemId, m.top.shouldForceRefresh))
+  else if m.top.itemsToLoad = "audioStream"
+    results.push(AudioStream(m.top.itemId))
+  else if m.top.itemsToLoad = "backdropImage"
+    results.push(BackdropImage(m.top.itemId))
+  else if m.top.itemsToLoad = "boxsetitems"
+    data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+      "ParentId": m.top.itemId,
+      "SortBy": "PremiereDate,ProductionYear,SortName",
+      "SortOrder": "Ascending",
+      "Fields": "PrimaryImageAspectRatio,Overview",
+      "EnableTotalRecordCount": false
+    }), "boxsetitems")
+    if isValid(data) and isValid(data.Items)
+      for each item in data.Items
+        node = m.transformer.transformBaseItem(item)
         if isValid(node) then results.push(node)
-      else
-        ' No resumable episode — fall back to next unstarted episode.
-        ' DisableFirstEpisode: true so a Resume button never appears for a completely unwatched series.
-        nextUpData = fetchJson(GetApi().BuildGetNextUpRequest({ SeriesId: m.top.itemId, Limit: 1, DisableFirstEpisode: true, Fields: "PrimaryImageAspectRatio" }), "seriesNextUp")
-        if isValid(nextUpData) and isValid(nextUpData.Items) and nextUpData.Items.Count() > 0
-          node = m.transformer.transformBaseItem(nextUpData.Items[0])
-          if isValid(node) then results.push(node)
+      end for
+    end if
+  else if m.top.itemsToLoad = "artistAlbums"
+    ' Albums where this artist is the album artist (AlbumArtistIds), sorted by year descending
+    data = MusicAlbumList(m.top.itemId)
+    if isValid(data) and isValid(data.Items)
+      for each item in data.Items
+        results.push(item)
+      end for
+    end if
+  else if m.top.itemsToLoad = "artistAppearsOn"
+    ' Albums where this artist contributes (ContributingArtistIds) but is not the album artist
+    data = AppearsOnList(m.top.itemId)
+    if isValid(data) and isValid(data.Items)
+      for each item in data.Items
+        results.push(item)
+      end for
+    end if
+  else if m.top.itemsToLoad = "albumSongs"
+    ' All Audio tracks under a MusicAlbum, sorted by track number
+    data = MusicSongList(m.top.itemId)
+    if isValid(data) and isValid(data.Items)
+      for each item in data.Items
+        results.push(item)
+      end for
+    end if
+  else if m.top.itemsToLoad = "lyrics"
+    ' Fetch lyrics for an Audio item and join lines into a single string.
+    ' Returns a one-element array containing the lyrics string, or empty on failure.
+    lyricsData = GetItemLyrics(m.top.itemId)
+    if isValid(lyricsData) and isValid(lyricsData.Lyrics)
+      lines = []
+      for each lyric in lyricsData.Lyrics
+        if isValid(lyric.Text) and lyric.Text <> ""
+          lines.push(lyric.Text)
         end if
+      end for
+      if lines.count() > 0
+        results.push(lines.join(Chr(10)))
       end if
-    else if m.top.itemsToLoad = "metaData"
-      results.push(ItemMetaData(m.top.itemId))
-    else if m.top.itemsToLoad = "metaDataDetails"
-      results.push(ItemDetailsMetaData(m.top.itemId, m.top.shouldForceRefresh))
-    else if m.top.itemsToLoad = "audioStream"
-      results.push(AudioStream(m.top.itemId))
-    else if m.top.itemsToLoad = "backdropImage"
-      results.push(BackdropImage(m.top.itemId))
-    else if m.top.itemsToLoad = "boxsetitems"
-      data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-          "ParentId": m.top.itemId,
-          "SortBy": "PremiereDate,ProductionYear,SortName",
-          "SortOrder": "Ascending",
-          "Fields": "PrimaryImageAspectRatio,Overview",
-          "EnableTotalRecordCount": false
-      }), "boxsetitems")
-      if isValid(data) and isValid(data.Items)
-        for each item in data.Items
-          node = m.transformer.transformBaseItem(item)
-          if isValid(node) then results.push(node)
-        end for
-      end if
-    else if m.top.itemsToLoad = "artistAlbums"
-      ' Albums where this artist is the album artist (AlbumArtistIds), sorted by year descending
-      data = MusicAlbumList(m.top.itemId)
-      if isValid(data) and isValid(data.Items)
-        for each item in data.Items
-          results.push(item)
-        end for
-      end if
-    else if m.top.itemsToLoad = "artistAppearsOn"
-      ' Albums where this artist contributes (ContributingArtistIds) but is not the album artist
-      data = AppearsOnList(m.top.itemId)
-      if isValid(data) and isValid(data.Items)
-        for each item in data.Items
-          results.push(item)
-        end for
-      end if
-    else if m.top.itemsToLoad = "albumSongs"
-      ' All Audio tracks under a MusicAlbum, sorted by track number
-      data = MusicSongList(m.top.itemId)
-      if isValid(data) and isValid(data.Items)
-        for each item in data.Items
-          results.push(item)
-        end for
-      end if
-    else if m.top.itemsToLoad = "lyrics"
-      ' Fetch lyrics for an Audio item and join lines into a single string.
-      ' Returns a one-element array containing the lyrics string, or empty on failure.
-      lyricsData = GetItemLyrics(m.top.itemId)
-      if isValid(lyricsData) and isValid(lyricsData.Lyrics)
-        lines = []
-        for each lyric in lyricsData.Lyrics
-          if isValid(lyric.Text) and lyric.Text <> ""
-            lines.push(lyric.Text)
-          end if
-        end for
-        if lines.count() > 0
-          results.push(lines.join(Chr(10)))
-        end if
-      end if
-    else if m.top.itemsToLoad = "artistSimilar"
-      ' Similar artists via the artist-specific endpoint (more reliable than Items/{id}/Similar for MusicArtist)
-      params = { "userId": globalUser.id, "limit": 16 }
-      data = fetchJson(GetApi().BuildGetArtistSimilarRequest(m.top.itemId, params), "artistSimilar")
-      if isValid(data) and isValid(data.Items)
-        for each item in data.Items
-          node = m.transformer.transformBaseItem(item)
-          if isValid(node) then results.push(node)
-        end for
-      end if
-    else if m.top.itemsToLoad = "artistSongs"
-      ' All Audio tracks by this artist (ArtistIds = any capacity: album artist OR contributing).
-      ' Sorted by album then track number so songs group naturally even without album rows.
-      ' Limit 100 to avoid overwhelming the row for prolific artists.
-      data = GetSongsByArtistBroad(m.top.itemId)
-      if isValid(data) and isValid(data.Items)
-        for each item in data.Items
-          results.push(item)
-        end for
-      end if
-    else if m.top.itemsToLoad = "playlistItems"
-      ' All items in a Playlist, sorted newest-added first.
-      data = fetchJson(GetApi().BuildGetPlaylistItemsRequest(m.top.itemId, {
-            "SortBy": "DateCreated",
-            "SortOrder": "Descending",
-            "Fields": "PrimaryImageAspectRatio,Overview",
-            "EnableTotalRecordCount": false
-        }), "playlistItems")
-        if isValid(data) and isValid(data.Items)
-          for each item in data.Items
-            node = m.transformer.transformBaseItem(item)
-            if isValid(node) then results.push(node)
-          end for
-        end if
-      else if m.top.itemsToLoad = "photoAlbumItems"
-        ' All photos in a PhotoAlbum, sorted by name.
-        data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-            "ParentId": m.top.itemId,
-            "IncludeItemTypes": "Photo",
-            "SortBy": "SortName",
-            "SortOrder": "Ascending",
-            "Fields": "PrimaryImageAspectRatio",
-            "EnableTotalRecordCount": false
-        }), "photoAlbumItems")
-        if isValid(data) and isValid(data.Items)
-          for each item in data.Items
-            node = m.transformer.transformBaseItem(item)
-            if isValid(node) then results.push(node)
-          end for
-        end if
-      else if m.top.itemsToLoad = "channelPrograms"
-        ' Upcoming (not yet aired) programs on a Live TV channel, sorted by start time.
-        ' ChannelInfo required for subtitle display (channel name) in JRRowItem.
-        data = fetchJson(GetApi().BuildGetLiveTVProgramsRequest({
-            "ChannelIds": m.top.itemId,
-            "HasAired": false,
-            "SortBy": "StartDate",
-            "SortOrder": "Ascending",
-            "Limit": 20,
-            "Fields": "ChannelInfo,PrimaryImageAspectRatio,Overview",
-            "EnableTotalRecordCount": false
-        }), "channelPrograms")
-        if isValid(data) and isValid(data.Items)
-          for each item in data.Items
-            node = m.transformer.transformBaseItem(item)
-            if isValid(node) then results.push(node)
-          end for
-        end if
-      end if
+    end if
+  else if m.top.itemsToLoad = "artistSimilar"
+    ' Similar artists via the artist-specific endpoint (more reliable than Items/{id}/Similar for MusicArtist)
+    params = { "userId": globalUser.id, "limit": 16 }
+    data = fetchJson(GetApi().BuildGetArtistSimilarRequest(m.top.itemId, params), "artistSimilar")
+    if isValid(data) and isValid(data.Items)
+      for each item in data.Items
+        node = m.transformer.transformBaseItem(item)
+        if isValid(node) then results.push(node)
+      end for
+    end if
+  else if m.top.itemsToLoad = "artistSongs"
+    ' All Audio tracks by this artist (ArtistIds = any capacity: album artist OR contributing).
+    ' Sorted by album then track number so songs group naturally even without album rows.
+    ' Limit 100 to avoid overwhelming the row for prolific artists.
+    data = GetSongsByArtistBroad(m.top.itemId)
+    if isValid(data) and isValid(data.Items)
+      for each item in data.Items
+        results.push(item)
+      end for
+    end if
+  else if m.top.itemsToLoad = "playlistItems"
+    ' All items in a Playlist, sorted newest-added first.
+    data = fetchJson(GetApi().BuildGetPlaylistItemsRequest(m.top.itemId, {
+      "SortBy": "DateCreated",
+      "SortOrder": "Descending",
+      "Fields": "PrimaryImageAspectRatio,Overview",
+      "EnableTotalRecordCount": false
+    }), "playlistItems")
+    if isValid(data) and isValid(data.Items)
+      for each item in data.Items
+        node = m.transformer.transformBaseItem(item)
+        if isValid(node) then results.push(node)
+      end for
+    end if
+  else if m.top.itemsToLoad = "photoAlbumItems"
+    ' All photos in a PhotoAlbum, sorted by name.
+    data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+      "ParentId": m.top.itemId,
+      "IncludeItemTypes": "Photo",
+      "SortBy": "SortName",
+      "SortOrder": "Ascending",
+      "Fields": "PrimaryImageAspectRatio",
+      "EnableTotalRecordCount": false
+    }), "photoAlbumItems")
+    if isValid(data) and isValid(data.Items)
+      for each item in data.Items
+        node = m.transformer.transformBaseItem(item)
+        if isValid(node) then results.push(node)
+      end for
+    end if
+  else if m.top.itemsToLoad = "channelPrograms"
+    ' Upcoming (not yet aired) programs on a Live TV channel, sorted by start time.
+    ' ChannelInfo required for subtitle display (channel name) in JRRowItem.
+    data = fetchJson(GetApi().BuildGetLiveTVProgramsRequest({
+      "ChannelIds": m.top.itemId,
+      "HasAired": false,
+      "SortBy": "StartDate",
+      "SortOrder": "Ascending",
+      "Limit": 20,
+      "Fields": "ChannelInfo,PrimaryImageAspectRatio,Overview",
+      "EnableTotalRecordCount": false
+    }), "channelPrograms")
+    if isValid(data) and isValid(data.Items)
+      for each item in data.Items
+        node = m.transformer.transformBaseItem(item)
+        if isValid(node) then results.push(node)
+      end for
+    end if
+  end if
 
-      m.top.content = results
+  m.top.content = results
 
-    end sub
+end sub
 
-    sub getPersonVideos(videoType as string, dest as object)
-      params = { personIds: m.top.itemId, recursive: true, includeItemTypes: videoType, Limit: 50, SortBy: "Random" }
-      data = fetchJson(GetApi().BuildGetItemsByQueryRequest(params), "personVideos_" + videoType)
-      if isValid(data) and data.count() > 0
-        for each item in data.items
-          node = m.transformer.transformBaseItem(item)
-          if isValid(node) then dest.push(node)
-        end for
-      end if
-    end sub
+sub getPersonVideos(videoType as string, dest as object)
+  params = { personIds: m.top.itemId, recursive: true, includeItemTypes: videoType, Limit: 50, SortBy: "Random" }
+  data = fetchJson(GetApi().BuildGetItemsByQueryRequest(params), "personVideos_" + videoType)
+  if isValid(data) and data.count() > 0
+    for each item in data.items
+      node = m.transformer.transformBaseItem(item)
+      if isValid(node) then dest.push(node)
+    end for
+  end if
+end sub

--- a/components/search/SearchTask.bs
+++ b/components/search/SearchTask.bs
@@ -25,11 +25,11 @@ function searchMedia(query as string)
   ' Regular library items — Person and MusicArtist are fetched via dedicated endpoints below.
   ' LiveTvProgram is excluded here because /Items EPG search is incomplete; /LiveTv/Programs is used instead.
   data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-      "searchTerm": query,
-      "IncludeItemTypes": "Movie,Series,Episode,Video,MusicVideo,Audio,MusicAlbum,Playlist,LiveTvChannel,PhotoAlbum,Photo,BoxSet",
-      "EnableTotalRecordCount": false,
-      "Recursive": true,
-      "limit": 100
+    "searchTerm": query,
+    "IncludeItemTypes": "Movie,Series,Episode,Video,MusicVideo,Audio,MusicAlbum,Playlist,LiveTvChannel,PhotoAlbum,Photo,BoxSet",
+    "EnableTotalRecordCount": false,
+    "Recursive": true,
+    "limit": 100
   }), "searchItems")
   if isValid(data) and isValid(data.Items)
     for each item in data.Items
@@ -45,9 +45,9 @@ function searchMedia(query as string)
 
   ' People — /Items does not return Person type; /Persons endpoint required.
   personData = fetchJson(GetApi().BuildGetPersonsRequest({
-      "searchTerm": query,
-      "Limit": 20,
-      "EnableTotalRecordCount": false
+    "searchTerm": query,
+    "Limit": 20,
+    "EnableTotalRecordCount": false
   }), "searchPersons")
   if isValid(personData) and isValid(personData.Items)
     for each item in personData.Items
@@ -57,9 +57,9 @@ function searchMedia(query as string)
 
   ' Artists — /Items does not return MusicArtist type; /Artists endpoint required.
   artistData = fetchJson(GetApi().BuildGetArtistsRequest({
-      "searchTerm": query,
-      "Limit": 20,
-      "EnableTotalRecordCount": false
+    "searchTerm": query,
+    "Limit": 20,
+    "EnableTotalRecordCount": false
   }), "searchArtists")
   if isValid(artistData) and isValid(artistData.Items)
     for each item in artistData.Items
@@ -69,9 +69,9 @@ function searchMedia(query as string)
 
   ' Live TV Programs — /LiveTv/Programs searches the full EPG; /Items only covers recordings.
   programData = fetchJson(GetApi().BuildGetLiveTVProgramsRequest({
-      "SearchTerm": query,
-      "Limit": 20,
-      "EnableTotalRecordCount": false
+    "SearchTerm": query,
+    "Limit": 20,
+    "EnableTotalRecordCount": false
   }), "searchPrograms")
   if isValid(programData) and isValid(programData.Items)
     for each item in programData.Items

--- a/components/tasks/QuickPlayTask.bs
+++ b/components/tasks/QuickPlayTask.bs
@@ -125,12 +125,12 @@ end sub
 
 sub doAlbum(input as object, items as object)
   data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-      "parentId": input.id,
-      "imageTypeLimit": 1,
-      "sortBy": "SortName",
-      "limit": 500,
-      "enableUserData": false,
-      "EnableTotalRecordCount": false
+    "parentId": input.id,
+    "imageTypeLimit": 1,
+    "sortBy": "SortName",
+    "limit": 500,
+    "enableUserData": false,
+    "EnableTotalRecordCount": false
   }), "qp_album")
   if isValid(data) and isValidAndNotEmpty(data.items)
     items.append(data.items)
@@ -139,14 +139,14 @@ end sub
 
 sub doArtist(input as object, items as object)
   data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-      "artistIds": input.id,
-      "includeItemTypes": "Audio",
-      "sortBy": "Album",
-      "limit": 500,
-      "imageTypeLimit": 1,
-      "Recursive": true,
-      "enableUserData": false,
-      "EnableTotalRecordCount": false
+    "artistIds": input.id,
+    "includeItemTypes": "Audio",
+    "sortBy": "Album",
+    "limit": 500,
+    "imageTypeLimit": 1,
+    "Recursive": true,
+    "enableUserData": false,
+    "EnableTotalRecordCount": false
   }), "qp_artist")
   if isValid(data) and isValidAndNotEmpty(data.items)
     items.append(data.items)
@@ -155,9 +155,9 @@ end sub
 
 sub doBoxset(input as object, items as object)
   data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-      "parentid": input.id,
-      "limit": 500,
-      "EnableTotalRecordCount": false
+    "parentid": input.id,
+    "limit": 500,
+    "EnableTotalRecordCount": false
   }), "qp_boxset")
   if isValid(data) and isValidAndNotEmpty(data.Items)
     items.append(data.Items)
@@ -170,14 +170,14 @@ function doSeries(input as object, items as object) as longinteger
 
   ' Check for a resumable (in-progress) episode first
   resumeData = fetchJson(GetApi().BuildGetResumeItemsRequest({
-      "parentId": input.id,
-      "Filters": "IsResumable",
-      "SortBy": "DatePlayed",
-      "SortOrder": "Descending",
-      "Limit": 1,
-      "recursive": true,
-      "ImageTypeLimit": 1,
-      "EnableTotalRecordCount": false
+    "parentId": input.id,
+    "Filters": "IsResumable",
+    "SortBy": "DatePlayed",
+    "SortOrder": "Descending",
+    "Limit": 1,
+    "recursive": true,
+    "ImageTypeLimit": 1,
+    "EnableTotalRecordCount": false
   }), "qp_seriesResume")
 
   if isValid(resumeData) and isValidAndNotEmpty(resumeData.Items)
@@ -189,12 +189,12 @@ function doSeries(input as object, items as object) as longinteger
   else
     ' Fall back to next unstarted episode
     data = fetchJson(GetApi().BuildGetNextUpRequest({
-        "seriesId": input.id,
-        "Limit": 1,
-        "DisableFirstEpisode": false,
-        "ImageTypeLimit": 1,
-        "EnableRewatching": localUser.settings.uiDetailsEnableRewatchingNextUp,
-        "EnableTotalRecordCount": false
+      "seriesId": input.id,
+      "Limit": 1,
+      "DisableFirstEpisode": false,
+      "ImageTypeLimit": 1,
+      "EnableRewatching": localUser.settings.uiDetailsEnableRewatchingNextUp,
+      "EnableTotalRecordCount": false
     }), "qp_seriesNextUp")
 
     if isValid(data) and isValidAndNotEmpty(data.Items)
@@ -202,494 +202,494 @@ function doSeries(input as object, items as object) as longinteger
     else
       ' All episodes fully watched and rewatching disabled — shuffle the whole series
       allEps = fetchJson(GetApi().BuildGetEpisodesRequest(input.id, {
-            "SortBy": "Random",
-            "limit": 500,
-            "EnableTotalRecordCount": false
-        }), "qp_seriesShuffle")
-        if isValid(allEps) and isValidAndNotEmpty(allEps.Items)
-          items.append(allEps.Items)
-        end if
+        "SortBy": "Random",
+        "limit": 500,
+        "EnableTotalRecordCount": false
+      }), "qp_seriesShuffle")
+      if isValid(allEps) and isValidAndNotEmpty(allEps.Items)
+        items.append(allEps.Items)
       end if
     end if
+  end if
 
-    return firstItemStartingPoint
-  end function
+  return firstItemStartingPoint
+end function
 
-  function doSeason(input as object, items as object) as longinteger
-    firstItemStartingPoint = 0&
-    seriesId = isValidAndNotEmpty(input.seriesId) ? input.seriesId : ""
-    if seriesId = "" then return 0&
+function doSeason(input as object, items as object) as longinteger
+  firstItemStartingPoint = 0&
+  seriesId = isValidAndNotEmpty(input.seriesId) ? input.seriesId : ""
+  if seriesId = "" then return 0&
 
-    episodesData = fetchJson(GetApi().BuildGetEpisodesRequest(seriesId, {
-          "seasonId": input.id,
-          "limit": 500,
-          "EnableTotalRecordCount": false
-      }), "qp_seasonEps")
+  episodesData = fetchJson(GetApi().BuildGetEpisodesRequest(seriesId, {
+    "seasonId": input.id,
+    "limit": 500,
+    "EnableTotalRecordCount": false
+  }), "qp_seasonEps")
 
-      if isValid(episodesData) and isValidAndNotEmpty(episodesData.Items)
-        ' find the first unwatched episode
-        firstUnwatchedIndex = invalid
-        resumePosition = 0&
-        for each item in episodesData.Items
-          if isValid(item.UserData)
-            if isValid(item.UserData.Played) and item.UserData.Played = false
-              firstUnwatchedIndex = isValid(item.IndexNumber) ? item.IndexNumber - 1 : 0
-              if isValid(item.UserData.PlaybackPositionTicks)
-                resumePosition = item.UserData.PlaybackPositionTicks
-              end if
-              exit for
-            end if
+  if isValid(episodesData) and isValidAndNotEmpty(episodesData.Items)
+    ' find the first unwatched episode
+    firstUnwatchedIndex = invalid
+    resumePosition = 0&
+    for each item in episodesData.Items
+      if isValid(item.UserData)
+        if isValid(item.UserData.Played) and item.UserData.Played = false
+          firstUnwatchedIndex = isValid(item.IndexNumber) ? item.IndexNumber - 1 : 0
+          if isValid(item.UserData.PlaybackPositionTicks)
+            resumePosition = item.UserData.PlaybackPositionTicks
           end if
+          exit for
+        end if
+      end if
+    end for
+
+    if isValid(firstUnwatchedIndex)
+      for i = firstUnwatchedIndex to episodesData.Items.count() - 1
+        items.push(episodesData.Items[i])
+      end for
+      firstItemStartingPoint = resumePosition
+    else
+      ' try to find a "continue watching" episode
+      continueData = fetchJson(GetApi().BuildGetResumeItemsRequest({
+        "parentId": input.id,
+        "SortBy": "DatePlayed",
+        "recursive": true,
+        "SortOrder": "Descending",
+        "Filters": "IsResumable",
+        "EnableTotalRecordCount": false
+      }), "qp_seasonContinue")
+
+      if isValid(continueData) and isValidAndNotEmpty(continueData.Items)
+        for each item in continueData.Items
+          items.push(item)
         end for
+        ' Set starting point for the first resumable episode
+        firstEp = continueData.Items[0]
+        if isValid(firstEp.UserData) and isValid(firstEp.UserData.PlaybackPositionTicks)
+          firstItemStartingPoint = firstEp.UserData.PlaybackPositionTicks
+        end if
+      else
+        ' play the whole season in order
+        items.append(episodesData.Items)
+      end if
+    end if
+  end if
 
-        if isValid(firstUnwatchedIndex)
-          for i = firstUnwatchedIndex to episodesData.Items.count() - 1
-            items.push(episodesData.Items[i])
-          end for
-          firstItemStartingPoint = resumePosition
+  return firstItemStartingPoint
+end function
+
+sub doPerson(input as object, items as object)
+  ' get movies by the person
+  personMovies = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+    "personIds": input.id,
+    "includeItemTypes": "Movie",
+    "excludeItemTypes": "Season,Series",
+    "recursive": true,
+    "limit": 500
+  }), "qp_personMovies")
+  if isValid(personMovies) and isValidAndNotEmpty(personMovies.Items)
+    items.append(personMovies.Items)
+  end if
+
+  ' get watched episodes by the person
+  personEpisodes = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+    "personIds": input.id,
+    "includeItemTypes": "Episode,Recording",
+    "isPlayed": true,
+    "excludeItemTypes": "Season,Series",
+    "recursive": true,
+    "limit": 500
+  }), "qp_personEpisodes")
+  if isValid(personEpisodes) and isValidAndNotEmpty(personEpisodes.Items)
+    items.append(personEpisodes.Items)
+  end if
+end sub
+
+sub doPlaylist(input as object, items as object)
+  data = fetchJson(GetApi().BuildGetPlaylistItemsRequest(input.id, {
+    "limit": 500
+  }), "qp_playlist")
+  if isValid(data) and isValidAndNotEmpty(data.Items)
+    items.append(data.Items)
+  end if
+end sub
+
+sub doPhotoAlbum(input as object, items as object)
+  data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+    "parentId": input.id,
+    "includeItemTypes": "Photo",
+    "sortBy": "Random",
+    "Recursive": true
+  }), "qp_photoAlbum")
+  if isValid(data) and isValidAndNotEmpty(data.items)
+    items.append(data.items)
+  end if
+end sub
+
+' --- Folder / CollectionFolder / UserView (complex multi-call) ---
+
+function doFolder(input as object) as dynamic
+  items = []
+  shouldShuffle = true
+  outputAction = "queue"
+
+  paramArray = {
+    "includeItemTypes": "Episode,Recording,Movie,Video",
+    "videoTypes": "VideoFile",
+    "sortBy": "Random",
+    "limit": 500,
+    "imageTypeLimit": 1,
+    "Recursive": true,
+    "enableUserData": false,
+    "EnableTotalRecordCount": false
+  }
+
+  folderType = LCase(isValidAndNotEmpty(input.folderType) ? input.folderType : "")
+  seriesCount = isValid(input.seriesCount) ? input.seriesCount : 0
+
+  if folderType = "studio"
+    paramArray["studioIds"] = input.id
+  else if folderType = "genre"
+    paramArray["genreIds"] = input.id
+    if isValid(input.movieCount) and input.movieCount > 0
+      paramArray["includeItemTypes"] = "Movie"
+    end if
+  else if folderType = "musicgenre"
+    paramArray["genreIds"] = input.id
+    paramArray.delete("videoTypes")
+    paramArray["includeItemTypes"] = "Audio"
+  else if folderType = "photoalbum"
+    paramArray["parentId"] = input.id
+    paramArray["includeItemTypes"] = "Photo"
+    paramArray.delete("videoTypes")
+    paramArray.delete("Recursive")
+  else
+    paramArray["parentId"] = input.id
+  end if
+
+  if seriesCount > 0
+    paramArray["includeItemTypes"] = "Series"
+    paramArray.Delete("videoTypes")
+  end if
+
+  folderData = fetchJson(GetApi().BuildGetItemsByQueryRequest(paramArray), "qp_folder")
+
+  if isValid(folderData) and isValidAndNotEmpty(folderData.items)
+    if seriesCount > 0
+      if seriesCount = 1
+        ' Single series — delegate to series quickplay
+        doSeries({ id: folderData.items[0].Id }, items)
+        shouldShuffle = false
+      else
+        doMultipleSeries(folderData.items, items)
+      end if
+    else
+      if folderType = "photoalbum"
+        outputAction = "photo"
+      end if
+      items.append(folderData.items)
+    end if
+  end if
+
+  return { action: outputAction, items: items, shuffle: shouldShuffle }
+end function
+
+function doCollectionFolder(input as object) as dynamic
+  items = []
+  shouldShuffle = true
+  outputAction = "queue"
+
+  collectionType = LCase(isValidAndNotEmpty(input.collectionType) ? input.collectionType : "")
+
+  if collectionType = "movies"
+    doVideoContainer(input, items)
+    shouldShuffle = false
+  else if collectionType = "music"
+    data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+      "parentId": input.id,
+      "includeItemTypes": "Audio",
+      "sortBy": "Album",
+      "Recursive": true,
+      "limit": 500,
+      "imageTypeLimit": 1,
+      "enableUserData": false,
+      "EnableTotalRecordCount": false
+    }), "qp_collectionMusic")
+    if isValid(data) and isValidAndNotEmpty(data.items)
+      items.append(data.Items)
+    end if
+  else if collectionType = "boxsets"
+    ' pick a random boxset and play its contents
+    boxsetData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+      "parentId": input.id,
+      "limit": 500,
+      "imageTypeLimit": 0,
+      "enableUserData": false,
+      "EnableTotalRecordCount": false,
+      "enableImages": false
+    }), "qp_collectionBoxsets")
+    if isValid(boxsetData) and isValidAndNotEmpty(boxsetData.items)
+      arrayIndex = Rnd(boxsetData.items.count()) - 1
+      myBoxset = boxsetData.items[arrayIndex]
+      innerData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+        "parentId": myBoxset.id,
+        "EnableTotalRecordCount": false
+      }), "qp_collectionBoxsetInner")
+      if isValid(innerData) and isValidAndNotEmpty(innerData.items)
+        items.append(innerData.Items)
+      end if
+    end if
+    shouldShuffle = false
+  else if collectionType = "tvshows" or collectionType = "collectionfolder"
+    doVideoContainer(input, items)
+    shouldShuffle = false
+  else if collectionType = "musicvideos"
+    data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+      "parentId": input.id,
+      "includeItemTypes": "MusicVideo",
+      "sortBy": "Random",
+      "Recursive": true,
+      "limit": 500,
+      "imageTypeLimit": 1,
+      "enableUserData": false,
+      "EnableTotalRecordCount": false
+    }), "qp_collectionMusicVideos")
+    if isValid(data) and isValidAndNotEmpty(data.items)
+      items.append(data.Items)
+    end if
+    shouldShuffle = false
+  else if collectionType = "homevideos"
+    data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+      "parentId": input.id,
+      "includeItemTypes": "Photo",
+      "sortBy": "Random",
+      "Recursive": true
+    }), "qp_collectionPhotos")
+    if isValid(data) and isValidAndNotEmpty(data.items)
+      items.append(data.items)
+      outputAction = "photo"
+    end if
+  end if
+
+  return { action: outputAction, items: items, shuffle: shouldShuffle }
+end function
+
+function doUserView(input as object) as dynamic
+  items = []
+  shouldShuffle = true
+  outputAction = "queue"
+
+  collectionType = LCase(isValidAndNotEmpty(input.collectionType) ? input.collectionType : "")
+
+  if collectionType = "playlists"
+    ' pick a random playlist and play its contents
+    playlistData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+      "parentId": input.id,
+      "imageTypeLimit": 0,
+      "enableUserData": false,
+      "EnableTotalRecordCount": false,
+      "enableImages": false
+    }), "qp_userViewPlaylists")
+    if isValid(playlistData) and isValidAndNotEmpty(playlistData.items)
+      arrayIndex = Rnd(playlistData.items.count()) - 1
+      myPlaylist = playlistData.items[arrayIndex]
+      playlistItems = fetchJson(GetApi().BuildGetPlaylistItemsRequest(myPlaylist.id, {
+        "EnableTotalRecordCount": false,
+        "limit": 500
+      }), "qp_userViewPlaylistItems")
+      if isValid(playlistItems) and isValidAndNotEmpty(playlistItems.items)
+        items.append(playlistItems.items)
+      end if
+    end if
+  else if collectionType = "livetv"
+    ' pick a random channel
+    channelData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+      "includeItemTypes": "TVChannel",
+      "sortBy": "Random",
+      "Recursive": true,
+      "imageTypeLimit": 0,
+      "enableUserData": false,
+      "EnableTotalRecordCount": false,
+      "enableImages": false
+    }), "qp_userViewChannels")
+    if isValid(channelData) and isValidAndNotEmpty(channelData.items)
+      arrayIndex = Rnd(channelData.items.count()) - 1
+      myChannel = channelData.items[arrayIndex]
+      ' Return channel as a queue item with TvChannel type
+      myChannel.Type = "TvChannel"
+      items.push(myChannel)
+    end if
+    shouldShuffle = false
+  else if collectionType = "movies" or collectionType = "tvshows"
+    doVideoContainer(input, items)
+    shouldShuffle = false
+  end if
+
+  return { action: outputAction, items: items, shuffle: shouldShuffle }
+end function
+
+' Helper: video container logic (movies or tvshows collection)
+sub doVideoContainer(input as object, items as object)
+  collectionType = LCase(isValidAndNotEmpty(input.collectionType) ? input.collectionType : "")
+
+  if collectionType = "movies"
+    data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+      "parentId": input.id,
+      "sortBy": "Random",
+      "recursive": true,
+      "includeItemTypes": "Movie,Video",
+      "limit": 500
+    }), "qp_videoContainerMovies")
+    if isValid(data) and isValidAndNotEmpty(data.items)
+      for each item in data.Items
+        ' only add videos we're not currently watching
+        if isValid(item.userdata) and isValid(item.userdata.PlaybackPositionTicks)
+          if item.userdata.PlaybackPositionTicks = 0
+            items.push(item)
+          end if
         else
-          ' try to find a "continue watching" episode
-          continueData = fetchJson(GetApi().BuildGetResumeItemsRequest({
-              "parentId": input.id,
-              "SortBy": "DatePlayed",
-              "recursive": true,
-              "SortOrder": "Descending",
-              "Filters": "IsResumable",
-              "EnableTotalRecordCount": false
-          }), "qp_seasonContinue")
-
-          if isValid(continueData) and isValidAndNotEmpty(continueData.Items)
-            for each item in continueData.Items
-              items.push(item)
-            end for
-            ' Set starting point for the first resumable episode
-            firstEp = continueData.Items[0]
-            if isValid(firstEp.UserData) and isValid(firstEp.UserData.PlaybackPositionTicks)
-              firstItemStartingPoint = firstEp.UserData.PlaybackPositionTicks
-            end if
-          else
-            ' play the whole season in order
-            items.append(episodesData.Items)
-          end if
+          items.push(item)
         end if
+      end for
+    end if
+  else if collectionType = "tvshows" or collectionType = "collectionfolder"
+    tvshowsData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+      "parentId": input.id,
+      "sortBy": "Random",
+      "recursive": true,
+      "excludeItemTypes": "Season",
+      "imageTypeLimit": 0,
+      "enableUserData": false,
+      "EnableTotalRecordCount": false,
+      "enableImages": false
+    }), "qp_videoContainerTvShows")
+    if isValid(tvshowsData) and isValidAndNotEmpty(tvshowsData.items)
+      if tvshowsData.items[0].Type = "Series"
+        doMultipleSeries(tvshowsData.items, items)
+      else
+        items.append(tvshowsData.items)
       end if
+    end if
+  end if
+end sub
 
-      return firstItemStartingPoint
-    end function
+' Helper: shuffle play watched episodes from multiple series
+sub doMultipleSeries(tvshows as object, items as object)
+  numTotal = 0
+  numLimit = 500
+  for each tvshow in tvshows
+    showData = fetchJson(GetApi().BuildGetEpisodesRequest(tvshow.id, {
+      "SortBy": "Random",
+      "imageTypeLimit": 0,
+      "EnableTotalRecordCount": false,
+      "enableImages": false
+    }), "qp_multiSeries_" + tvshow.id)
+    if isValid(showData) and isValidAndNotEmpty(showData.items)
+      for each episode in showData.items
+        if isValid(episode.userdata) and isValid(episode.userdata.Played)
+          if episode.userdata.Played
+            items.push(episode)
+          end if
+        end if
+      end for
+      numTotal = numTotal + showData.items.count()
+      if numTotal >= numLimit then exit for
+    end if
+  end for
+end sub
 
-    sub doPerson(input as object, items as object)
-      ' get movies by the person
-      personMovies = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-          "personIds": input.id,
-          "includeItemTypes": "Movie",
-          "excludeItemTypes": "Season,Series",
-          "recursive": true,
-          "limit": 500
-      }), "qp_personMovies")
-      if isValid(personMovies) and isValidAndNotEmpty(personMovies.Items)
-        items.append(personMovies.Items)
+' --- Play All actions (from Main.bs button handlers) ---
+
+sub doPlayAllSeries(input as object, items as object)
+  allEpData = fetchJson(GetApi().BuildGetEpisodesRequest(input.id, {
+    SortBy: "IndexNumber,SortName",
+    SortOrder: "Ascending"
+  }), "qp_playAllSeries")
+  if isValid(allEpData) and isValid(allEpData.Items)
+    ' Exclude Season 0 (Specials) from Play All
+    for each ep in allEpData.Items
+      if isValid(ep.ParentIndexNumber) and ep.ParentIndexNumber > 0
+        items.push(ep)
       end if
+    end for
+  end if
+end sub
 
-      ' get watched episodes by the person
-      personEpisodes = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-          "personIds": input.id,
-          "includeItemTypes": "Episode,Recording",
-          "isPlayed": true,
-          "excludeItemTypes": "Season,Series",
-          "recursive": true,
-          "limit": 500
-      }), "qp_personEpisodes")
-      if isValid(personEpisodes) and isValidAndNotEmpty(personEpisodes.Items)
-        items.append(personEpisodes.Items)
-      end if
-    end sub
+sub doPlayAllSeason(input as object, items as object)
+  allEpData = fetchJson(GetApi().BuildGetEpisodesRequest(input.seriesId, {
+    SeasonId: input.id,
+    SortBy: "IndexNumber,SortName",
+    SortOrder: "Ascending"
+  }), "qp_playAllSeason")
+  if isValid(allEpData) and isValid(allEpData.Items)
+    items.append(allEpData.Items)
+  end if
+end sub
 
-    sub doPlaylist(input as object, items as object)
-      data = fetchJson(GetApi().BuildGetPlaylistItemsRequest(input.id, {
-            "limit": 500
-        }), "qp_playlist")
-        if isValid(data) and isValidAndNotEmpty(data.Items)
-          items.append(data.Items)
-        end if
-      end sub
+sub doPlayAllBoxset(input as object, items as object)
+  data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+    "ParentId": input.id,
+    "SortBy": "PremiereDate,ProductionYear,SortName",
+    "SortOrder": "Ascending",
+    "EnableTotalRecordCount": false
+  }), "qp_playAllBoxset")
+  if isValid(data) and isValid(data.Items)
+    items.append(data.Items)
+  end if
+end sub
 
-      sub doPhotoAlbum(input as object, items as object)
-        data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-            "parentId": input.id,
-            "includeItemTypes": "Photo",
-            "sortBy": "Random",
-            "Recursive": true
-        }), "qp_photoAlbum")
-        if isValid(data) and isValidAndNotEmpty(data.items)
-          items.append(data.items)
-        end if
-      end sub
+sub doPlayAllAlbum(input as object, items as object)
+  data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+    "parentId": input.id,
+    "includeitemtypes": "Audio",
+    "SortBy": "ParentIndexNumber,IndexNumber,SortName",
+    "SortOrder": "Ascending",
+    "EnableTotalRecordCount": false
+  }), "qp_playAllAlbum")
+  if isValid(data) and isValid(data.Items)
+    items.append(data.Items)
+  end if
+end sub
 
-      ' --- Folder / CollectionFolder / UserView (complex multi-call) ---
+sub doPlayAllArtist(input as object, items as object)
+  data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
+    "ArtistIds": input.id,
+    "Recursive": "true",
+    "MediaTypes": "Audio",
+    "Filters": "IsNotFolder",
+    "SortBy": "SortName",
+    "Limit": 300,
+    "Fields": "Chapters",
+    "ExcludeLocationTypes": "Virtual",
+    "EnableTotalRecordCount": false,
+    "CollapseBoxSetItems": false
+  }), "qp_playAllArtist")
+  if isValid(data) and isValid(data.Items)
+    items.append(data.Items)
+  end if
+end sub
 
-      function doFolder(input as object) as dynamic
-        items = []
-        shouldShuffle = true
-        outputAction = "queue"
+sub doPlayAllPlaylist(input as object, items as object)
+  data = fetchJson(GetApi().BuildGetPlaylistItemsRequest(input.id, {
+    "SortBy": "ListItemOrder",
+    "SortOrder": "Ascending",
+    "EnableTotalRecordCount": false,
+    "limit": 500
+  }), "qp_playAllPlaylist")
+  if isValid(data) and isValid(data.Items)
+    items.append(data.Items)
+  end if
+end sub
 
-        paramArray = {
-          "includeItemTypes": "Episode,Recording,Movie,Video",
-          "videoTypes": "VideoFile",
-          "sortBy": "Random",
-          "limit": 500,
-          "imageTypeLimit": 1,
-          "Recursive": true,
-          "enableUserData": false,
-          "EnableTotalRecordCount": false
-        }
+sub doInstantMix(input as object, items as object)
+  data = fetchJson(GetApi().BuildGetInstantMixRequest(input.id, { "Limit": 201 }), "qp_instantMix")
+  if isValid(data) and isValid(data.Items)
+    items.append(data.Items)
+  end if
+end sub
 
-        folderType = LCase(isValidAndNotEmpty(input.folderType) ? input.folderType : "")
-        seriesCount = isValid(input.seriesCount) ? input.seriesCount : 0
-
-        if folderType = "studio"
-          paramArray["studioIds"] = input.id
-        else if folderType = "genre"
-          paramArray["genreIds"] = input.id
-          if isValid(input.movieCount) and input.movieCount > 0
-            paramArray["includeItemTypes"] = "Movie"
-          end if
-        else if folderType = "musicgenre"
-          paramArray["genreIds"] = input.id
-          paramArray.delete("videoTypes")
-          paramArray["includeItemTypes"] = "Audio"
-        else if folderType = "photoalbum"
-          paramArray["parentId"] = input.id
-          paramArray["includeItemTypes"] = "Photo"
-          paramArray.delete("videoTypes")
-          paramArray.delete("Recursive")
-        else
-          paramArray["parentId"] = input.id
-        end if
-
-        if seriesCount > 0
-          paramArray["includeItemTypes"] = "Series"
-          paramArray.Delete("videoTypes")
-        end if
-
-        folderData = fetchJson(GetApi().BuildGetItemsByQueryRequest(paramArray), "qp_folder")
-
-        if isValid(folderData) and isValidAndNotEmpty(folderData.items)
-          if seriesCount > 0
-            if seriesCount = 1
-              ' Single series — delegate to series quickplay
-              doSeries({ id: folderData.items[0].Id }, items)
-              shouldShuffle = false
-            else
-              doMultipleSeries(folderData.items, items)
-            end if
-          else
-            if folderType = "photoalbum"
-              outputAction = "photo"
-            end if
-            items.append(folderData.items)
-          end if
-        end if
-
-        return { action: outputAction, items: items, shuffle: shouldShuffle }
-      end function
-
-      function doCollectionFolder(input as object) as dynamic
-        items = []
-        shouldShuffle = true
-        outputAction = "queue"
-
-        collectionType = LCase(isValidAndNotEmpty(input.collectionType) ? input.collectionType : "")
-
-        if collectionType = "movies"
-          doVideoContainer(input, items)
-          shouldShuffle = false
-        else if collectionType = "music"
-          data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-              "parentId": input.id,
-              "includeItemTypes": "Audio",
-              "sortBy": "Album",
-              "Recursive": true,
-              "limit": 500,
-              "imageTypeLimit": 1,
-              "enableUserData": false,
-              "EnableTotalRecordCount": false
-          }), "qp_collectionMusic")
-          if isValid(data) and isValidAndNotEmpty(data.items)
-            items.append(data.Items)
-          end if
-        else if collectionType = "boxsets"
-          ' pick a random boxset and play its contents
-          boxsetData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-              "parentId": input.id,
-              "limit": 500,
-              "imageTypeLimit": 0,
-              "enableUserData": false,
-              "EnableTotalRecordCount": false,
-              "enableImages": false
-          }), "qp_collectionBoxsets")
-          if isValid(boxsetData) and isValidAndNotEmpty(boxsetData.items)
-            arrayIndex = Rnd(boxsetData.items.count()) - 1
-            myBoxset = boxsetData.items[arrayIndex]
-            innerData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-                "parentId": myBoxset.id,
-                "EnableTotalRecordCount": false
-            }), "qp_collectionBoxsetInner")
-            if isValid(innerData) and isValidAndNotEmpty(innerData.items)
-              items.append(innerData.Items)
-            end if
-          end if
-          shouldShuffle = false
-        else if collectionType = "tvshows" or collectionType = "collectionfolder"
-          doVideoContainer(input, items)
-          shouldShuffle = false
-        else if collectionType = "musicvideos"
-          data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-              "parentId": input.id,
-              "includeItemTypes": "MusicVideo",
-              "sortBy": "Random",
-              "Recursive": true,
-              "limit": 500,
-              "imageTypeLimit": 1,
-              "enableUserData": false,
-              "EnableTotalRecordCount": false
-          }), "qp_collectionMusicVideos")
-          if isValid(data) and isValidAndNotEmpty(data.items)
-            items.append(data.Items)
-          end if
-          shouldShuffle = false
-        else if collectionType = "homevideos"
-          data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-              "parentId": input.id,
-              "includeItemTypes": "Photo",
-              "sortBy": "Random",
-              "Recursive": true
-          }), "qp_collectionPhotos")
-          if isValid(data) and isValidAndNotEmpty(data.items)
-            items.append(data.items)
-            outputAction = "photo"
-          end if
-        end if
-
-        return { action: outputAction, items: items, shuffle: shouldShuffle }
-      end function
-
-      function doUserView(input as object) as dynamic
-        items = []
-        shouldShuffle = true
-        outputAction = "queue"
-
-        collectionType = LCase(isValidAndNotEmpty(input.collectionType) ? input.collectionType : "")
-
-        if collectionType = "playlists"
-          ' pick a random playlist and play its contents
-          playlistData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-              "parentId": input.id,
-              "imageTypeLimit": 0,
-              "enableUserData": false,
-              "EnableTotalRecordCount": false,
-              "enableImages": false
-          }), "qp_userViewPlaylists")
-          if isValid(playlistData) and isValidAndNotEmpty(playlistData.items)
-            arrayIndex = Rnd(playlistData.items.count()) - 1
-            myPlaylist = playlistData.items[arrayIndex]
-            playlistItems = fetchJson(GetApi().BuildGetPlaylistItemsRequest(myPlaylist.id, {
-                  "EnableTotalRecordCount": false,
-                  "limit": 500
-              }), "qp_userViewPlaylistItems")
-              if isValid(playlistItems) and isValidAndNotEmpty(playlistItems.items)
-                items.append(playlistItems.items)
-              end if
-            end if
-          else if collectionType = "livetv"
-            ' pick a random channel
-            channelData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-                "includeItemTypes": "TVChannel",
-                "sortBy": "Random",
-                "Recursive": true,
-                "imageTypeLimit": 0,
-                "enableUserData": false,
-                "EnableTotalRecordCount": false,
-                "enableImages": false
-            }), "qp_userViewChannels")
-            if isValid(channelData) and isValidAndNotEmpty(channelData.items)
-              arrayIndex = Rnd(channelData.items.count()) - 1
-              myChannel = channelData.items[arrayIndex]
-              ' Return channel as a queue item with TvChannel type
-              myChannel.Type = "TvChannel"
-              items.push(myChannel)
-            end if
-            shouldShuffle = false
-          else if collectionType = "movies" or collectionType = "tvshows"
-            doVideoContainer(input, items)
-            shouldShuffle = false
-          end if
-
-          return { action: outputAction, items: items, shuffle: shouldShuffle }
-        end function
-
-        ' Helper: video container logic (movies or tvshows collection)
-        sub doVideoContainer(input as object, items as object)
-          collectionType = LCase(isValidAndNotEmpty(input.collectionType) ? input.collectionType : "")
-
-          if collectionType = "movies"
-            data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-                "parentId": input.id,
-                "sortBy": "Random",
-                "recursive": true,
-                "includeItemTypes": "Movie,Video",
-                "limit": 500
-            }), "qp_videoContainerMovies")
-            if isValid(data) and isValidAndNotEmpty(data.items)
-              for each item in data.Items
-                ' only add videos we're not currently watching
-                if isValid(item.userdata) and isValid(item.userdata.PlaybackPositionTicks)
-                  if item.userdata.PlaybackPositionTicks = 0
-                    items.push(item)
-                  end if
-                else
-                  items.push(item)
-                end if
-              end for
-            end if
-          else if collectionType = "tvshows" or collectionType = "collectionfolder"
-            tvshowsData = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-                "parentId": input.id,
-                "sortBy": "Random",
-                "recursive": true,
-                "excludeItemTypes": "Season",
-                "imageTypeLimit": 0,
-                "enableUserData": false,
-                "EnableTotalRecordCount": false,
-                "enableImages": false
-            }), "qp_videoContainerTvShows")
-            if isValid(tvshowsData) and isValidAndNotEmpty(tvshowsData.items)
-              if tvshowsData.items[0].Type = "Series"
-                doMultipleSeries(tvshowsData.items, items)
-              else
-                items.append(tvshowsData.items)
-              end if
-            end if
-          end if
-        end sub
-
-        ' Helper: shuffle play watched episodes from multiple series
-        sub doMultipleSeries(tvshows as object, items as object)
-          numTotal = 0
-          numLimit = 500
-          for each tvshow in tvshows
-            showData = fetchJson(GetApi().BuildGetEpisodesRequest(tvshow.id, {
-                  "SortBy": "Random",
-                  "imageTypeLimit": 0,
-                  "EnableTotalRecordCount": false,
-                  "enableImages": false
-              }), "qp_multiSeries_" + tvshow.id)
-              if isValid(showData) and isValidAndNotEmpty(showData.items)
-                for each episode in showData.items
-                  if isValid(episode.userdata) and isValid(episode.userdata.Played)
-                    if episode.userdata.Played
-                      items.push(episode)
-                    end if
-                  end if
-                end for
-                numTotal = numTotal + showData.items.count()
-                if numTotal >= numLimit then exit for
-              end if
-            end for
-          end sub
-
-          ' --- Play All actions (from Main.bs button handlers) ---
-
-          sub doPlayAllSeries(input as object, items as object)
-            allEpData = fetchJson(GetApi().BuildGetEpisodesRequest(input.id, {
-                  SortBy: "IndexNumber,SortName",
-                  SortOrder: "Ascending"
-              }), "qp_playAllSeries")
-              if isValid(allEpData) and isValid(allEpData.Items)
-                ' Exclude Season 0 (Specials) from Play All
-                for each ep in allEpData.Items
-                  if isValid(ep.ParentIndexNumber) and ep.ParentIndexNumber > 0
-                    items.push(ep)
-                  end if
-                end for
-              end if
-            end sub
-
-            sub doPlayAllSeason(input as object, items as object)
-              allEpData = fetchJson(GetApi().BuildGetEpisodesRequest(input.seriesId, {
-                    SeasonId: input.id,
-                    SortBy: "IndexNumber,SortName",
-                    SortOrder: "Ascending"
-                }), "qp_playAllSeason")
-                if isValid(allEpData) and isValid(allEpData.Items)
-                  items.append(allEpData.Items)
-                end if
-              end sub
-
-              sub doPlayAllBoxset(input as object, items as object)
-                data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-                    "ParentId": input.id,
-                    "SortBy": "PremiereDate,ProductionYear,SortName",
-                    "SortOrder": "Ascending",
-                    "EnableTotalRecordCount": false
-                }), "qp_playAllBoxset")
-                if isValid(data) and isValid(data.Items)
-                  items.append(data.Items)
-                end if
-              end sub
-
-              sub doPlayAllAlbum(input as object, items as object)
-                data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-                    "parentId": input.id,
-                    "includeitemtypes": "Audio",
-                    "SortBy": "ParentIndexNumber,IndexNumber,SortName",
-                    "SortOrder": "Ascending",
-                    "EnableTotalRecordCount": false
-                }), "qp_playAllAlbum")
-                if isValid(data) and isValid(data.Items)
-                  items.append(data.Items)
-                end if
-              end sub
-
-              sub doPlayAllArtist(input as object, items as object)
-                data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-                    "ArtistIds": input.id,
-                    "Recursive": "true",
-                    "MediaTypes": "Audio",
-                    "Filters": "IsNotFolder",
-                    "SortBy": "SortName",
-                    "Limit": 300,
-                    "Fields": "Chapters",
-                    "ExcludeLocationTypes": "Virtual",
-                    "EnableTotalRecordCount": false,
-                    "CollapseBoxSetItems": false
-                }), "qp_playAllArtist")
-                if isValid(data) and isValid(data.Items)
-                  items.append(data.Items)
-                end if
-              end sub
-
-              sub doPlayAllPlaylist(input as object, items as object)
-                data = fetchJson(GetApi().BuildGetPlaylistItemsRequest(input.id, {
-                      "SortBy": "ListItemOrder",
-                      "SortOrder": "Ascending",
-                      "EnableTotalRecordCount": false,
-                      "limit": 500
-                  }), "qp_playAllPlaylist")
-                  if isValid(data) and isValid(data.Items)
-                    items.append(data.Items)
-                  end if
-                end sub
-
-                sub doInstantMix(input as object, items as object)
-                  data = fetchJson(GetApi().BuildGetInstantMixRequest(input.id, { "Limit": 201 }), "qp_instantMix")
-                  if isValid(data) and isValid(data.Items)
-                    items.append(data.Items)
-                  end if
-                end sub
-
-                sub doLoadTrailers(input as object, items as object)
-                  data = fetchJson(GetApi().BuildGetLocalTrailersRequest(input.id), "qp_trailers")
-                  if isValid(data)
-                    items.append(data)
-                  end if
-                end sub
+sub doLoadTrailers(input as object, items as object)
+  data = fetchJson(GetApi().BuildGetLocalTrailersRequest(input.id), "qp_trailers")
+  if isValid(data)
+    items.append(data)
+  end if
+end sub

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -935,1200 +935,1200 @@ sub fetchNextEpisode()
   m.checkedForNextEpisode = true
 
   req = GetApi().BuildGetEpisodesRequest(m.top.showID, {
-      StartItemId: m.top.id,
-      Limit: 2
-    })
-    promises.chain(fetchAsync(req, "nextEpisode-" + m.top.id)).then(sub(res as object)
-      ' Any HTTP response lands here (incl. 4xx/5xx). Only a 2xx body tells us
-      ' about the next episode; a non-ok response falls through to retry, just
-      ' like the old Task, which only acted when res.ok.
-      if not res.ok
-        onNextEpisodeFetchFailed()
-        return
-      end if
-
-      m.top.observeField("position", "onPositionChanged")
-
-      ' BuildGetEpisodesRequest(Limit 2) returns [current, next]; a count other
-      ' than 2 means there is no next episode, so disable the Next Episode button.
-      if not (isValid(res.json) and isValid(res.json.Items) and res.json.Items.count() = 2)
-        m.nextupbuttonseconds = 0
-      end if
-    end sub).catch(sub(err as object)
-      ' Transport failure / timeout (see the error contract) — never completed,
-      ' so allow a retry on the next "playing" transition.
+    StartItemId: m.top.id,
+    Limit: 2
+  })
+  promises.chain(fetchAsync(req, "nextEpisode-" + m.top.id)).then(sub(res as object)
+    ' Any HTTP response lands here (incl. 4xx/5xx). Only a 2xx body tells us
+    ' about the next episode; a non-ok response falls through to retry, just
+    ' like the old Task, which only acted when res.ok.
+    if not res.ok
       onNextEpisodeFetchFailed()
-      m.log.warn("next-episode fetch failed", err.reason)
-    end sub)
-  end sub
-
-  ' Re-arms the next-episode check after a fetch that never produced a usable
-  ' response, so a later "playing" transition retries it.
-  sub onNextEpisodeFetchFailed()
-    m.checkedForNextEpisode = false
-  end sub
-
-  ' Check if a VideoNotification is visually present (including during fade-out animation)
-  function isNotificationVisible(notification as object) as boolean
-    return notification.state = "showing" or notification.state = "dismissing"
-  end function
-
-  ' Show the Next Episode notification with countdown text
-  sub showNextEpisodeButton()
-    if m.osd.visible then return
-    if m.top.content.contenttype <> 4 then return ' only display when content is type "Episode"
-    if m.nextupbuttonseconds = 0 then return ' is the button disabled?
-    if m.nextEpisodeNotification.state = "showing" then return
-
-    ' Don't show Next Episode while segment notification is active (including fade-out)
-    if isNotificationVisible(m.segmentNotification) then return
-
-    ' Set text before showing
-    updateNextEpisodeCount()
-
-    m.nextEpisodeNotification.visible = true
-    m.nextEpisodeNotification.callFunc("show")
-  end sub
-
-  ' Update Next Episode countdown text
-  sub updateNextEpisodeCount()
-    nextEpisodeCountdown = Int(m.top.duration - m.top.position)
-    if nextEpisodeCountdown < 0
-      nextEpisodeCountdown = 0
-    end if
-    m.nextEpisodeNotification.text = translate(translationKeys.LabelNextEpisode) + " " + nextEpisodeCountdown.toStr().trim()
-  end sub
-
-  ' Hide the Next Episode notification
-  sub hideNextEpisodeButton()
-    if not isValid(m.nextEpisodeNotification) then return
-    m.nextEpisodeNotification.callFunc("dismiss")
-  end sub
-
-  ' Handler for Next Episode notification action
-  sub onNextEpisodeNotificationAction()
-    action = m.nextEpisodeNotification.action
-    if action = "activated"
-      forceFinishPlayback()
       return
-    else if action = "dismissed"
-      ' Only restore video focus if OSD didn't take focus during the dismiss animation
-      if not m.osd.visible
-        m.top.setFocus(true)
-      end if
-    end if
-  end sub
-
-  ' Checks if we need to display the Next Episode button
-  sub checkTimeToDisplayNextEpisode()
-    if m.top.content.contenttype <> 4 then return ' only display when content is type "Episode"
-    if m.nextupbuttonseconds = 0 then return ' is the button disabled?
-
-    ' Don't show Next Episode button if trickPlayBar is visible
-    if m.top.trickPlayBar.visible then return
-
-    ' Don't show while segment notification is active (including fade-out) — it takes priority
-    if isNotificationVisible(m.segmentNotification) then return
-
-    if isValid(m.top.duration) and isValid(m.top.position)
-      nextEpisodeCountdown = Int(m.top.duration - m.top.position)
-
-      if nextEpisodeCountdown < 0 and isNotificationVisible(m.nextEpisodeNotification)
-        hideNextEpisodeButton()
-        return
-      else if nextEpisodeCountdown > 1 and int(m.top.position) >= (m.top.duration - m.nextupbuttonseconds - 1)
-        if m.nextEpisodeNotification.state <> "showing"
-          showNextEpisodeButton()
-        else
-          ' Notification already showing — just update the countdown text
-          updateNextEpisodeCount()
-        end if
-        return
-      end if
     end if
 
-    ' If notification is visible but shouldn't be, hide it
-    if isNotificationVisible(m.nextEpisodeNotification)
+    m.top.observeField("position", "onPositionChanged")
+
+    ' BuildGetEpisodesRequest(Limit 2) returns [current, next]; a count other
+    ' than 2 means there is no next episode, so disable the Next Episode button.
+    if not (isValid(res.json) and isValid(res.json.Items) and res.json.Items.count() = 2)
+      m.nextupbuttonseconds = 0
+    end if
+  end sub).catch(sub(err as object)
+    ' Transport failure / timeout (see the error contract) — never completed,
+    ' so allow a retry on the next "playing" transition.
+    onNextEpisodeFetchFailed()
+    m.log.warn("next-episode fetch failed", err.reason)
+  end sub)
+end sub
+
+' Re-arms the next-episode check after a fetch that never produced a usable
+' response, so a later "playing" transition retries it.
+sub onNextEpisodeFetchFailed()
+  m.checkedForNextEpisode = false
+end sub
+
+' Check if a VideoNotification is visually present (including during fade-out animation)
+function isNotificationVisible(notification as object) as boolean
+  return notification.state = "showing" or notification.state = "dismissing"
+end function
+
+' Show the Next Episode notification with countdown text
+sub showNextEpisodeButton()
+  if m.osd.visible then return
+  if m.top.content.contenttype <> 4 then return ' only display when content is type "Episode"
+  if m.nextupbuttonseconds = 0 then return ' is the button disabled?
+  if m.nextEpisodeNotification.state = "showing" then return
+
+  ' Don't show Next Episode while segment notification is active (including fade-out)
+  if isNotificationVisible(m.segmentNotification) then return
+
+  ' Set text before showing
+  updateNextEpisodeCount()
+
+  m.nextEpisodeNotification.visible = true
+  m.nextEpisodeNotification.callFunc("show")
+end sub
+
+' Update Next Episode countdown text
+sub updateNextEpisodeCount()
+  nextEpisodeCountdown = Int(m.top.duration - m.top.position)
+  if nextEpisodeCountdown < 0
+    nextEpisodeCountdown = 0
+  end if
+  m.nextEpisodeNotification.text = translate(translationKeys.LabelNextEpisode) + " " + nextEpisodeCountdown.toStr().trim()
+end sub
+
+' Hide the Next Episode notification
+sub hideNextEpisodeButton()
+  if not isValid(m.nextEpisodeNotification) then return
+  m.nextEpisodeNotification.callFunc("dismiss")
+end sub
+
+' Handler for Next Episode notification action
+sub onNextEpisodeNotificationAction()
+  action = m.nextEpisodeNotification.action
+  if action = "activated"
+    forceFinishPlayback()
+    return
+  else if action = "dismissed"
+    ' Only restore video focus if OSD didn't take focus during the dismiss animation
+    if not m.osd.visible
+      m.top.setFocus(true)
+    end if
+  end if
+end sub
+
+' Checks if we need to display the Next Episode button
+sub checkTimeToDisplayNextEpisode()
+  if m.top.content.contenttype <> 4 then return ' only display when content is type "Episode"
+  if m.nextupbuttonseconds = 0 then return ' is the button disabled?
+
+  ' Don't show Next Episode button if trickPlayBar is visible
+  if m.top.trickPlayBar.visible then return
+
+  ' Don't show while segment notification is active (including fade-out) — it takes priority
+  if isNotificationVisible(m.segmentNotification) then return
+
+  if isValid(m.top.duration) and isValid(m.top.position)
+    nextEpisodeCountdown = Int(m.top.duration - m.top.position)
+
+    if nextEpisodeCountdown < 0 and isNotificationVisible(m.nextEpisodeNotification)
       hideNextEpisodeButton()
-    end if
-  end sub
-
-  ' Forces playback to finished state for proper watched-status and auto-play.
-  ' Triggers synchronous teardown (onState -> PlayerHostView.onPlayerStateChange -> destroy/
-  ' goBack -> onDestroy), invalidating all m. references. Callers MUST return immediately after.
-  sub forceFinishPlayback()
-    ' Explicitly mark as watched via dedicated API endpoint.
-    ' Uses the API pool (not SideEffectTask) so it can't be overwritten
-    ' by the playstate report that fires during teardown.
-    if m.top.id <> ""
-      req = GetApi().BuildMarkPlayedRequest(m.top.id)
-      if isValid(req)
-        resultNode = submitApiRequest(req, "forceFinishMarkPlayed")
-        if isValid(resultNode)
-          m.log.info("Force-finishing playback — marking as watched", m.top.id)
-        else
-          m.log.warn("Force-finishing playback — API pool not ready, mark-played dropped", m.top.id)
-        end if
+      return
+    else if nextEpisodeCountdown > 1 and int(m.top.position) >= (m.top.duration - m.nextupbuttonseconds - 1)
+      if m.nextEpisodeNotification.state <> "showing"
+        showNextEpisodeButton()
       else
-        m.log.warn("Force-finishing playback — could not build mark-played request", m.top.id)
+        ' Notification already showing — just update the countdown text
+        updateNextEpisodeCount()
+      end if
+      return
+    end if
+  end if
+
+  ' If notification is visible but shouldn't be, hide it
+  if isNotificationVisible(m.nextEpisodeNotification)
+    hideNextEpisodeButton()
+  end if
+end sub
+
+' Forces playback to finished state for proper watched-status and auto-play.
+' Triggers synchronous teardown (onState -> PlayerHostView.onPlayerStateChange -> destroy/
+' goBack -> onDestroy), invalidating all m. references. Callers MUST return immediately after.
+sub forceFinishPlayback()
+  ' Explicitly mark as watched via dedicated API endpoint.
+  ' Uses the API pool (not SideEffectTask) so it can't be overwritten
+  ' by the playstate report that fires during teardown.
+  if m.top.id <> ""
+    req = GetApi().BuildMarkPlayedRequest(m.top.id)
+    if isValid(req)
+      resultNode = submitApiRequest(req, "forceFinishMarkPlayed")
+      if isValid(resultNode)
+        m.log.info("Force-finishing playback — marking as watched", m.top.id)
+      else
+        m.log.warn("Force-finishing playback — API pool not ready, mark-played dropped", m.top.id)
       end if
     else
-      m.log.info("Force-finishing playback — no item ID, skipping mark-played")
+      m.log.warn("Force-finishing playback — could not build mark-played request", m.top.id)
     end if
+  else
+    m.log.info("Force-finishing playback — no item ID, skipping mark-played")
+  end if
 
-    ' Tell reportPlayback to report position at end of video so the server
-    ' sees a natural completion — matching the mark-played request.
-    m.forceFinished = true
+  ' Tell reportPlayback to report position at end of video so the server
+  ' sees a natural completion — matching the mark-played request.
+  m.forceFinished = true
 
-    m.top.control = "stop"
-    m.top.state = "finished"
-  end sub
+  m.top.control = "stop"
+  m.top.state = "finished"
+end sub
 
-  ' Check media segments and trigger appropriate actions based on current playback position
-  sub checkMediaSegments()
-    if m.mediaSegments.Count() = 0 then return
-    if m.osd.visible then return
-    if m.top.trickPlayBar.visible then return
+' Check media segments and trigger appropriate actions based on current playback position
+sub checkMediaSegments()
+  if m.mediaSegments.Count() = 0 then return
+  if m.osd.visible then return
+  if m.top.trickPlayBar.visible then return
 
-    userSession = m.global.user
-    segment = findActiveSegment(m.mediaSegments, m.top.position)
+  userSession = m.global.user
+  segment = findActiveSegment(m.mediaSegments, m.top.position)
 
-    if isValid(segment)
-      segmentId = segment.Id ?? ""
-      if segmentId = "" then return
+  if isValid(segment)
+    segmentId = segment.Id ?? ""
+    if segmentId = "" then return
 
-      segmentType = segment.Type ?? ""
-      action = resolveSegmentAction(segmentType, userSession.settings, userSession.config)
-      m.log.verbose("Active segment found", segmentType, segmentId, "action:", action)
+    segmentType = segment.Type ?? ""
+    action = resolveSegmentAction(segmentType, userSession.settings, userSession.config)
+    m.log.verbose("Active segment found", segmentType, segmentId, "action:", action)
 
-      if action = MediaSegmentAction.SKIP
-        ' Auto-skip only fires once per segment
-        if m.skippedSegments.DoesExist(segmentId) then return
+    if action = MediaSegmentAction.SKIP
+      ' Auto-skip only fires once per segment
+      if m.skippedSegments.DoesExist(segmentId) then return
 
-        ' Auto-skip: seek to end of segment immediately
-        seekPosition = segmentTicksToSeconds(segment.EndTicks)
+      ' Auto-skip: seek to end of segment immediately
+      seekPosition = segmentTicksToSeconds(segment.EndTicks)
 
-        ' Outro ending near video end: force finish for watched-status and auto-play
-        if segmentType = MediaSegmentType.OUTRO and m.top.duration > 0 and seekPosition >= m.top.duration - 5
-          forceFinishPlayback()
-          return
-        end if
-
-        ' Dismiss notification from a prior segment (e.g. back-to-back askToSkip → skip)
-        if isNotificationVisible(m.segmentNotification) or m.segmentNotification.state = "paused"
-          m.segmentNotification.callFunc("dismiss")
-        end if
-
-        m.log.info("Auto-skipping segment", segmentType, "to", seekPosition)
-        m.top.seek = seekPosition
-        m.skippedSegments[segmentId] = true
-        m.activeSegmentId = ""
-      else if action = MediaSegmentAction.ASK_TO_SKIP
-        ' Dismissed this visit — don't re-show until user leaves and re-enters the segment
-        if segmentId = m.dismissedSegmentId then return
-
-        ' Re-show notification if it was paused (hidden for OSD)
-        if m.segmentNotification.state = "paused" and m.activeSegmentId = segmentId
-          m.log.verbose("Re-showing paused segment notification", segmentId)
-          m.segmentNotification.visible = true
-          m.segmentNotification.callFunc("show")
-        else if m.activeSegmentId <> segmentId
-          ' Show notification for a new segment
-          m.activeSegmentId = segmentId
-
-          ' Suppress Next Episode notification while segment notification is active
-          if isNotificationVisible(m.nextEpisodeNotification)
-            hideNextEpisodeButton()
-          end if
-
-          ' Commercial and Recap segments stay visible for the entire segment.
-          ' Other types auto-dismiss after 10 seconds.
-          if segmentType = MediaSegmentType.COMMERCIAL or segmentType = MediaSegmentType.RECAP
-            m.segmentNotification.autoDismissSeconds = 0
-          else
-            m.segmentNotification.autoDismissSeconds = 10
-          end if
-
-          m.log.info("Showing skip notification", segmentType, segmentId)
-          segmentLabel = m.segmentTypeLabels[segmentType]
-          if not isValidAndNotEmpty(segmentLabel) then segmentLabel = segmentType
-          m.segmentNotification.text = translate(translationKeys.ButtonSkip) + " " + segmentLabel
-          m.segmentNotification.visible = true
-          m.segmentNotification.callFunc("show")
-        end if
-      else
-        ' MediaSegmentAction.NONE — dismiss stale notification from a prior segment
-        if isNotificationVisible(m.segmentNotification) or m.segmentNotification.state = "paused"
-          m.segmentNotification.callFunc("dismiss")
-        end if
-        m.activeSegmentId = ""
+      ' Outro ending near video end: force finish for watched-status and auto-play
+      if segmentType = MediaSegmentType.OUTRO and m.top.duration > 0 and seekPosition >= m.top.duration - 5
+        forceFinishPlayback()
+        return
       end if
-    else
-      ' Not inside any segment — dismiss segment notification if visible or paused
+
+      ' Dismiss notification from a prior segment (e.g. back-to-back askToSkip → skip)
       if isNotificationVisible(m.segmentNotification) or m.segmentNotification.state = "paused"
-        m.log.verbose("Left segment, dismissing notification")
+        m.segmentNotification.callFunc("dismiss")
+      end if
+
+      m.log.info("Auto-skipping segment", segmentType, "to", seekPosition)
+      m.top.seek = seekPosition
+      m.skippedSegments[segmentId] = true
+      m.activeSegmentId = ""
+    else if action = MediaSegmentAction.ASK_TO_SKIP
+      ' Dismissed this visit — don't re-show until user leaves and re-enters the segment
+      if segmentId = m.dismissedSegmentId then return
+
+      ' Re-show notification if it was paused (hidden for OSD)
+      if m.segmentNotification.state = "paused" and m.activeSegmentId = segmentId
+        m.log.verbose("Re-showing paused segment notification", segmentId)
+        m.segmentNotification.visible = true
+        m.segmentNotification.callFunc("show")
+      else if m.activeSegmentId <> segmentId
+        ' Show notification for a new segment
+        m.activeSegmentId = segmentId
+
+        ' Suppress Next Episode notification while segment notification is active
+        if isNotificationVisible(m.nextEpisodeNotification)
+          hideNextEpisodeButton()
+        end if
+
+        ' Commercial and Recap segments stay visible for the entire segment.
+        ' Other types auto-dismiss after 10 seconds.
+        if segmentType = MediaSegmentType.COMMERCIAL or segmentType = MediaSegmentType.RECAP
+          m.segmentNotification.autoDismissSeconds = 0
+        else
+          m.segmentNotification.autoDismissSeconds = 10
+        end if
+
+        m.log.info("Showing skip notification", segmentType, segmentId)
+        segmentLabel = m.segmentTypeLabels[segmentType]
+        if not isValidAndNotEmpty(segmentLabel) then segmentLabel = segmentType
+        m.segmentNotification.text = translate(translationKeys.ButtonSkip) + " " + segmentLabel
+        m.segmentNotification.visible = true
+        m.segmentNotification.callFunc("show")
+      end if
+    else
+      ' MediaSegmentAction.NONE — dismiss stale notification from a prior segment
+      if isNotificationVisible(m.segmentNotification) or m.segmentNotification.state = "paused"
         m.segmentNotification.callFunc("dismiss")
       end if
       m.activeSegmentId = ""
-      m.dismissedSegmentId = ""
     end if
-  end sub
-
-  ' Handler for segment notification action
-  sub onSegmentNotificationAction()
-    action = m.segmentNotification.action
-    if action = "activated"
-      if m.activeSegmentId = ""
-        m.log.warn("Segment skip activated with no active segment")
-        return
-      end if
-
-      m.log.info("Segment skip activated by user", m.activeSegmentId)
-      segment = findSegmentById(m.mediaSegments, m.activeSegmentId)
-      if isValid(segment)
-        seekPosition = segmentTicksToSeconds(segment.EndTicks)
-        segmentType = segment.Type ?? ""
-
-        ' Outro ending near video end: force finish for watched-status and auto-play
-        if segmentType = MediaSegmentType.OUTRO and m.top.duration > 0 and seekPosition >= m.top.duration - 5
-          forceFinishPlayback()
-          return
-        end if
-
-        m.top.seek = seekPosition
-        m.skippedSegments[m.activeSegmentId] = true
-      else
-        m.log.warn("Active segment not found for skip", m.activeSegmentId)
-      end if
-      m.activeSegmentId = ""
-      m.top.setFocus(true)
-    else if action = "dismissed"
-      m.log.verbose("Segment notification dismissed", m.activeSegmentId)
-      ' Mark as dismissed for this visit — allows re-show if user leaves and re-enters the segment
-      if m.activeSegmentId <> ""
-        m.dismissedSegmentId = m.activeSegmentId
-        m.activeSegmentId = ""
-      end if
-      ' Only restore video focus if OSD didn't take focus during the dismiss animation
-      if not m.osd.visible
-        m.top.setFocus(true)
-      end if
-    end if
-  end sub
-
-  ' Safety net: ensure focus isn't orphaned after notification dismissal animation completes
-  sub onNotificationStateChanged()
-    if m.segmentNotification.state = "hidden" or m.nextEpisodeNotification.state = "hidden"
-      if not m.osd.visible and not m.top.hasFocus()
-        m.top.setFocus(true)
-      end if
-    end if
-  end sub
-
-  ' When Video Player state changes
-  sub onPositionChanged()
-    ' Fall back to content.length (which Jellyfin populates from mediaSource.RunTimeTicks)
-    ' when Roku's own duration probe returns 0. This happens with live-transcoded progressive
-    ' MKV: ffmpeg can't know the final duration while encoding, so it writes 0 into the
-    ' MKV SegmentInfo header, and Roku's probe inherits that. Without this fallback,
-    ' progressPercentage stays pinned at 0, and since the OSD only observes progressPercentage,
-    ' the progress bar never advances and timestamps never refresh.
-    effectiveDuration = m.top.duration
-    if effectiveDuration <= 0 and isValid(m.top.content) and m.top.content.length > 0
-      effectiveDuration = m.top.content.length
-    end if
-
-    if effectiveDuration <= 0
-      m.osd.progressPercentage = 0
-    else
-      m.osd.progressPercentage = m.top.position / effectiveDuration
-    end if
-    m.osd.positionTime = m.top.position
-    m.osd.remainingPositionTime = effectiveDuration - m.top.position
-
-    if isValid(m.captionTask)
-      m.captionTask.currentPos = Int(m.top.position * 1000)
-    end if
-
-    ' Update trickplay carousel's playback position for proactive tile caching
-    ' This runs even when carousel is not visible to keep cache warm
-    if isValid(m.trickplayCarousel)
-      m.trickplayCarousel.playbackPosition = m.top.position
-    end if
-
-    ' Check if dialog is open
-    m.dialog = m.top.getScene().findNode("dialogBackground")
-    if not isValid(m.dialog)
-      ' Do not check segments or next episode for intro videos
-      if not m.LoadMetaDataTask.isIntro
-        checkMediaSegments()
-        checkTimeToDisplayNextEpisode()
-      end if
-    end if
-
-    ' Carousel visibility state machine:
-    ' 1. Normal scrubbing: carousel auto-shows when trickPlayBar visible (not OSD)
-    ' 2. Seek confirmation: when user presses OK, carousel is hidden (line 1146) and
-    '    m.carouselHiddenForSeek flag prevents auto-show until seek completes
-    ' 3. Seek completion: when trickPlayBar closes, flags reset and carousel ready for next scrub
-    ' This prevents the carousel from flashing back on between OK press and trickPlayBar closing
-    if isValid(m.trickplayCarousel) and not m.carouselHiddenForSeek
-      trickPlayBarVisible = m.top.trickPlayBar.visible and not m.osd.visible
-      m.trickplayCarousel.isVisible = trickPlayBarVisible
-
-      ' Reset seek tracking when trickPlayBar closes (user confirmed or cancelled seek)
-      if not trickPlayBarVisible
-        m.isTrackingSeek = false
-        m.carouselHiddenForSeek = false
-        m.lastSentThumbnailIndex = -1 ' Reset so next scrub session sends initial position
-      end if
-    end if
-
-    ' Update trickplay carousel position during normal playback only
-    ' When trickPlayBar is visible, onTrickPlayBarTextChange is the authoritative source
-    if isValid(m.trickplayCarousel) and m.trickplayCarousel.isVisible and not m.top.trickPlayBar.visible
-      updateTrickplayCarousel(m.top.position)
-    end if
-  end sub
-
-  ' Updates trickplay carousel with index calculated from video position
-  ' Snaps to thumbnail boundaries for cleaner UX
-  ' @param {Float} position - Video position in seconds
-  sub updateTrickplayCarousel(position as float)
-    if not isValid(m.trickplayCarousel) then return
-    if not isValidAndNotEmpty(m.trickplayCarousel.trickplayConfig) then return
-
-    interval = m.trickplayCarousel.trickplayConfig.interval
-
-    ' Calculate thumbnail index from position
-    thumbnailIndex = trickplay.calculateThumbnailIndex(position, interval)
-
-    ' Skip if same index as last sent - prevents double-rendering at tile boundaries
-    ' when both onPositionChanged and onTrickPlayBarTextChange fire with similar positions
-    if thumbnailIndex = m.lastSentThumbnailIndex then return
-    m.lastSentThumbnailIndex = thumbnailIndex
-
-    ' Update carousel with index (triggers shifting logic)
-    m.trickplayCarousel.thumbnailIndex = thumbnailIndex
-  end sub
-
-  ' Called when Roku's trickPlayBar position text changes
-  ' Parses the time string to get seek position and syncs our carousel
-  ' This ensures carousel stays in sync with Roku's authoritative seek position
-  sub onTrickPlayBarTextChange()
-    if not m.top.trickPlayBar.visible then return
-    if not isValid(m.trickPlayBarPositionText) then return
-
-    timeText = m.trickPlayBarPositionText.text
-    if not isValidAndNotEmpty(timeText) then return
-
-    ' Parse time string "53:50" (MM:SS) or "1:23:45" (H:MM:SS) to seconds
-    seekPosition = timeText.split(":")
-    seekTime = 0
-
-    if seekPosition.count() = 3
-      ' H:MM:SS format
-      seekTime = seekPosition[0].toInt() * 3600 ' hours
-      seekTime = seekTime + seekPosition[1].toInt() * 60 ' minutes
-      seekTime = seekTime + seekPosition[2].toInt() ' seconds
-    else if seekPosition.count() = 2
-      ' MM:SS format
-      seekTime = seekPosition[0].toInt() * 60 ' minutes
-      seekTime = seekTime + seekPosition[1].toInt() ' seconds
-    else
-      ' Unexpected format - use current position as fallback
-      seekTime = m.top.position
-    end if
-
-    m.log.debug("TrickPlayBar text changed", timeText, "parsed to", seekTime, "seconds")
-
-    ' Sync carousel with Roku's authoritative seek position
-    m.isTrackingSeek = true
-
-    ' Update carousel to match
-    if isValid(m.trickplayCarousel) and m.trickplayCarousel.isVisible
-      updateTrickplayCarousel(seekTime)
-    end if
-  end sub
-
-  ' retryPlayback: Re-runs the content loader from the current position with updated task flags.
-  ' Used by error handlers to retry without exiting the player.
-  ' @param {boolean} bypassDovi - skips DoVi container profile so the server can grant direct play
-  ' @param {boolean} forceTranscode - disables direct play so the server returns a transcode URL
-  sub retryPlayback(bypassDovi as boolean, forceTranscode as boolean)
-    m.global.queueManager.callFunc("setCurrentStartingPoint", int(m.top.position) * 10000000&)
-    ' Prevents PlayerHostView from advancing/exiting when stop causes Roku to fire "finished".
-    m.top.isRetrying = true
-    m.top.control = "stop"
-    m.LoadMetaDataTask.shouldBypassDoviPreservation = bypassDovi
-    m.LoadMetaDataTask.shouldForceTranscoding = forceTranscode
-    m.LoadMetaDataTask.selectedSubtitleIndex = m.top.SelectedSubtitle
-    m.LoadMetaDataTask.selectedAudioStreamIndex = m.top.audioIndex
-    m.LoadMetaDataTask.itemId = m.currentItem.id
-    m.LoadMetaDataTask.observeField("content", "onVideoContentLoaded")
-    m.LoadMetaDataTask.control = "RUN"
-  end sub
-
-  '
-  ' When Video Player state changes
-  sub onState()
-    ' On first play, verify audioTrack matches the intended Jellyfin selection using
-    ' Roku's availableAudioTracks (now populated). The Index + 1 fallback set during
-    ' onVideoContentLoaded may be wrong for non-standard MKV track numbering.
-    if m.top.state = "playing" and not m.isPlayReported
-      if isValid(m.top.availableAudioTracks) and isValid(m.top.audioIndex) and not m.top.isTranscoded
-        correctedTrack = getRokuAudioTrackPosition(m.top.audioIndex, m.top.fullAudioData, m.top.availableAudioTracks)
-        if correctedTrack <> m.top.audioTrack
-          m.log.info("Correcting audioTrack on first play", "was", m.top.audioTrack, "corrected", correctedTrack, "jellyfinIndex", m.top.audioIndex)
-          m.top.audioTrack = correctedTrack
-        else
-          m.log.debug("audioTrack verified correct on first play", "audioTrack", m.top.audioTrack, "jellyfinIndex", m.top.audioIndex)
-        end if
-      end if
-    end if
-
-    if isValid(m.captionTask)
-      m.captionTask.playerState = m.top.state + m.top.globalCaptionMode
-    end if
-
-    ' Pass video state into OSD
-    m.osd.playbackState = m.top.state
-
-    if m.top.state = "buffering"
-      ' When buffering, start timer to monitor buffering process
-      if isValid(m.bufferCheckTimer)
-        m.bufferCheckTimer.control = "start"
-        m.bufferCheckTimer.ObserveField("fire", "bufferCheck")
-      end if
-      ' Show non-blocking spinner for mid-playback buffering (seek, network stall)
-      if m.isPlayReported
-        startLoadingSpinner(false)
-      end if
-    else if m.top.state = "error"
-      m.log.error(m.top.errorCode, m.top.errorMsg, m.top.errorStr, m.isPlayReported, m.top.isTranscodeAvailable)
-
-      print m.top.errorInfo
-
-      ' Detect a Roku video buffer overflow (buffer:loop: source) caused by DoVi transcoding.
-      ' When DoVi preservation forced a transcode and the HLS segments overflow the device buffer,
-      ' retry with direct play by bypassing the DoVi container profile injection.
-      isBufferLoopError = isValid(m.top.errorInfo) and isValid(m.top.errorInfo.source) and m.top.errorInfo.source = "buffer:loop:"
-
-      if isBufferLoopError and m.top.isDoviDirectPlayFallbackAvailable
-        m.log.warn("Buffer overflow in DoVi transcode; falling back to direct play", m.currentItem.id)
-        m.top.isDoviDirectPlayFallbackAvailable = false ' prevent retry loop if direct play also fails
-        retryPlayback(true, false)
-      else if not m.isPlayReported and m.top.isTranscodeAvailable
-        m.log.warn("Direct play failed; falling back to transcode", m.currentItem.id)
-        m.top.isTranscodeAvailable = false ' prevent retry loop if transcode also fails
-        retryPlayback(false, true)
-      else
-        ' If an error was encountered, stop timers and display dialog
-        m.top.unobserveField("state")
-        m.playbackTimer.control = "stop"
-        m.bufferCheckTimer.control = "stop"
-        m.bufferCheckTimer.unobserveField("fire")
-        ' Ensure trickplay carousel is cleaned up on error just like stopped/finished states
-        if isValid(m.trickplayCarousel)
-          m.trickplayCarousel.isVisible = false
-        end if
-        stopLoadingSpinner()
-        showPlaybackErrorDialog(translate(translationKeys.ErrorDuringPlayback))
-      end if
-    else if m.top.state = "playing"
-      stopLoadingSpinner()
-      ' Check if next episode is available
-      if isValid(m.top.showID) and m.top.showID <> "" and not m.checkedForNextEpisode and m.top.content.contenttype = 4
-        fetchNextEpisode()
-      end if
-
-      if m.isPlayReported = false
-        reportPlayback("start")
-        m.isPlayReported = true
-
-        ' Load channel list in background for channel up/down navigation
-        if isLiveTvPlayback() and not m.channelListLoaded
-          loadChannelListForQueue()
-        end if
-      else
-        reportPlayback()
-      end if
-      m.playbackTimer.control = "start"
-    else if m.top.state = "paused"
-      stopLoadingSpinner()
-      m.playbackTimer.control = "stop"
-      reportPlayback()
-    else if m.top.state = "stopped"
-      ' Skip during channel switch; the incoming VideoPlayerView will hide the spinner
-      if not (m.isSwitchingChannel = true)
-        stopLoadingSpinner()
-      end if
-      m.playbackTimer.control = "stop"
-      m.playbackTimer.unobserveField("fire")
-      m.bufferCheckTimer.control = "stop"
-      m.bufferCheckTimer.unobserveField("fire")
-      reportPlayback("stop")
-      m.isPlayReported = false
-      if isValid(m.trickplayCarousel)
-        m.trickplayCarousel.isVisible = false
-        m.trickplayCarousel.callFunc("reset")
-      end if
-    else if m.top.state = "finished"
-      stopLoadingSpinner()
-      m.playbackTimer.control = "stop"
-      m.playbackTimer.unobserveField("fire")
-      m.bufferCheckTimer.control = "stop"
-      m.bufferCheckTimer.unobserveField("fire")
-      reportPlayback("finished")
-      if isValid(m.trickplayCarousel)
-        m.trickplayCarousel.isVisible = false
-        m.trickplayCarousel.callFunc("reset")
-      end if
-    else
-      m.log.warning("Unhandled state", m.top.state, m.isPlayReported, m.playFinished)
-    end if
-    m.log.debug("end onState", m.top.state)
-  end sub
-
-  '
-  ' Report playback to server
-  sub reportPlayback(state = "update" as string)
-    if not isValid(m.top.position) then return
-
-    m.log.debug("start reportPlayback", state, int(m.top.position))
-
-    ' When force-finished, report position at end of video so the server
-    ' sees a natural completion — matching the mark-played request.
-    positionSeconds = m.top.position
-    if m.forceFinished and (state = "stop" or state = "finished")
-      positionSeconds = m.top.duration
-    end if
-
-    params = {
-      "ItemId": m.top.id,
-      "PlaySessionId": m.top.PlaySessionId,
-      "PositionTicks": int(positionSeconds) * 10000000&, 'Ensure a LongInteger is used
-      "IsPaused": (m.top.state = "paused")
-    }
-    ' Live TV requires MediaSourceId/LiveStreamId for server-side stream tracking
-    if isLiveTvPlayback() and isValid(m.top.transcodeParams)
-      params.append({
-        "MediaSourceId": m.top.transcodeParams.MediaSourceId,
-        "LiveStreamId": m.top.transcodeParams.LiveStreamId
-      })
-      m.bufferCheckTimer.duration = 30
-    end if
-
-    if (state = "stop" or state = "finished") and isValid(m.originalClosedCaptionState)
-      m.log.debug("reportPlayback setting", m.top.globalCaptionMode, "back to", m.originalClosedCaptionState)
-      m.top.globalCaptionMode = m.originalClosedCaptionState
-      m.originalClosedCaptionState = invalid
-    end if
-
-    ' Report playstate via side-effect task
-    req = GetApi().BuildPlaystateRequest(state, params)
-    SubmitSideEffect(req)
-
-    ' Refresh live TV metadata at the program boundary, or on 60 s wall-clock fallback
-    ' when endDate is missing. Wall-clock rather than a tick counter so the interval
-    ' stays at 60 s regardless of playbackTimer duration.
-    if state = "update" and isLiveTvPlayback()
-      now = CreateObject("roDateTime").AsSeconds()
-      if m.liveTvProgramEndTime > 0 and now >= m.liveTvProgramEndTime
-        triggerLiveTvMetadataRefresh()
-      else if m.liveTvProgramEndTime = 0
-        if m.liveTvNextFallbackRefreshAt = 0
-          m.liveTvNextFallbackRefreshAt = now + 60
-        else if now >= m.liveTvNextFallbackRefreshAt
-          m.liveTvNextFallbackRefreshAt = now + 60
-          triggerLiveTvMetadataRefresh()
-        end if
-      end if
-    end if
-
-    m.log.debug("end reportPlayback", state, int(m.top.position))
-  end sub
-
-  '
-  ' Check the the buffering has not hung
-  sub bufferCheck()
-
-    if m.top.state <> "buffering"
-      ' If video is not buffering, stop timer
-      m.bufferCheckTimer.control = "stop"
-      m.bufferCheckTimer.unobserveField("fire")
-      return
-    end if
-    if isValid(m.top.bufferingStatus)
-
-      ' Check that the buffering percentage is increasing
-      if m.top.bufferingStatus["percentage"] > m.bufferPercentage
-        m.bufferPercentage = m.top.bufferingStatus["percentage"]
-      else if isLiveTvPlayback()
-        m.top.callFunc("refresh")
-      else
-        ' If buffering has stopped Display dialog
-        showPlaybackErrorDialog(translate(translationKeys.ErrorThereWasAnErrorRetrievingThe))
-
-        ' Stop playback and exit player
-        m.top.control = "stop"
-      end if
-    end if
-
-  end sub
-
-  function isLiveTvPlayback() as boolean
-    return isValid(m.currentItem) and LCase(m.currentItem.type) = "tvchannel"
-  end function
-
-  sub triggerLiveTvMetadataRefresh()
-    ' Zero the end time first to prevent duplicate refresh triggers
-    m.liveTvProgramEndTime = 0
-
-    if not isValid(m.liveTvRefreshTask)
-      m.liveTvRefreshTask = CreateObject("roSGNode", "RefreshLiveTvMetadataTask")
-      m.liveTvRefreshTask.observeField("refreshedItem", "onLiveTvMetadataRefreshed")
-    end if
-
-    m.liveTvRefreshTask.channelId = m.top.id
-    m.liveTvRefreshTask.control = "RUN"
-  end sub
-
-  sub onLiveTvMetadataRefreshed()
-    m.liveTvRefreshTask.control = "STOP"
-    meta = m.liveTvRefreshTask.refreshedItem
-    if not isValid(meta) then return
-
-    m.osd.itemData = meta
-
-    ' Logo priority: program logo → program primary → channel icon. Always write the result
-    ' (empty string included) so the prior program's logo doesn't linger when the new one
-    ' has no artwork. Mirrors the initial-load chain in LoadVideoContentTask.
-    newLogoUrl as string = ""
-    if meta.type = "TvChannel"
-      osdLogoSize = imageSize.LOGO_OSD
-      currentProgram = meta.currentProgram
-      if isValid(currentProgram) and isValidAndNotEmpty(currentProgram.logoImageTag)
-        newLogoUrl = ImageURL(currentProgram.id, "Logo", { maxHeight: osdLogoSize.height, maxWidth: osdLogoSize.width, quality: 90, tag: currentProgram.logoImageTag })
-      else if isValid(currentProgram) and isValidAndNotEmpty(currentProgram.primaryImageTag)
-        newLogoUrl = ImageURL(currentProgram.id, "Primary", { maxHeight: osdLogoSize.height, maxWidth: osdLogoSize.width, quality: 90, tag: currentProgram.primaryImageTag })
-      else if isValidAndNotEmpty(meta.primaryImageTag)
-        newLogoUrl = ImageURL(meta.id, "Primary", { maxHeight: osdLogoSize.height, maxWidth: osdLogoSize.width, quality: 90, tag: meta.primaryImageTag })
-      end if
-    end if
-    m.osd.videoLogo = newLogoUrl
-
-    m.liveTvProgramEndTime = parseProgramEndTimeEpoch(meta)
-    m.liveTvNextFallbackRefreshAt = 0
-  end sub
-
-  ' Collapsed from LoadChannelListForQueueTask, a pure-fetch Task that existed only to
-  ' move one fetchRes off the render thread (Phase-4 collapse; see docs/dev/promises.md).
-  ' Fire-once per playback (guarded by m.channelListLoaded), so no seq guard is needed —
-  ' a single .then can't race itself the way a hot re-fire would.
-  sub loadChannelListForQueue()
-    currentChannelId = m.top.id
-    if not isValidAndNotEmpty(currentChannelId) then return
-
-    req = GetApi().BuildGetLiveTVChannelsRequest({
-      SortBy: "Number",
-      SortOrder: "Ascending",
-      UserId: m.global.user.id,
-      enableImages: false,
-      addCurrentProgram: false,
-      enableUserData: false
-    })
-    m.log.info("Loading channel list for navigation", currentChannelId)
-
-    ' Carry currentChannelId through the promise context (no closures in BS).
-    promises.chain(fetchAsync(req, "channelList-" + m.top.id), { currentChannelId: currentChannelId }).then(sub(res as object, ctx as object)
-      ' Any HTTP response lands here (incl. 4xx/5xx). Replicates the old Task's
-      ' loadChannelList(): bail on a bad payload, otherwise build + install the queue.
-      if not res.ok or not isValid(res.json) or not isValid(res.json.Items)
-        m.log.warn("Failed to load channel list")
-        return
-      end if
-
-      ' buildChannelQueueList is a light array→array transform (source/utils/liveTv.bs) —
-      ' render-thread-safe (no node creation), which is why this Task was a collapse candidate.
-      built = buildChannelQueueList(res.json.Items, ctx.currentChannelId)
-
-      if not isValidAndNotEmpty(built.items) or built.currentIndex < 0
-        m.log.warn("Channel list empty or current channel not found, skipping queue update")
-        return
-      end if
-
-      queueManager = m.global.queueManager
-      queueManager.callFunc("set", built.items)
-      queueManager.callFunc("setPosition", built.currentIndex)
-      m.channelListLoaded = true
-
-      m.log.info("Channel list loaded into queue", "count", built.items.count(), "position", built.currentIndex)
-    end sub).catch(sub(err as object)
-      ' Transport failure / timeout (see the error contract) — never completed.
-      m.log.warn("Failed to load channel list", err.reason)
-    end sub)
-  end sub
-
-  ' stateAllowsOSD: Check if current video state allows showing the OSD
-  '
-  ' @return {boolean} indicating if video state allows the OSD to show
-  function stateAllowsOSD() as boolean
-    validStates = ["playing", "paused", "stopped"]
-    return inArray(validStates, m.top.state)
-  end function
-
-
-  ' availSubtitleTrackIdx: Returns Roku's index for requested subtitle track
-  '
-  ' @param {string} tracknameToFind - TrackName for subtitle we're looking to match
-  ' @return {integer} indicating Roku's index for requested subtitle track. Returns SubtitleSelection.NONE if not found
-  function availSubtitleTrackIdx(tracknameToFind as string) as integer
-    idx = 0
-    for each availTrack in m.top.availableSubtitleTracks
-      ' The TrackName must contain the URL we supplied originally, though
-      ' Roku mangles the name a bit, so we check if the URL is a substring, rather
-      ' than strict equality
-      if inStr(1, availTrack.TrackName, tracknameToFind)
-        return idx
-      end if
-      idx = idx + 1
-    end for
-    return SubtitleSelection.NONE
-  end function
-
-  function onKeyEvent(key as string, press as boolean) as boolean
-
-    ' Keypress handler while user is inside the chapter menu
-    if m.chapterMenu.hasFocus()
-      if not press then return false
-
-      if key = "OK"
-        focusedChapter = m.chapterMenu.itemFocused
-        selectedChapter = m.chapterMenu.content.getChild(focusedChapter)
-        seekTime = selectedChapter.playstart
-
-        ' Don't seek if user clicked on No Chapter Data
-        if seekTime = m.playbackEnum.null then return true
-
-        m.top.seek = seekTime
-        return true
-      end if
-
-      if key = "back" or key = "replay"
-        m.chapterList.visible = false
-        m.osd.shouldShowChapterList = false
-        m.chapterMenu.setFocus(false)
-        m.osd.hasFocus = true
-        m.osd.setFocus(true)
-        return true
-      end if
-
-      if key = "play"
-        handleVideoPlayPauseAction()
-      end if
-
-      return true
-    end if
-
-    ' VideoNotification components handle OK key internally via their onKeyEvent.
-    ' For non-OK keys, hide notifications (paused state) so they can re-show after OSD closes.
-    ' Next Episode is dismissed but will re-appear on subsequent position updates if still in the time window.
-    if isNotificationVisible(m.nextEpisodeNotification) or isNotificationVisible(m.segmentNotification)
-      ' OK is handled by the notification's onKeyEvent — don't intercept here
-      if key <> "OK"
-        if m.segmentNotification.state = "showing"
-          m.segmentNotification.callFunc("hide")
-        end if
-        if m.nextEpisodeNotification.state = "showing"
-          m.nextEpisodeNotification.callFunc("dismiss")
-        end if
-        m.top.setFocus(true)
-      end if
-    end if
-
-    if not press then return false
-
-    if key = "down" and not m.top.trickPlayBar.visible
-      ' Don't allow user to open menu prior to video loading
-      if not stateAllowsOSD() then return true
-
-      m.osd.visible = true
-      m.osd.hasFocus = true
-      m.osd.setFocus(true)
-      return true
-
-    else if key = "up" and not m.top.trickPlayBar.visible
-      ' Don't allow user to open menu prior to video loading
-      if not stateAllowsOSD() then return true
-
-      m.osd.visible = true
-      m.osd.hasFocus = true
-      m.osd.setFocus(true)
-      return true
-
-    else if key = "OK" and not m.top.trickPlayBar.visible
-      ' Don't allow user to open menu prior to video loading
-      if not stateAllowsOSD() then return true
-
-      ' Show OSD, but don't pause video
-      m.osd.visible = true
-      m.osd.hasFocus = true
-      m.osd.setFocus(true)
-      return true
-    end if
-
-    ' Disable OSD for intro videos
-    if key = "play" and not m.top.trickPlayBar.visible
-
-      ' Don't allow user to open menu prior to video loading
-      if not stateAllowsOSD() then return true
-
-      ' If video is paused, resume it and don't show OSD
-      if m.top.state = "paused"
-        m.top.control = "resume"
-        return true
-      end if
-
-      ' Pause video and show OSD
-      m.top.control = "pause"
-      m.osd.playbackState = "paused"
-      m.osd.visible = true
-      m.osd.hasFocus = true
-      m.osd.setFocus(true)
-      return true
-    end if
-
-    if key = "back"
-      m.top.control = "stop"
-    end if
-
-    ' Handle OK/Play key during seek - hide carousel and let Roku seek to its position
-    ' Since we're now synced to Roku's position via the trickPlayBar text observer,
-    ' we don't need to do our own seek - Roku's native seek will match our displayed thumbnail
-    if (key = "OK" or key = "play") and m.top.trickPlayBar.visible
-
-      m.isTrackingSeek = false
-      if isValid(m.trickplayCarousel)
-        ' Hide carousel immediately on seek confirmation
-        m.trickplayCarousel.isVisible = false
-        ' Set flag to prevent auto-show (line 790 guard) until trickPlayBar closes (line 797 reset)
-        ' This prevents carousel flashing back on between OK press and trickPlayBar closing
-        m.carouselHiddenForSeek = true
-      end if
-      ' Return false to let Roku handle the seek and close the trickPlayBar
-      return false
-    end if
-
-    ' Handle left/right/FF/RW keys - show carousel, observer syncs position from trickPlayBar text
-    if not m.osd.visible and (key = "left" or key = "right" or key = "fastforward" or key = "rewind")
-      if isValid(m.trickplayCarousel)
-        m.trickplayCarousel.isVisible = true
-      end if
-      return false
-    end if
-
-    return false
-  end function
-
-  ' onDestroy: Full teardown releasing all resources before component removal
-  ' Called by SceneManager when popping this scene
-  sub onDestroy()
-    ' Unobserve all fields first to prevent callbacks during teardown
-    m.top.unobserveField("state")
-    m.top.unobserveField("content")
-    m.top.unobserveField("selectedSubtitle")
-    m.top.unobserveField("audioIndex")
-    m.top.unobserveField("mediaSourceId")
-    m.top.unobserveField("shouldAllowCaptions")
-    m.top.unobserveField("subtitleTrack")
-    m.top.unobserveField("globalCaptionMode")
-    m.top.unobserveField("position")
-
-    if isValid(m.osd)
-      m.osd.unobserveField("action")
-      m.osd.callFunc("onDestroy")
-    end if
-
-    ' Stop and release timers
-    if isValid(m.playbackTimer)
-      m.playbackTimer.control = "stop"
-      m.playbackTimer.unobserveField("fire")
-      m.playbackTimer = invalid
-    end if
-
-    if isValid(m.bufferCheckTimer)
-      m.bufferCheckTimer.control = "stop"
-      m.bufferCheckTimer.unobserveField("fire")
-      m.bufferCheckTimer = invalid
-    end if
-
-    ' Stop and release task nodes
-    if isValid(m.LoadMetaDataTask)
-      m.LoadMetaDataTask.control = "STOP"
-      m.LoadMetaDataTask.unobserveField("content")
-      m.LoadMetaDataTask = invalid
-    end if
-
-    if isValid(m.liveTvRefreshTask)
-      m.liveTvRefreshTask.control = "STOP"
-      m.liveTvRefreshTask.unobserveField("refreshedItem")
-      m.liveTvRefreshTask = invalid
-    end if
-    m.liveTvProgramEndTime = 0
-
-    if isValid(m.captionTask)
-      m.captionTask.control = "STOP"
-      m.captionTask.unobserveField("currentCaption")
-      m.captionTask.unobserveField("useThis")
-      m.captionTask.callFunc("onDestroy")
-      m.captionTask = invalid
-    end if
-
-    ' Unobserve trickPlayBar position text
-    if isValid(m.trickPlayBarPositionText)
-      m.trickPlayBarPositionText.unobserveField("text")
-      m.trickPlayBarPositionText = invalid
-    end if
-
-    ' Destroy child components that have onDestroy()
-    if isValid(m.trickplayCarousel)
-      m.trickplayCarousel.callFunc("onDestroy")
-      m.trickplayCarousel = invalid
-    end if
-
-    ' Destroy notification components
-    if isValid(m.segmentNotification)
-      m.segmentNotification.unobserveField("action")
-      m.segmentNotification.unobserveField("state")
-      m.segmentNotification.callFunc("onDestroy")
-      m.segmentNotification = invalid
-    end if
-
-    if isValid(m.nextEpisodeNotification)
-      m.nextEpisodeNotification.unobserveField("action")
-      m.nextEpisodeNotification.unobserveField("state")
-      m.nextEpisodeNotification.callFunc("onDestroy")
-      m.nextEpisodeNotification = invalid
-    end if
-
-    ' Clear segment state
-    m.mediaSegments = []
-    m.skippedSegments = {}
-    m.dismissedSegmentId = ""
-    m.activeSegmentId = ""
-
-    ' Clear remaining node references
-    m.osd = invalid
-    m.chapterList = invalid
-    m.chapterMenu = invalid
-    m.chapterContent = invalid
-    m.captionGroup = invalid
-  end sub
-
-  ' handleTransport: Roku voice transport handler. Called from source/main.bs when an
-  ' roInputEvent with info.type = "transport" arrives and the active scene is this player.
-  '
-  ' Returns { status: "<code>" } per roInput.EventResponse() — Roku OS uses the status
-  ' to render the appropriate HUD message. Codes used here:
-  '   - success / success.seek-start / success.seek-end — op completed (with bounds note)
-  '   - error.redundant — state already matches request (e.g. pause-while-paused)
-  '   - error.generic — op semantically unsupported in this context
-  '   - unhandled — command we don't recognize; lets Roku show "Command not available"
-  '
-  ' See https://github.com/rokudev/dev-doc — docs/DEVELOPER/media-playback/voice-controls/transport-controls.md
-  function handleTransport(evt as object) as object
-    if not isValid(evt) or not isValid(evt.command) then return { status: "unhandled" }
-    cmd = lcase(evt.command)
-    m.log.info("voice transport", cmd)
-
-    if cmd = "play" or cmd = "resume"
-      if m.top.state = "paused"
-        m.top.control = "resume"
-        return { status: "success" }
-      end if
-      if m.top.state = "playing" then return { status: "error.redundant" }
-      m.top.control = "play"
-      return { status: "success" }
-    end if
-
-    if cmd = "pause"
-      if m.top.state = "paused" then return { status: "error.redundant" }
-      m.top.control = "pause"
-      return { status: "success" }
-    end if
-
-    if cmd = "stop"
-      ' Mirror back-key behavior: stop playback AND leave the play route. onState reports
-      ' the stop to Jellyfin; the physical back key leaves the route for free (bubbles to
-      ' the outlet -> goBack), but voice transport doesn't, so exit explicitly via the host.
-      m.top.control = "stop"
-      host = m.top.getParent()
-      if isValid(host) then host.callFunc("exitPlayback")
-      return { status: "success" }
-    end if
-
-    if cmd = "ok"
-      ' Mirror physical OK in idle video state — open the OSD. If already visible,
-      ' physical OK activates the focused button; voice can't replicate that without
-      ' synthesizing a key event, so treat the second voice-OK as a redundant noop.
-      if not stateAllowsOSD() then return { status: "error.generic" }
-      if isValid(m.osd) and m.osd.visible then return { status: "error.redundant" }
-      m.osd.visible = true
-      m.osd.hasFocus = true
-      m.osd.setFocus(true)
-      return { status: "success" }
-    end if
-
-    if cmd = "forward"
-      m.top.control = "fastforward"
-      return { status: "success" }
-    end if
-
-    if cmd = "rewind"
-      m.top.control = "rewind"
-      return { status: "success" }
-    end if
-
-    if cmd = "replay"
-      return seekRelativeWithBounds(-getInstantReplaySeconds())
-    end if
-
-    if cmd = "startover"
-      return seekToWithBounds(0)
-    end if
-
-    if cmd = "seek"
-      return handleVoiceSeekCommand(evt)
-    end if
-
-    if cmd = "next"
-      return handleVoiceNextItem()
-    end if
-
-    if cmd = "skip"
-      ' Try to skip an active media segment first; fall through to next-item if none.
-      if tryActiveSegmentSkip() then return { status: "success" }
-      return handleVoiceNextItem()
-    end if
-
-    if cmd = "nowplaying"
-      return announceNowPlaying()
-    end if
-
-    if cmd = "shuffle" or cmd = "loop"
-      ' Video player has no shuffle/loop UI. Audio player handles these.
-      return { status: "error.generic" }
-    end if
-
-    if cmd = "like"
-      return setFavorite(true)
-    end if
-
-    if cmd = "dislike"
-      return setFavorite(false)
-    end if
-
-    return { status: "unhandled" }
-  end function
-
-  function getInstantReplaySeconds() as integer
-    return voiceTransport.resolveInstantReplaySeconds(m.global.user.settings.playbackInstantReplaySeconds)
-  end function
-
-  function seekRelativeWithBounds(deltaSeconds as integer) as object
-    if not isValid(m.top.position) then return { status: "error.generic" }
-    return seekToWithBounds(m.top.position + deltaSeconds)
-  end function
-
-  ' 30s end-slack matches the Roku transport-controls reference example for video —
-  ' clamping shy of duration prevents the player from firing end-of-content immediately.
-  function seekToWithBounds(targetSeconds as float) as object
-    result = voiceTransport.computeSeekStatus(targetSeconds, m.top.duration, 30)
-    m.top.seek = result.clamped
-    return { status: result.status }
-  end function
-
-  function handleVoiceSeekCommand(evt as object) as object
-    parsed = voiceTransport.parseSeekDelta(evt)
-    if not parsed.valid then return { status: "error.generic" }
-    return seekRelativeWithBounds(parsed.delta)
-  end function
-
-  ' Skip an active media segment (intro/recap/etc.) if one is currently in-window.
-  ' Returns true if a segment was skipped, false if no active segment.
-  function tryActiveSegmentSkip() as boolean
-    if not isValid(m.activeSegmentId) or m.activeSegmentId = "" then return false
-    if not isValid(m.mediaSegments) or m.mediaSegments.count() = 0 then return false
-    segment = findSegmentById(m.mediaSegments, m.activeSegmentId)
-    if not isValid(segment) then return false
-
-    seekPosition = segmentTicksToSeconds(segment.EndTicks)
-    segmentType = segment.Type ?? ""
-
-    ' Outro near end-of-content: force-finish so watched-state and auto-play fire.
-    if segmentType = MediaSegmentType.OUTRO and m.top.duration > 0 and seekPosition >= m.top.duration - 5
-      forceFinishPlayback()
-    else
-      m.top.seek = seekPosition
-      m.skippedSegments[m.activeSegmentId] = true
-    end if
-
-    m.activeSegmentId = ""
-    if isValid(m.segmentNotification) and isNotificationVisible(m.segmentNotification)
+  else
+    ' Not inside any segment — dismiss segment notification if visible or paused
+    if isNotificationVisible(m.segmentNotification) or m.segmentNotification.state = "paused"
+      m.log.verbose("Left segment, dismissing notification")
       m.segmentNotification.callFunc("dismiss")
     end if
-    return true
-  end function
+    m.activeSegmentId = ""
+    m.dismissedSegmentId = ""
+  end if
+end sub
 
-  ' Reuse the OSD itemNext code path so Live-TV channel advance, queue advance, and
-  ' Episode→next-Episode all behave identically to pressing the on-screen Next button.
-  function handleVoiceNextItem() as object
-    queueManager = m.global.queueManager
-    if not isValid(queueManager) then return { status: "error.generic" }
-    queueCount = queueManager.callFunc("getCount")
-    queuePosition = queueManager.callFunc("getPosition")
-    isTvChannel = isLiveTvPlayback() and m.channelListLoaded and queueCount > 1
-
-    targetPosition = -1
-    if queuePosition < queueCount - 1
-      targetPosition = queuePosition + 1
-    else if isTvChannel
-      targetPosition = 0
+' Handler for segment notification action
+sub onSegmentNotificationAction()
+  action = m.segmentNotification.action
+  if action = "activated"
+    if m.activeSegmentId = ""
+      m.log.warn("Segment skip activated with no active segment")
+      return
     end if
 
-    if targetPosition < 0 then return { status: "error.generic" }
-    switchToQueueItem(queueManager, targetPosition)
-    return { status: "success" }
-  end function
+    m.log.info("Segment skip activated by user", m.activeSegmentId)
+    segment = findSegmentById(m.mediaSegments, m.activeSegmentId)
+    if isValid(segment)
+      seekPosition = segmentTicksToSeconds(segment.EndTicks)
+      segmentType = segment.Type ?? ""
 
-  ' Returns the metadata in the response — main.bs's transport dispatcher calls
-  ' roAppManager.SetNowPlayingContentMetaData() on the MAIN thread (roAppManager
-  ' can't be created on the render thread, where this callFunc executes).
-  function announceNowPlaying() as object
-    if not isValid(m.osd) or not isValid(m.osd.itemData) then return { status: "error.generic" }
-    item = m.osd.itemData
-    title = voiceTransport.formatNowPlayingTitle(item)
-    if title = "" then return { status: "error.generic" }
-    return {
-      status: "success",
-      nowPlaying: {
-        title: title,
-        contentType: item.type ?? ""
-      }
-    }
-  end function
+      ' Outro ending near video end: force finish for watched-status and auto-play
+      if segmentType = MediaSegmentType.OUTRO and m.top.duration > 0 and seekPosition >= m.top.duration - 5
+        forceFinishPlayback()
+        return
+      end if
 
-  function setFavorite(isLike as boolean) as object
-    if not isValid(m.osd) or not isValid(m.osd.itemData) or not isValid(m.osd.itemData.id)
-      return { status: "error.generic" }
-    end if
-    itemId = m.osd.itemData.id
-    if itemId = "" then return { status: "error.generic" }
-    if isLike
-      SubmitSideEffect(GetApi().BuildMarkFavoriteRequest(itemId))
+      m.top.seek = seekPosition
+      m.skippedSegments[m.activeSegmentId] = true
     else
-      SubmitSideEffect(GetApi().BuildUnmarkFavoriteRequest(itemId))
+      m.log.warn("Active segment not found for skip", m.activeSegmentId)
     end if
+    m.activeSegmentId = ""
+    m.top.setFocus(true)
+  else if action = "dismissed"
+    m.log.verbose("Segment notification dismissed", m.activeSegmentId)
+    ' Mark as dismissed for this visit — allows re-show if user leaves and re-enters the segment
+    if m.activeSegmentId <> ""
+      m.dismissedSegmentId = m.activeSegmentId
+      m.activeSegmentId = ""
+    end if
+    ' Only restore video focus if OSD didn't take focus during the dismiss animation
+    if not m.osd.visible
+      m.top.setFocus(true)
+    end if
+  end if
+end sub
+
+' Safety net: ensure focus isn't orphaned after notification dismissal animation completes
+sub onNotificationStateChanged()
+  if m.segmentNotification.state = "hidden" or m.nextEpisodeNotification.state = "hidden"
+    if not m.osd.visible and not m.top.hasFocus()
+      m.top.setFocus(true)
+    end if
+  end if
+end sub
+
+' When Video Player state changes
+sub onPositionChanged()
+  ' Fall back to content.length (which Jellyfin populates from mediaSource.RunTimeTicks)
+  ' when Roku's own duration probe returns 0. This happens with live-transcoded progressive
+  ' MKV: ffmpeg can't know the final duration while encoding, so it writes 0 into the
+  ' MKV SegmentInfo header, and Roku's probe inherits that. Without this fallback,
+  ' progressPercentage stays pinned at 0, and since the OSD only observes progressPercentage,
+  ' the progress bar never advances and timestamps never refresh.
+  effectiveDuration = m.top.duration
+  if effectiveDuration <= 0 and isValid(m.top.content) and m.top.content.length > 0
+    effectiveDuration = m.top.content.length
+  end if
+
+  if effectiveDuration <= 0
+    m.osd.progressPercentage = 0
+  else
+    m.osd.progressPercentage = m.top.position / effectiveDuration
+  end if
+  m.osd.positionTime = m.top.position
+  m.osd.remainingPositionTime = effectiveDuration - m.top.position
+
+  if isValid(m.captionTask)
+    m.captionTask.currentPos = Int(m.top.position * 1000)
+  end if
+
+  ' Update trickplay carousel's playback position for proactive tile caching
+  ' This runs even when carousel is not visible to keep cache warm
+  if isValid(m.trickplayCarousel)
+    m.trickplayCarousel.playbackPosition = m.top.position
+  end if
+
+  ' Check if dialog is open
+  m.dialog = m.top.getScene().findNode("dialogBackground")
+  if not isValid(m.dialog)
+    ' Do not check segments or next episode for intro videos
+    if not m.LoadMetaDataTask.isIntro
+      checkMediaSegments()
+      checkTimeToDisplayNextEpisode()
+    end if
+  end if
+
+  ' Carousel visibility state machine:
+  ' 1. Normal scrubbing: carousel auto-shows when trickPlayBar visible (not OSD)
+  ' 2. Seek confirmation: when user presses OK, carousel is hidden (line 1146) and
+  '    m.carouselHiddenForSeek flag prevents auto-show until seek completes
+  ' 3. Seek completion: when trickPlayBar closes, flags reset and carousel ready for next scrub
+  ' This prevents the carousel from flashing back on between OK press and trickPlayBar closing
+  if isValid(m.trickplayCarousel) and not m.carouselHiddenForSeek
+    trickPlayBarVisible = m.top.trickPlayBar.visible and not m.osd.visible
+    m.trickplayCarousel.isVisible = trickPlayBarVisible
+
+    ' Reset seek tracking when trickPlayBar closes (user confirmed or cancelled seek)
+    if not trickPlayBarVisible
+      m.isTrackingSeek = false
+      m.carouselHiddenForSeek = false
+      m.lastSentThumbnailIndex = -1 ' Reset so next scrub session sends initial position
+    end if
+  end if
+
+  ' Update trickplay carousel position during normal playback only
+  ' When trickPlayBar is visible, onTrickPlayBarTextChange is the authoritative source
+  if isValid(m.trickplayCarousel) and m.trickplayCarousel.isVisible and not m.top.trickPlayBar.visible
+    updateTrickplayCarousel(m.top.position)
+  end if
+end sub
+
+' Updates trickplay carousel with index calculated from video position
+' Snaps to thumbnail boundaries for cleaner UX
+' @param {Float} position - Video position in seconds
+sub updateTrickplayCarousel(position as float)
+  if not isValid(m.trickplayCarousel) then return
+  if not isValidAndNotEmpty(m.trickplayCarousel.trickplayConfig) then return
+
+  interval = m.trickplayCarousel.trickplayConfig.interval
+
+  ' Calculate thumbnail index from position
+  thumbnailIndex = trickplay.calculateThumbnailIndex(position, interval)
+
+  ' Skip if same index as last sent - prevents double-rendering at tile boundaries
+  ' when both onPositionChanged and onTrickPlayBarTextChange fire with similar positions
+  if thumbnailIndex = m.lastSentThumbnailIndex then return
+  m.lastSentThumbnailIndex = thumbnailIndex
+
+  ' Update carousel with index (triggers shifting logic)
+  m.trickplayCarousel.thumbnailIndex = thumbnailIndex
+end sub
+
+' Called when Roku's trickPlayBar position text changes
+' Parses the time string to get seek position and syncs our carousel
+' This ensures carousel stays in sync with Roku's authoritative seek position
+sub onTrickPlayBarTextChange()
+  if not m.top.trickPlayBar.visible then return
+  if not isValid(m.trickPlayBarPositionText) then return
+
+  timeText = m.trickPlayBarPositionText.text
+  if not isValidAndNotEmpty(timeText) then return
+
+  ' Parse time string "53:50" (MM:SS) or "1:23:45" (H:MM:SS) to seconds
+  seekPosition = timeText.split(":")
+  seekTime = 0
+
+  if seekPosition.count() = 3
+    ' H:MM:SS format
+    seekTime = seekPosition[0].toInt() * 3600 ' hours
+    seekTime = seekTime + seekPosition[1].toInt() * 60 ' minutes
+    seekTime = seekTime + seekPosition[2].toInt() ' seconds
+  else if seekPosition.count() = 2
+    ' MM:SS format
+    seekTime = seekPosition[0].toInt() * 60 ' minutes
+    seekTime = seekTime + seekPosition[1].toInt() ' seconds
+  else
+    ' Unexpected format - use current position as fallback
+    seekTime = m.top.position
+  end if
+
+  m.log.debug("TrickPlayBar text changed", timeText, "parsed to", seekTime, "seconds")
+
+  ' Sync carousel with Roku's authoritative seek position
+  m.isTrackingSeek = true
+
+  ' Update carousel to match
+  if isValid(m.trickplayCarousel) and m.trickplayCarousel.isVisible
+    updateTrickplayCarousel(seekTime)
+  end if
+end sub
+
+' retryPlayback: Re-runs the content loader from the current position with updated task flags.
+' Used by error handlers to retry without exiting the player.
+' @param {boolean} bypassDovi - skips DoVi container profile so the server can grant direct play
+' @param {boolean} forceTranscode - disables direct play so the server returns a transcode URL
+sub retryPlayback(bypassDovi as boolean, forceTranscode as boolean)
+  m.global.queueManager.callFunc("setCurrentStartingPoint", int(m.top.position) * 10000000&)
+  ' Prevents PlayerHostView from advancing/exiting when stop causes Roku to fire "finished".
+  m.top.isRetrying = true
+  m.top.control = "stop"
+  m.LoadMetaDataTask.shouldBypassDoviPreservation = bypassDovi
+  m.LoadMetaDataTask.shouldForceTranscoding = forceTranscode
+  m.LoadMetaDataTask.selectedSubtitleIndex = m.top.SelectedSubtitle
+  m.LoadMetaDataTask.selectedAudioStreamIndex = m.top.audioIndex
+  m.LoadMetaDataTask.itemId = m.currentItem.id
+  m.LoadMetaDataTask.observeField("content", "onVideoContentLoaded")
+  m.LoadMetaDataTask.control = "RUN"
+end sub
+
+'
+' When Video Player state changes
+sub onState()
+  ' On first play, verify audioTrack matches the intended Jellyfin selection using
+  ' Roku's availableAudioTracks (now populated). The Index + 1 fallback set during
+  ' onVideoContentLoaded may be wrong for non-standard MKV track numbering.
+  if m.top.state = "playing" and not m.isPlayReported
+    if isValid(m.top.availableAudioTracks) and isValid(m.top.audioIndex) and not m.top.isTranscoded
+      correctedTrack = getRokuAudioTrackPosition(m.top.audioIndex, m.top.fullAudioData, m.top.availableAudioTracks)
+      if correctedTrack <> m.top.audioTrack
+        m.log.info("Correcting audioTrack on first play", "was", m.top.audioTrack, "corrected", correctedTrack, "jellyfinIndex", m.top.audioIndex)
+        m.top.audioTrack = correctedTrack
+      else
+        m.log.debug("audioTrack verified correct on first play", "audioTrack", m.top.audioTrack, "jellyfinIndex", m.top.audioIndex)
+      end if
+    end if
+  end if
+
+  if isValid(m.captionTask)
+    m.captionTask.playerState = m.top.state + m.top.globalCaptionMode
+  end if
+
+  ' Pass video state into OSD
+  m.osd.playbackState = m.top.state
+
+  if m.top.state = "buffering"
+    ' When buffering, start timer to monitor buffering process
+    if isValid(m.bufferCheckTimer)
+      m.bufferCheckTimer.control = "start"
+      m.bufferCheckTimer.ObserveField("fire", "bufferCheck")
+    end if
+    ' Show non-blocking spinner for mid-playback buffering (seek, network stall)
+    if m.isPlayReported
+      startLoadingSpinner(false)
+    end if
+  else if m.top.state = "error"
+    m.log.error(m.top.errorCode, m.top.errorMsg, m.top.errorStr, m.isPlayReported, m.top.isTranscodeAvailable)
+
+    print m.top.errorInfo
+
+    ' Detect a Roku video buffer overflow (buffer:loop: source) caused by DoVi transcoding.
+    ' When DoVi preservation forced a transcode and the HLS segments overflow the device buffer,
+    ' retry with direct play by bypassing the DoVi container profile injection.
+    isBufferLoopError = isValid(m.top.errorInfo) and isValid(m.top.errorInfo.source) and m.top.errorInfo.source = "buffer:loop:"
+
+    if isBufferLoopError and m.top.isDoviDirectPlayFallbackAvailable
+      m.log.warn("Buffer overflow in DoVi transcode; falling back to direct play", m.currentItem.id)
+      m.top.isDoviDirectPlayFallbackAvailable = false ' prevent retry loop if direct play also fails
+      retryPlayback(true, false)
+    else if not m.isPlayReported and m.top.isTranscodeAvailable
+      m.log.warn("Direct play failed; falling back to transcode", m.currentItem.id)
+      m.top.isTranscodeAvailable = false ' prevent retry loop if transcode also fails
+      retryPlayback(false, true)
+    else
+      ' If an error was encountered, stop timers and display dialog
+      m.top.unobserveField("state")
+      m.playbackTimer.control = "stop"
+      m.bufferCheckTimer.control = "stop"
+      m.bufferCheckTimer.unobserveField("fire")
+      ' Ensure trickplay carousel is cleaned up on error just like stopped/finished states
+      if isValid(m.trickplayCarousel)
+        m.trickplayCarousel.isVisible = false
+      end if
+      stopLoadingSpinner()
+      showPlaybackErrorDialog(translate(translationKeys.ErrorDuringPlayback))
+    end if
+  else if m.top.state = "playing"
+    stopLoadingSpinner()
+    ' Check if next episode is available
+    if isValid(m.top.showID) and m.top.showID <> "" and not m.checkedForNextEpisode and m.top.content.contenttype = 4
+      fetchNextEpisode()
+    end if
+
+    if m.isPlayReported = false
+      reportPlayback("start")
+      m.isPlayReported = true
+
+      ' Load channel list in background for channel up/down navigation
+      if isLiveTvPlayback() and not m.channelListLoaded
+        loadChannelListForQueue()
+      end if
+    else
+      reportPlayback()
+    end if
+    m.playbackTimer.control = "start"
+  else if m.top.state = "paused"
+    stopLoadingSpinner()
+    m.playbackTimer.control = "stop"
+    reportPlayback()
+  else if m.top.state = "stopped"
+    ' Skip during channel switch; the incoming VideoPlayerView will hide the spinner
+    if not (m.isSwitchingChannel = true)
+      stopLoadingSpinner()
+    end if
+    m.playbackTimer.control = "stop"
+    m.playbackTimer.unobserveField("fire")
+    m.bufferCheckTimer.control = "stop"
+    m.bufferCheckTimer.unobserveField("fire")
+    reportPlayback("stop")
+    m.isPlayReported = false
+    if isValid(m.trickplayCarousel)
+      m.trickplayCarousel.isVisible = false
+      m.trickplayCarousel.callFunc("reset")
+    end if
+  else if m.top.state = "finished"
+    stopLoadingSpinner()
+    m.playbackTimer.control = "stop"
+    m.playbackTimer.unobserveField("fire")
+    m.bufferCheckTimer.control = "stop"
+    m.bufferCheckTimer.unobserveField("fire")
+    reportPlayback("finished")
+    if isValid(m.trickplayCarousel)
+      m.trickplayCarousel.isVisible = false
+      m.trickplayCarousel.callFunc("reset")
+    end if
+  else
+    m.log.warning("Unhandled state", m.top.state, m.isPlayReported, m.playFinished)
+  end if
+  m.log.debug("end onState", m.top.state)
+end sub
+
+'
+' Report playback to server
+sub reportPlayback(state = "update" as string)
+  if not isValid(m.top.position) then return
+
+  m.log.debug("start reportPlayback", state, int(m.top.position))
+
+  ' When force-finished, report position at end of video so the server
+  ' sees a natural completion — matching the mark-played request.
+  positionSeconds = m.top.position
+  if m.forceFinished and (state = "stop" or state = "finished")
+    positionSeconds = m.top.duration
+  end if
+
+  params = {
+    "ItemId": m.top.id,
+    "PlaySessionId": m.top.PlaySessionId,
+    "PositionTicks": int(positionSeconds) * 10000000&, 'Ensure a LongInteger is used
+    "IsPaused": (m.top.state = "paused")
+  }
+  ' Live TV requires MediaSourceId/LiveStreamId for server-side stream tracking
+  if isLiveTvPlayback() and isValid(m.top.transcodeParams)
+    params.append({
+      "MediaSourceId": m.top.transcodeParams.MediaSourceId,
+      "LiveStreamId": m.top.transcodeParams.LiveStreamId
+    })
+    m.bufferCheckTimer.duration = 30
+  end if
+
+  if (state = "stop" or state = "finished") and isValid(m.originalClosedCaptionState)
+    m.log.debug("reportPlayback setting", m.top.globalCaptionMode, "back to", m.originalClosedCaptionState)
+    m.top.globalCaptionMode = m.originalClosedCaptionState
+    m.originalClosedCaptionState = invalid
+  end if
+
+  ' Report playstate via side-effect task
+  req = GetApi().BuildPlaystateRequest(state, params)
+  SubmitSideEffect(req)
+
+  ' Refresh live TV metadata at the program boundary, or on 60 s wall-clock fallback
+  ' when endDate is missing. Wall-clock rather than a tick counter so the interval
+  ' stays at 60 s regardless of playbackTimer duration.
+  if state = "update" and isLiveTvPlayback()
+    now = CreateObject("roDateTime").AsSeconds()
+    if m.liveTvProgramEndTime > 0 and now >= m.liveTvProgramEndTime
+      triggerLiveTvMetadataRefresh()
+    else if m.liveTvProgramEndTime = 0
+      if m.liveTvNextFallbackRefreshAt = 0
+        m.liveTvNextFallbackRefreshAt = now + 60
+      else if now >= m.liveTvNextFallbackRefreshAt
+        m.liveTvNextFallbackRefreshAt = now + 60
+        triggerLiveTvMetadataRefresh()
+      end if
+    end if
+  end if
+
+  m.log.debug("end reportPlayback", state, int(m.top.position))
+end sub
+
+'
+' Check the the buffering has not hung
+sub bufferCheck()
+
+  if m.top.state <> "buffering"
+    ' If video is not buffering, stop timer
+    m.bufferCheckTimer.control = "stop"
+    m.bufferCheckTimer.unobserveField("fire")
+    return
+  end if
+  if isValid(m.top.bufferingStatus)
+
+    ' Check that the buffering percentage is increasing
+    if m.top.bufferingStatus["percentage"] > m.bufferPercentage
+      m.bufferPercentage = m.top.bufferingStatus["percentage"]
+    else if isLiveTvPlayback()
+      m.top.callFunc("refresh")
+    else
+      ' If buffering has stopped Display dialog
+      showPlaybackErrorDialog(translate(translationKeys.ErrorThereWasAnErrorRetrievingThe))
+
+      ' Stop playback and exit player
+      m.top.control = "stop"
+    end if
+  end if
+
+end sub
+
+function isLiveTvPlayback() as boolean
+  return isValid(m.currentItem) and LCase(m.currentItem.type) = "tvchannel"
+end function
+
+sub triggerLiveTvMetadataRefresh()
+  ' Zero the end time first to prevent duplicate refresh triggers
+  m.liveTvProgramEndTime = 0
+
+  if not isValid(m.liveTvRefreshTask)
+    m.liveTvRefreshTask = CreateObject("roSGNode", "RefreshLiveTvMetadataTask")
+    m.liveTvRefreshTask.observeField("refreshedItem", "onLiveTvMetadataRefreshed")
+  end if
+
+  m.liveTvRefreshTask.channelId = m.top.id
+  m.liveTvRefreshTask.control = "RUN"
+end sub
+
+sub onLiveTvMetadataRefreshed()
+  m.liveTvRefreshTask.control = "STOP"
+  meta = m.liveTvRefreshTask.refreshedItem
+  if not isValid(meta) then return
+
+  m.osd.itemData = meta
+
+  ' Logo priority: program logo → program primary → channel icon. Always write the result
+  ' (empty string included) so the prior program's logo doesn't linger when the new one
+  ' has no artwork. Mirrors the initial-load chain in LoadVideoContentTask.
+  newLogoUrl as string = ""
+  if meta.type = "TvChannel"
+    osdLogoSize = imageSize.LOGO_OSD
+    currentProgram = meta.currentProgram
+    if isValid(currentProgram) and isValidAndNotEmpty(currentProgram.logoImageTag)
+      newLogoUrl = ImageURL(currentProgram.id, "Logo", { maxHeight: osdLogoSize.height, maxWidth: osdLogoSize.width, quality: 90, tag: currentProgram.logoImageTag })
+    else if isValid(currentProgram) and isValidAndNotEmpty(currentProgram.primaryImageTag)
+      newLogoUrl = ImageURL(currentProgram.id, "Primary", { maxHeight: osdLogoSize.height, maxWidth: osdLogoSize.width, quality: 90, tag: currentProgram.primaryImageTag })
+    else if isValidAndNotEmpty(meta.primaryImageTag)
+      newLogoUrl = ImageURL(meta.id, "Primary", { maxHeight: osdLogoSize.height, maxWidth: osdLogoSize.width, quality: 90, tag: meta.primaryImageTag })
+    end if
+  end if
+  m.osd.videoLogo = newLogoUrl
+
+  m.liveTvProgramEndTime = parseProgramEndTimeEpoch(meta)
+  m.liveTvNextFallbackRefreshAt = 0
+end sub
+
+' Collapsed from LoadChannelListForQueueTask, a pure-fetch Task that existed only to
+' move one fetchRes off the render thread (Phase-4 collapse; see docs/dev/promises.md).
+' Fire-once per playback (guarded by m.channelListLoaded), so no seq guard is needed —
+' a single .then can't race itself the way a hot re-fire would.
+sub loadChannelListForQueue()
+  currentChannelId = m.top.id
+  if not isValidAndNotEmpty(currentChannelId) then return
+
+  req = GetApi().BuildGetLiveTVChannelsRequest({
+    SortBy: "Number",
+    SortOrder: "Ascending",
+    UserId: m.global.user.id,
+    enableImages: false,
+    addCurrentProgram: false,
+    enableUserData: false
+  })
+  m.log.info("Loading channel list for navigation", currentChannelId)
+
+  ' Carry currentChannelId through the promise context (no closures in BS).
+  promises.chain(fetchAsync(req, "channelList-" + m.top.id), { currentChannelId: currentChannelId }).then(sub(res as object, ctx as object)
+    ' Any HTTP response lands here (incl. 4xx/5xx). Replicates the old Task's
+    ' loadChannelList(): bail on a bad payload, otherwise build + install the queue.
+    if not res.ok or not isValid(res.json) or not isValid(res.json.Items)
+      m.log.warn("Failed to load channel list")
+      return
+    end if
+
+    ' buildChannelQueueList is a light array→array transform (source/utils/liveTv.bs) —
+    ' render-thread-safe (no node creation), which is why this Task was a collapse candidate.
+    built = buildChannelQueueList(res.json.Items, ctx.currentChannelId)
+
+    if not isValidAndNotEmpty(built.items) or built.currentIndex < 0
+      m.log.warn("Channel list empty or current channel not found, skipping queue update")
+      return
+    end if
+
+    queueManager = m.global.queueManager
+    queueManager.callFunc("set", built.items)
+    queueManager.callFunc("setPosition", built.currentIndex)
+    m.channelListLoaded = true
+
+    m.log.info("Channel list loaded into queue", "count", built.items.count(), "position", built.currentIndex)
+  end sub).catch(sub(err as object)
+    ' Transport failure / timeout (see the error contract) — never completed.
+    m.log.warn("Failed to load channel list", err.reason)
+  end sub)
+end sub
+
+' stateAllowsOSD: Check if current video state allows showing the OSD
+'
+' @return {boolean} indicating if video state allows the OSD to show
+function stateAllowsOSD() as boolean
+  validStates = ["playing", "paused", "stopped"]
+  return inArray(validStates, m.top.state)
+end function
+
+
+' availSubtitleTrackIdx: Returns Roku's index for requested subtitle track
+'
+' @param {string} tracknameToFind - TrackName for subtitle we're looking to match
+' @return {integer} indicating Roku's index for requested subtitle track. Returns SubtitleSelection.NONE if not found
+function availSubtitleTrackIdx(tracknameToFind as string) as integer
+  idx = 0
+  for each availTrack in m.top.availableSubtitleTracks
+    ' The TrackName must contain the URL we supplied originally, though
+    ' Roku mangles the name a bit, so we check if the URL is a substring, rather
+    ' than strict equality
+    if inStr(1, availTrack.TrackName, tracknameToFind)
+      return idx
+    end if
+    idx = idx + 1
+  end for
+  return SubtitleSelection.NONE
+end function
+
+function onKeyEvent(key as string, press as boolean) as boolean
+
+  ' Keypress handler while user is inside the chapter menu
+  if m.chapterMenu.hasFocus()
+    if not press then return false
+
+    if key = "OK"
+      focusedChapter = m.chapterMenu.itemFocused
+      selectedChapter = m.chapterMenu.content.getChild(focusedChapter)
+      seekTime = selectedChapter.playstart
+
+      ' Don't seek if user clicked on No Chapter Data
+      if seekTime = m.playbackEnum.null then return true
+
+      m.top.seek = seekTime
+      return true
+    end if
+
+    if key = "back" or key = "replay"
+      m.chapterList.visible = false
+      m.osd.shouldShowChapterList = false
+      m.chapterMenu.setFocus(false)
+      m.osd.hasFocus = true
+      m.osd.setFocus(true)
+      return true
+    end if
+
+    if key = "play"
+      handleVideoPlayPauseAction()
+    end if
+
+    return true
+  end if
+
+  ' VideoNotification components handle OK key internally via their onKeyEvent.
+  ' For non-OK keys, hide notifications (paused state) so they can re-show after OSD closes.
+  ' Next Episode is dismissed but will re-appear on subsequent position updates if still in the time window.
+  if isNotificationVisible(m.nextEpisodeNotification) or isNotificationVisible(m.segmentNotification)
+    ' OK is handled by the notification's onKeyEvent — don't intercept here
+    if key <> "OK"
+      if m.segmentNotification.state = "showing"
+        m.segmentNotification.callFunc("hide")
+      end if
+      if m.nextEpisodeNotification.state = "showing"
+        m.nextEpisodeNotification.callFunc("dismiss")
+      end if
+      m.top.setFocus(true)
+    end if
+  end if
+
+  if not press then return false
+
+  if key = "down" and not m.top.trickPlayBar.visible
+    ' Don't allow user to open menu prior to video loading
+    if not stateAllowsOSD() then return true
+
+    m.osd.visible = true
+    m.osd.hasFocus = true
+    m.osd.setFocus(true)
+    return true
+
+  else if key = "up" and not m.top.trickPlayBar.visible
+    ' Don't allow user to open menu prior to video loading
+    if not stateAllowsOSD() then return true
+
+    m.osd.visible = true
+    m.osd.hasFocus = true
+    m.osd.setFocus(true)
+    return true
+
+  else if key = "OK" and not m.top.trickPlayBar.visible
+    ' Don't allow user to open menu prior to video loading
+    if not stateAllowsOSD() then return true
+
+    ' Show OSD, but don't pause video
+    m.osd.visible = true
+    m.osd.hasFocus = true
+    m.osd.setFocus(true)
+    return true
+  end if
+
+  ' Disable OSD for intro videos
+  if key = "play" and not m.top.trickPlayBar.visible
+
+    ' Don't allow user to open menu prior to video loading
+    if not stateAllowsOSD() then return true
+
+    ' If video is paused, resume it and don't show OSD
+    if m.top.state = "paused"
+      m.top.control = "resume"
+      return true
+    end if
+
+    ' Pause video and show OSD
+    m.top.control = "pause"
+    m.osd.playbackState = "paused"
+    m.osd.visible = true
+    m.osd.hasFocus = true
+    m.osd.setFocus(true)
+    return true
+  end if
+
+  if key = "back"
+    m.top.control = "stop"
+  end if
+
+  ' Handle OK/Play key during seek - hide carousel and let Roku seek to its position
+  ' Since we're now synced to Roku's position via the trickPlayBar text observer,
+  ' we don't need to do our own seek - Roku's native seek will match our displayed thumbnail
+  if (key = "OK" or key = "play") and m.top.trickPlayBar.visible
+
+    m.isTrackingSeek = false
+    if isValid(m.trickplayCarousel)
+      ' Hide carousel immediately on seek confirmation
+      m.trickplayCarousel.isVisible = false
+      ' Set flag to prevent auto-show (line 790 guard) until trickPlayBar closes (line 797 reset)
+      ' This prevents carousel flashing back on between OK press and trickPlayBar closing
+      m.carouselHiddenForSeek = true
+    end if
+    ' Return false to let Roku handle the seek and close the trickPlayBar
+    return false
+  end if
+
+  ' Handle left/right/FF/RW keys - show carousel, observer syncs position from trickPlayBar text
+  if not m.osd.visible and (key = "left" or key = "right" or key = "fastforward" or key = "rewind")
+    if isValid(m.trickplayCarousel)
+      m.trickplayCarousel.isVisible = true
+    end if
+    return false
+  end if
+
+  return false
+end function
+
+' onDestroy: Full teardown releasing all resources before component removal
+' Called by SceneManager when popping this scene
+sub onDestroy()
+  ' Unobserve all fields first to prevent callbacks during teardown
+  m.top.unobserveField("state")
+  m.top.unobserveField("content")
+  m.top.unobserveField("selectedSubtitle")
+  m.top.unobserveField("audioIndex")
+  m.top.unobserveField("mediaSourceId")
+  m.top.unobserveField("shouldAllowCaptions")
+  m.top.unobserveField("subtitleTrack")
+  m.top.unobserveField("globalCaptionMode")
+  m.top.unobserveField("position")
+
+  if isValid(m.osd)
+    m.osd.unobserveField("action")
+    m.osd.callFunc("onDestroy")
+  end if
+
+  ' Stop and release timers
+  if isValid(m.playbackTimer)
+    m.playbackTimer.control = "stop"
+    m.playbackTimer.unobserveField("fire")
+    m.playbackTimer = invalid
+  end if
+
+  if isValid(m.bufferCheckTimer)
+    m.bufferCheckTimer.control = "stop"
+    m.bufferCheckTimer.unobserveField("fire")
+    m.bufferCheckTimer = invalid
+  end if
+
+  ' Stop and release task nodes
+  if isValid(m.LoadMetaDataTask)
+    m.LoadMetaDataTask.control = "STOP"
+    m.LoadMetaDataTask.unobserveField("content")
+    m.LoadMetaDataTask = invalid
+  end if
+
+  if isValid(m.liveTvRefreshTask)
+    m.liveTvRefreshTask.control = "STOP"
+    m.liveTvRefreshTask.unobserveField("refreshedItem")
+    m.liveTvRefreshTask = invalid
+  end if
+  m.liveTvProgramEndTime = 0
+
+  if isValid(m.captionTask)
+    m.captionTask.control = "STOP"
+    m.captionTask.unobserveField("currentCaption")
+    m.captionTask.unobserveField("useThis")
+    m.captionTask.callFunc("onDestroy")
+    m.captionTask = invalid
+  end if
+
+  ' Unobserve trickPlayBar position text
+  if isValid(m.trickPlayBarPositionText)
+    m.trickPlayBarPositionText.unobserveField("text")
+    m.trickPlayBarPositionText = invalid
+  end if
+
+  ' Destroy child components that have onDestroy()
+  if isValid(m.trickplayCarousel)
+    m.trickplayCarousel.callFunc("onDestroy")
+    m.trickplayCarousel = invalid
+  end if
+
+  ' Destroy notification components
+  if isValid(m.segmentNotification)
+    m.segmentNotification.unobserveField("action")
+    m.segmentNotification.unobserveField("state")
+    m.segmentNotification.callFunc("onDestroy")
+    m.segmentNotification = invalid
+  end if
+
+  if isValid(m.nextEpisodeNotification)
+    m.nextEpisodeNotification.unobserveField("action")
+    m.nextEpisodeNotification.unobserveField("state")
+    m.nextEpisodeNotification.callFunc("onDestroy")
+    m.nextEpisodeNotification = invalid
+  end if
+
+  ' Clear segment state
+  m.mediaSegments = []
+  m.skippedSegments = {}
+  m.dismissedSegmentId = ""
+  m.activeSegmentId = ""
+
+  ' Clear remaining node references
+  m.osd = invalid
+  m.chapterList = invalid
+  m.chapterMenu = invalid
+  m.chapterContent = invalid
+  m.captionGroup = invalid
+end sub
+
+' handleTransport: Roku voice transport handler. Called from source/main.bs when an
+' roInputEvent with info.type = "transport" arrives and the active scene is this player.
+'
+' Returns { status: "<code>" } per roInput.EventResponse() — Roku OS uses the status
+' to render the appropriate HUD message. Codes used here:
+'   - success / success.seek-start / success.seek-end — op completed (with bounds note)
+'   - error.redundant — state already matches request (e.g. pause-while-paused)
+'   - error.generic — op semantically unsupported in this context
+'   - unhandled — command we don't recognize; lets Roku show "Command not available"
+'
+' See https://github.com/rokudev/dev-doc — docs/DEVELOPER/media-playback/voice-controls/transport-controls.md
+function handleTransport(evt as object) as object
+  if not isValid(evt) or not isValid(evt.command) then return { status: "unhandled" }
+  cmd = lcase(evt.command)
+  m.log.info("voice transport", cmd)
+
+  if cmd = "play" or cmd = "resume"
+    if m.top.state = "paused"
+      m.top.control = "resume"
+      return { status: "success" }
+    end if
+    if m.top.state = "playing" then return { status: "error.redundant" }
+    m.top.control = "play"
     return { status: "success" }
-  end function
+  end if
+
+  if cmd = "pause"
+    if m.top.state = "paused" then return { status: "error.redundant" }
+    m.top.control = "pause"
+    return { status: "success" }
+  end if
+
+  if cmd = "stop"
+    ' Mirror back-key behavior: stop playback AND leave the play route. onState reports
+    ' the stop to Jellyfin; the physical back key leaves the route for free (bubbles to
+    ' the outlet -> goBack), but voice transport doesn't, so exit explicitly via the host.
+    m.top.control = "stop"
+    host = m.top.getParent()
+    if isValid(host) then host.callFunc("exitPlayback")
+    return { status: "success" }
+  end if
+
+  if cmd = "ok"
+    ' Mirror physical OK in idle video state — open the OSD. If already visible,
+    ' physical OK activates the focused button; voice can't replicate that without
+    ' synthesizing a key event, so treat the second voice-OK as a redundant noop.
+    if not stateAllowsOSD() then return { status: "error.generic" }
+    if isValid(m.osd) and m.osd.visible then return { status: "error.redundant" }
+    m.osd.visible = true
+    m.osd.hasFocus = true
+    m.osd.setFocus(true)
+    return { status: "success" }
+  end if
+
+  if cmd = "forward"
+    m.top.control = "fastforward"
+    return { status: "success" }
+  end if
+
+  if cmd = "rewind"
+    m.top.control = "rewind"
+    return { status: "success" }
+  end if
+
+  if cmd = "replay"
+    return seekRelativeWithBounds(-getInstantReplaySeconds())
+  end if
+
+  if cmd = "startover"
+    return seekToWithBounds(0)
+  end if
+
+  if cmd = "seek"
+    return handleVoiceSeekCommand(evt)
+  end if
+
+  if cmd = "next"
+    return handleVoiceNextItem()
+  end if
+
+  if cmd = "skip"
+    ' Try to skip an active media segment first; fall through to next-item if none.
+    if tryActiveSegmentSkip() then return { status: "success" }
+    return handleVoiceNextItem()
+  end if
+
+  if cmd = "nowplaying"
+    return announceNowPlaying()
+  end if
+
+  if cmd = "shuffle" or cmd = "loop"
+    ' Video player has no shuffle/loop UI. Audio player handles these.
+    return { status: "error.generic" }
+  end if
+
+  if cmd = "like"
+    return setFavorite(true)
+  end if
+
+  if cmd = "dislike"
+    return setFavorite(false)
+  end if
+
+  return { status: "unhandled" }
+end function
+
+function getInstantReplaySeconds() as integer
+  return voiceTransport.resolveInstantReplaySeconds(m.global.user.settings.playbackInstantReplaySeconds)
+end function
+
+function seekRelativeWithBounds(deltaSeconds as integer) as object
+  if not isValid(m.top.position) then return { status: "error.generic" }
+  return seekToWithBounds(m.top.position + deltaSeconds)
+end function
+
+' 30s end-slack matches the Roku transport-controls reference example for video —
+' clamping shy of duration prevents the player from firing end-of-content immediately.
+function seekToWithBounds(targetSeconds as float) as object
+  result = voiceTransport.computeSeekStatus(targetSeconds, m.top.duration, 30)
+  m.top.seek = result.clamped
+  return { status: result.status }
+end function
+
+function handleVoiceSeekCommand(evt as object) as object
+  parsed = voiceTransport.parseSeekDelta(evt)
+  if not parsed.valid then return { status: "error.generic" }
+  return seekRelativeWithBounds(parsed.delta)
+end function
+
+' Skip an active media segment (intro/recap/etc.) if one is currently in-window.
+' Returns true if a segment was skipped, false if no active segment.
+function tryActiveSegmentSkip() as boolean
+  if not isValid(m.activeSegmentId) or m.activeSegmentId = "" then return false
+  if not isValid(m.mediaSegments) or m.mediaSegments.count() = 0 then return false
+  segment = findSegmentById(m.mediaSegments, m.activeSegmentId)
+  if not isValid(segment) then return false
+
+  seekPosition = segmentTicksToSeconds(segment.EndTicks)
+  segmentType = segment.Type ?? ""
+
+  ' Outro near end-of-content: force-finish so watched-state and auto-play fire.
+  if segmentType = MediaSegmentType.OUTRO and m.top.duration > 0 and seekPosition >= m.top.duration - 5
+    forceFinishPlayback()
+  else
+    m.top.seek = seekPosition
+    m.skippedSegments[m.activeSegmentId] = true
+  end if
+
+  m.activeSegmentId = ""
+  if isValid(m.segmentNotification) and isNotificationVisible(m.segmentNotification)
+    m.segmentNotification.callFunc("dismiss")
+  end if
+  return true
+end function
+
+' Reuse the OSD itemNext code path so Live-TV channel advance, queue advance, and
+' Episode→next-Episode all behave identically to pressing the on-screen Next button.
+function handleVoiceNextItem() as object
+  queueManager = m.global.queueManager
+  if not isValid(queueManager) then return { status: "error.generic" }
+  queueCount = queueManager.callFunc("getCount")
+  queuePosition = queueManager.callFunc("getPosition")
+  isTvChannel = isLiveTvPlayback() and m.channelListLoaded and queueCount > 1
+
+  targetPosition = -1
+  if queuePosition < queueCount - 1
+    targetPosition = queuePosition + 1
+  else if isTvChannel
+    targetPosition = 0
+  end if
+
+  if targetPosition < 0 then return { status: "error.generic" }
+  switchToQueueItem(queueManager, targetPosition)
+  return { status: "success" }
+end function
+
+' Returns the metadata in the response — main.bs's transport dispatcher calls
+' roAppManager.SetNowPlayingContentMetaData() on the MAIN thread (roAppManager
+' can't be created on the render thread, where this callFunc executes).
+function announceNowPlaying() as object
+  if not isValid(m.osd) or not isValid(m.osd.itemData) then return { status: "error.generic" }
+  item = m.osd.itemData
+  title = voiceTransport.formatNowPlayingTitle(item)
+  if title = "" then return { status: "error.generic" }
+  return {
+    status: "success",
+    nowPlaying: {
+      title: title,
+      contentType: item.type ?? ""
+    }
+  }
+end function
+
+function setFavorite(isLike as boolean) as object
+  if not isValid(m.osd) or not isValid(m.osd.itemData) or not isValid(m.osd.itemData.id)
+    return { status: "error.generic" }
+  end if
+  itemId = m.osd.itemData.id
+  if itemId = "" then return { status: "error.generic" }
+  if isLike
+    SubmitSideEffect(GetApi().BuildMarkFavoriteRequest(itemId))
+  else
+    SubmitSideEffect(GetApi().BuildUnmarkFavoriteRequest(itemId))
+  end if
+  return { status: "success" }
+end function

--- a/docs/signals-backlog.md
+++ b/docs/signals-backlog.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-23
+last-updated: 2026-06-28
 ---
 
 # Signals backlog
@@ -70,4 +70,14 @@ Schema is enforced by `npm run lint:docs` (`signals-schema-invalid` category). A
 - **latest_acknowledged**: 0.1.3
 - **last_checked**: 2026-06-23
 - **action_when_moves**: if an official history-depth / `canGoBack()` API lands, bump the pin and gate the `JRScene` Exit confirmation on it to close the stale `nodeId` edge cleanly (replaces the navigation-in-progress mirror). Consider contributing the API upstream as a PR
+- **status**: watching
+
+### bsfmt-multiline-indent-regression: `brighterscript-formatter` multi-line-AA indent regression
+
+- **watching**: `brighterscript-formatter` releases after 1.7.28 that fix the [#140](https://github.com/rokucommunity/brighterscript-formatter/pull/140) "Multi-line Function parameters" indent regression
+- **current**: pinned to 1.7.27. 1.7.28 over-indents every statement after a multi-line associative-array call argument (e.g. `fn("...", {\n ... \n})`) — the indent level is never popped, so the over-indent cascades past `end sub`/`end function` into the next top-level declaration. Cosmetic only (BrightScript blocks are keyword-delimited, so it still compiles) but `bsfmt --check` enforces the corruption. Renovate re-proposes 1.7.28 as a patch (no version hold in `renovate.json` by choice); close that PR without merging until a fixed release ships
+- **latest_upstream**: 1.7.28
+- **latest_acknowledged**: 1.7.28
+- **last_checked**: 2026-06-28
+- **action_when_moves**: when a release after 1.7.28 ships, format the multi-line-AA reproduction snippet under it (`npx bsfmt --write` on a `fn("x", { k: v })`-across-lines snippet followed by a top-level function); if indentation is correct, merge the Renovate bump and drop the 1.7.27 pin in `package.json`. Link the upstream issue once filed
 - **status**: watching

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "adm-zip": "0.5.17",
         "ajv": "8.20.0",
         "brighterscript": "1.0.0-alpha.52",
-        "brighterscript-formatter": "1.7.28",
+        "brighterscript-formatter": "1.7.27",
         "brighterscript-xml-plugin": "1.0.0-alpha.3",
         "dotenv": "17.4.2",
         "eslint": "10.6.0",
@@ -2358,9 +2358,9 @@
       }
     },
     "node_modules/brighterscript-formatter": {
-      "version": "1.7.28",
-      "resolved": "https://registry.npmjs.org/brighterscript-formatter/-/brighterscript-formatter-1.7.28.tgz",
-      "integrity": "sha512-VZc1gidCzufYaRU4SiunAY51jotfdN+FgMq/S7XRjOSFBt+Hw6Jr+KgMjyuNlV8Buwl+cP4NerZzQgW44Lylhw==",
+      "version": "1.7.27",
+      "resolved": "https://registry.npmjs.org/brighterscript-formatter/-/brighterscript-formatter-1.7.27.tgz",
+      "integrity": "sha512-OLM98hMXIsHMR6vWvmwq9x8K8qyMZj6h3UscKns6TLSHKD28rpRwC0FciEMhPmxCeHei8w2bK++BbLUDAYzsmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "adm-zip": "0.5.17",
     "ajv": "8.20.0",
     "brighterscript": "1.0.0-alpha.52",
-    "brighterscript-formatter": "1.7.28",
+    "brighterscript-formatter": "1.7.27",
     "brighterscript-xml-plugin": "1.0.0-alpha.3",
     "dotenv": "17.4.2",
     "eslint": "10.6.0",

--- a/source/GridView/GridPresenterBase.bs
+++ b/source/GridView/GridPresenterBase.bs
@@ -162,51 +162,51 @@ class GridPresenterBase
     if not isValid(m.view) then return
 
     m.view.top.callFunc("loadFilters", {
-        userid: m.view.global.user.id,
-        parentid: parentItem.Id,
-        includeitemtypes: itemType
-      })
-    end sub
+      userid: m.view.global.user.id,
+      parentid: parentItem.Id,
+      includeitemtypes: itemType
+    })
+  end sub
 
-    ' Called when filters are delivered by the host component's promise (BaseGridView.loadFilters).
-    ' Caches the result in m.apiFilters and shows a toast on failure.
-    ' @param {object} filters - The filter options AA (empty {} on failure)
-    ' @param {string} errorMsg - Non-empty on failure; triggers a toast
-    sub onFiltersLoaded(filters as object, errorMsg as string)
-      m.apiFilters = filters
-      if errorMsg <> ""
-        m.showToast(errorMsg)
-      end if
-    end sub
+  ' Called when filters are delivered by the host component's promise (BaseGridView.loadFilters).
+  ' Caches the result in m.apiFilters and shows a toast on failure.
+  ' @param {object} filters - The filter options AA (empty {} on failure)
+  ' @param {string} errorMsg - Non-empty on failure; triggers a toast
+  sub onFiltersLoaded(filters as object, errorMsg as string)
+    m.apiFilters = filters
+    if errorMsg <> ""
+      m.showToast(errorMsg)
+    end if
+  end sub
 
-    ' ============================================================================
-    ' Toast Notifications
-    ' ============================================================================
+  ' ============================================================================
+  ' Toast Notifications
+  ' ============================================================================
 
-    ' Show a toast notification via the scene-level Toast component.
-    ' Safe to call from presenter classes (routes through view's scene reference).
-    ' @param {string} message - The message to display
-    ' @param {string} [toastType="error"] - "error", "success", or "info"
-    sub showToast(message as string, toastType = "error" as string)
-      if not isValid(m.view) then return
-      scene = m.view.top.getScene()
-      if isValid(scene)
-        scene.callFunc("showToast", message, toastType)
-      end if
-    end sub
+  ' Show a toast notification via the scene-level Toast component.
+  ' Safe to call from presenter classes (routes through view's scene reference).
+  ' @param {string} message - The message to display
+  ' @param {string} [toastType="error"] - "error", "success", or "info"
+  sub showToast(message as string, toastType = "error" as string)
+    if not isValid(m.view) then return
+    scene = m.view.top.getScene()
+    if isValid(scene)
+      scene.callFunc("showToast", message, toastType)
+    end if
+  end sub
 
-    ' ============================================================================
-    ' Cleanup
-    ' ============================================================================
+  ' ============================================================================
+  ' Cleanup
+  ' ============================================================================
 
-    ' Called when presenter is being destroyed
-    ' Override to clean up resources, stop tasks, unobserve fields
-    ' Always call super.onDestroy() at the end of overrides
-    sub onDestroy()
-      ' The filter fetch is now a promise on the host component; auto-abandon (injected into
-      ' BaseGridView.onDestroy) cancels any in-flight request, so there's no task/observer here.
-      m.apiFilters = invalid
-      m.view = invalid
-      m.log = invalid
-    end sub
-  end class
+  ' Called when presenter is being destroyed
+  ' Override to clean up resources, stop tasks, unobserve fields
+  ' Always call super.onDestroy() at the end of overrides
+  sub onDestroy()
+    ' The filter fetch is now a promise on the host component; auto-abandon (injected into
+    ' BaseGridView.onDestroy) cancels any in-flight request, so there's no task/observer here.
+    m.apiFilters = invalid
+    m.view = invalid
+    m.log = invalid
+  end sub
+end class

--- a/source/api/items.bs
+++ b/source/api/items.bs
@@ -288,11 +288,11 @@ end function
 ' Does NOT include albums the artist merely contributes to — see AppearsOnList().
 function MusicAlbumList(id as string)
   data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-      "AlbumArtistIds": id,
-      "includeitemtypes": "MusicAlbum",
-      "sortBy": "PremiereDate,ProductionYear,SortName",
-      "SortOrder": "Descending",
-      "Recursive": true
+    "AlbumArtistIds": id,
+    "includeitemtypes": "MusicAlbum",
+    "sortBy": "PremiereDate,ProductionYear,SortName",
+    "SortOrder": "Descending",
+    "Recursive": true
   }), "albumList")
   if not isValid(data) then return invalid
   if not isValid(data.Items) then return invalid
@@ -311,11 +311,11 @@ end function
 ' Sorted by year descending.
 function AppearsOnList(id as string)
   data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-      "ContributingArtistIds": id,
-      "includeitemtypes": "MusicAlbum",
-      "sortBy": "PremiereDate,ProductionYear,SortName",
-      "SortOrder": "Descending",
-      "Recursive": true
+    "ContributingArtistIds": id,
+    "includeitemtypes": "MusicAlbum",
+    "sortBy": "PremiereDate,ProductionYear,SortName",
+    "SortOrder": "Descending",
+    "Recursive": true
   }), "appearsOn")
   if not isValid(data) then return invalid
   if not isValid(data.Items) then return invalid
@@ -362,12 +362,12 @@ end function
 ' @param {string} id - MusicArtist item ID
 function GetSongsByArtistBroad(id as string) as dynamic
   data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-      "ArtistIds": id,
-      "includeitemtypes": "Audio",
-      "sortBy": "Album,ParentIndexNumber,IndexNumber,SortName",
-      "Recursive": true,
-      "Limit": 100,
-      "EnableTotalRecordCount": false
+    "ArtistIds": id,
+    "includeitemtypes": "Audio",
+    "sortBy": "Album,ParentIndexNumber,IndexNumber,SortName",
+    "Recursive": true,
+    "Limit": 100,
+    "EnableTotalRecordCount": false
   }), "songsByArtistBroad")
 
   if not isValid(data) then return invalid
@@ -386,9 +386,9 @@ end function
 ' Get Songs that are on an Album
 function MusicSongList(id as string)
   data = fetchJson(GetApi().BuildGetItemsByQueryRequest({
-      "parentId": id,
-      "includeitemtypes": "Audio",
-      "sortBy": "SortName"
+    "parentId": id,
+    "includeitemtypes": "Audio",
+    "sortBy": "SortName"
   }), "songList")
 
   results = []
@@ -408,249 +408,249 @@ end function
 ' Get audio item metadata (raw, no transform)
 function AudioItem(id as string)
   return fetchJson(GetApi().BuildGetItemRawRequest(id, {
-        "includeitemtypes": "Audio",
-        "sortBy": "SortName"
-    }), "audioItem")
-  end function
+    "includeitemtypes": "Audio",
+    "sortBy": "SortName"
+  }), "audioItem")
+end function
 
-  ' Get Intro Videos for an item
-  function GetIntroVideos(id as string)
-    return fetchJson(GetApi().BuildGetIntrosRequest(id), "intros")
-  end function
+' Get Intro Videos for an item
+function GetIntroVideos(id as string)
+  return fetchJson(GetApi().BuildGetIntrosRequest(id), "intros")
+end function
 
-  ' GetMediaSegments: Fetches media segments for an item (Intro, Outro, Recap, etc.).
-  '
-  ' Only available on Jellyfin 10.10.0+ servers. Returns invalid for older servers.
-  '
-  ' @param {string} id - The item ID
-  ' @returns {dynamic} - { Items: [MediaSegmentDto], TotalRecordCount } or invalid
-  function GetMediaSegments(id as string)
-    if not supportsMediaSegments() then return invalid
-    return fetchJson(GetApi().BuildGetMediaSegmentsRequest(id), "mediaSegments")
-  end function
+' GetMediaSegments: Fetches media segments for an item (Intro, Outro, Recap, etc.).
+'
+' Only available on Jellyfin 10.10.0+ servers. Returns invalid for older servers.
+'
+' @param {string} id - The item ID
+' @returns {dynamic} - { Items: [MediaSegmentDto], TotalRecordCount } or invalid
+function GetMediaSegments(id as string)
+  if not supportsMediaSegments() then return invalid
+  return fetchJson(GetApi().BuildGetMediaSegmentsRequest(id), "mediaSegments")
+end function
 
-  function AudioStream(id as string)
-    songData = AudioItem(id)
-    if isValid(songData)
-      content = createObject("RoSGNode", "ContentNode")
-      if isValid(songData.title)
-        content.title = songData.title
-      end if
+function AudioStream(id as string)
+  songData = AudioItem(id)
+  if isValid(songData)
+    content = createObject("RoSGNode", "ContentNode")
+    if isValid(songData.title)
+      content.title = songData.title
+    end if
 
-      playbackInfo = ItemPostPlaybackInfo(songData.id, songData.mediaSources[0].id)
-      if isValid(playbackInfo)
-        content.id = playbackInfo.PlaySessionId
+    playbackInfo = ItemPostPlaybackInfo(songData.id, songData.mediaSources[0].id)
+    if isValid(playbackInfo)
+      content.id = playbackInfo.PlaySessionId
 
-        if useTranscodeAudioStream(playbackInfo)
-          ' Transcode the audio
-          audioUrl = buildURL(playbackInfo.mediaSources[0].TranscodingURL)
-          if not isValid(audioUrl) then return invalid
-          content.url = audioUrl
-        else
-          ' Direct Stream the audio
-          params = {
-            "Static": "true",
-            "Container": songData.mediaSources[0].container,
-            "MediaSourceId": songData.mediaSources[0].id
-          }
-          content.streamformat = songData.mediaSources[0].container
-          audioUrl = buildURL(Substitute("Audio/{0}/stream", songData.id), params)
-          if not isValid(audioUrl) then return invalid
-          content.url = audioUrl
-        end if
+      if useTranscodeAudioStream(playbackInfo)
+        ' Transcode the audio
+        audioUrl = buildURL(playbackInfo.mediaSources[0].TranscodingURL)
+        if not isValid(audioUrl) then return invalid
+        content.url = audioUrl
       else
-        return invalid
+        ' Direct Stream the audio
+        params = {
+          "Static": "true",
+          "Container": songData.mediaSources[0].container,
+          "MediaSourceId": songData.mediaSources[0].id
+        }
+        content.streamformat = songData.mediaSources[0].container
+        audioUrl = buildURL(Substitute("Audio/{0}/stream", songData.id), params)
+        if not isValid(audioUrl) then return invalid
+        content.url = audioUrl
       end if
-
-      return content
     else
       return invalid
     end if
-  end function
 
-  function useTranscodeAudioStream(playbackInfo)
-    return isValid(playbackInfo.mediaSources[0]) and isValid(playbackInfo.mediaSources[0].TranscodingURL)
-  end function
+    return content
+  else
+    return invalid
+  end if
+end function
 
-  ' Get lyrics for an Audio item.
-  ' @param {string} itemId - The Audio item ID
-  ' @returns {dynamic} LyricDto: { Metadata: {...}, Lyrics: [{Start: ticks, Text: string}] }, or invalid
-  function GetItemLyrics(itemId as string) as dynamic
-    if not supportsLyrics() then return invalid
-    return fetchJson(GetApi().BuildGetItemLyricsRequest(itemId), "lyrics")
-  end function
+function useTranscodeAudioStream(playbackInfo)
+  return isValid(playbackInfo.mediaSources[0]) and isValid(playbackInfo.mediaSources[0].TranscodingURL)
+end function
 
-  ' supportsLyrics: Checks if the connected Jellyfin server supports the Lyrics API.
-  '
-  ' The /Audio/{itemId}/Lyrics endpoint was introduced in Jellyfin 10.9.0.
-  ' Servers below 10.9.0 do not have this endpoint and will return 404. Guarding
-  ' the request mirrors supportsMediaSegments() (source/utils/mediaSegments.bs) and
-  ' lets the endpoint-availability ledger record this as a validated version-guard.
-  '
-  ' @returns {boolean} - true if server supports lyrics
-  function supportsLyrics() as boolean
-    return versionChecker(m.global.server.version, "10.9.0")
-  end function
+' Get lyrics for an Audio item.
+' @param {string} itemId - The Audio item ID
+' @returns {dynamic} LyricDto: { Metadata: {...}, Lyrics: [{Start: ticks, Text: string}] }, or invalid
+function GetItemLyrics(itemId as string) as dynamic
+  if not supportsLyrics() then return invalid
+  return fetchJson(GetApi().BuildGetItemLyricsRequest(itemId), "lyrics")
+end function
 
-  function BackdropImage(id as string)
-    ' Use UI resolution for backdrop images
-    localDevice = m.global.device
-    imgParams = { "maxHeight": localDevice.uiResolution[1], "maxWidth": localDevice.uiResolution[0] }
-    return ImageURL(id, "Backdrop", imgParams)
-  end function
+' supportsLyrics: Checks if the connected Jellyfin server supports the Lyrics API.
+'
+' The /Audio/{itemId}/Lyrics endpoint was introduced in Jellyfin 10.9.0.
+' Servers below 10.9.0 do not have this endpoint and will return 404. Guarding
+' the request mirrors supportsMediaSegments() (source/utils/mediaSegments.bs) and
+' lets the endpoint-availability ledger record this as a validated version-guard.
+'
+' @returns {boolean} - true if server supports lyrics
+function supportsLyrics() as boolean
+  return versionChecker(m.global.server.version, "10.9.0")
+end function
 
-  ' Seasons for a TV Show
-  function TVSeasons(id as string) as dynamic
-    data = fetchJson(GetApi().BuildGetSeasonsRequest(id), "seasons")
-    ' validate data
-    if not isValid(data) or not isValid(data.Items) then return invalid
+function BackdropImage(id as string)
+  ' Use UI resolution for backdrop images
+  localDevice = m.global.device
+  imgParams = { "maxHeight": localDevice.uiResolution[1], "maxWidth": localDevice.uiResolution[0] }
+  return ImageURL(id, "Backdrop", imgParams)
+end function
 
-    transformer = JellyfinDataTransformer()
-    results = []
-    for each item in data.Items
-      results.push(transformer.transformBaseItem(item))
-    end for
-    data.Items = results
-    return data
-  end function
+' Seasons for a TV Show
+function TVSeasons(id as string) as dynamic
+  data = fetchJson(GetApi().BuildGetSeasonsRequest(id), "seasons")
+  ' validate data
+  if not isValid(data) or not isValid(data.Items) then return invalid
 
-  ' applyLiveTvMinSegments: For HLS transcodes that report no source duration (live channels),
-  ' request ≥8 segments per Roku's recommendation. Gives ~48 s seekable DVR window.
-  sub applyLiveTvMinSegments(postData as object)
-    if not isValid(postData) then return
-    if not isValid(postData.DeviceProfile) then return
-    if not isValid(postData.DeviceProfile.TranscodingProfiles) then return
-    for each profile in postData.DeviceProfile.TranscodingProfiles
-      if isValid(profile.Type) and profile.Type = "Video"
-        profile.MinSegments = 8
-      end if
-    end for
-  end sub
+  transformer = JellyfinDataTransformer()
+  results = []
+  for each item in data.Items
+    results.push(transformer.transformBaseItem(item))
+  end for
+  data.Items = results
+  return data
+end function
 
-  ' applyMediaSourceToPostData: Applies the media source ID or live TV retry flags to a postData object.
-  ' Live TV is detected by an empty mediaSourceId. On the first attempt, direct play is not disabled
-  ' so the server can evaluate compatibility (matching web client behaviour). On retry,
-  ' forceTranscoding=true sets EnableDirectPlay=false so the server provides a transcode URL instead.
-  '
-  ' @param {object} postData - The request body assoc array to modify
-  ' @param {string} mediaSourceId - Media source ID, or "" for live TV
-  ' @param {boolean} forceTranscoding - True when retrying with forced transcoding
-  sub applyMediaSourceToPostData(postData as object, mediaSourceId as string, forceTranscoding as boolean)
-    if mediaSourceId <> ""
-      postData.MediaSourceId = mediaSourceId
-    else
-      if forceTranscoding
-        postData.EnableDirectPlay = false
-      end if
+' applyLiveTvMinSegments: For HLS transcodes that report no source duration (live channels),
+' request ≥8 segments per Roku's recommendation. Gives ~48 s seekable DVR window.
+sub applyLiveTvMinSegments(postData as object)
+  if not isValid(postData) then return
+  if not isValid(postData.DeviceProfile) then return
+  if not isValid(postData.DeviceProfile.TranscodingProfiles) then return
+  for each profile in postData.DeviceProfile.TranscodingProfiles
+    if isValid(profile.Type) and profile.Type = "Video"
+      profile.MinSegments = 8
     end if
-  end sub
+  end for
+end sub
 
-  ' Tailors a video transcoding profile's AudioCodec list to the current source's channel count
-  ' so the server (and downstream HLS variant selection) can't fall back to a less-desirable codec.
-  '
-  ' Multichannel source (>2ch):
-  '   Strips ALL stereo-output codecs (aac, mp3, flac, alac, pcm, lpcm, wav, vorbis). Without this,
-  '   Jellyfin's HLS muxer offers BOTH the surround codec AND a stereo fallback as separate variants
-  '   in the master playlist, and Roku's HLS player has been observed (via in-house testing on
-  '   physical hardware; no upstream tracking issue at time of writing) to pick the stereo variant —
-  '   defeating the entire point of having surround passthrough hardware. Caller must already have
-  '   verified the device has surround passthrough before invoking with channelCount > 2.
-  '
-  ' Stereo source (≤2ch):
-  '   Strips surround passthrough codecs (eac3, ac3, dts) plus aac so transcoding falls through to
-  '   mp3. Avoids handing the server a surround target codec for content that's only 2ch anyway.
-  '   If filtering empties a previously non-empty list, falls back to "mp3" (the intended target).
-  '
-  ' Multichannel surround target (issue #573):
-  '   For a >2ch source, the stripped list MUST lead with a server-encodeable surround codec.
-  '   Two failure modes this prevents, both observed on Jellyfin 10.11 via PlaybackInfo probes:
-  '     - Empty list: Jellyfin's StreamBuilder omits the audioCodec query param, the server's
-  '       InferAudioCodec falls through to the container name ("m3u8"), ffmpeg gets
-  '       `-codec:a:0 m3u8` and exits 8. Happens when passthrough is detected only via codecs
-  '       not in surroundPriority (truehd/dtshd-only) so no surround codec is in the list.
-  '     - On-device-decode leak: a list like "truehd,opus" (truehd un-encodeable for a non-truehd
-  '       source; opus on-device-decode only) resolves server-side to opus, silently abandoning
-  '       the user's surround/passthrough intent for a decoded stereo-ish path.
-  '   Fix: prepend the user's preferred multichannel codec (playbackPreferredMultichannelCodec),
-  '   clamped to a reliably-encodeable HLS surround target — eac3 or ac3 (dts is excluded: the
-  '   server emits no audio stream for a dts transcode target). This is a no-op for healthy
-  '   profiles (their stripped list already leads with eac3/ac3) and only rescues the degenerate
-  '   truehd/dtshd-only shape.
-  sub optimizeAudioCodecListForSource(deviceProfile as object, channelCount as integer, preferredMultichannelCodec = "eac3" as string)
-    ' Validate inputs
-    if not isValid(deviceProfile) then return
-    if not isValid(deviceProfile.TranscodingProfiles) then return
+' applyMediaSourceToPostData: Applies the media source ID or live TV retry flags to a postData object.
+' Live TV is detected by an empty mediaSourceId. On the first attempt, direct play is not disabled
+' so the server can evaluate compatibility (matching web client behaviour). On retry,
+' forceTranscoding=true sets EnableDirectPlay=false so the server provides a transcode URL instead.
+'
+' @param {object} postData - The request body assoc array to modify
+' @param {string} mediaSourceId - Media source ID, or "" for live TV
+' @param {boolean} forceTranscoding - True when retrying with forced transcoding
+sub applyMediaSourceToPostData(postData as object, mediaSourceId as string, forceTranscoding as boolean)
+  if mediaSourceId <> ""
+    postData.MediaSourceId = mediaSourceId
+  else
+    if forceTranscoding
+      postData.EnableDirectPlay = false
+    end if
+  end if
+end sub
 
-    ' Codecs that, as a server transcode target, can't carry surround channels — strip these for
-    ' multichannel sources so the server is forced to pick a surround codec from the remaining list.
-    ' Note: this list is intentionally distinct from `stereoOutputCodecs` in deviceCapabilities.bs;
-    ' that list represents Roku decode-path behavior (different concept), so the contents differ.
-    stereoOnlyCodecs = ["aac", "mp3", "flac", "alac", "pcm", "lpcm", "wav", "vorbis"]
-    ' Surround passthrough codecs — pointless for stereo sources, strip them.
-    surroundCodecs = ["eac3", "ac3", "dts"]
+' Tailors a video transcoding profile's AudioCodec list to the current source's channel count
+' so the server (and downstream HLS variant selection) can't fall back to a less-desirable codec.
+'
+' Multichannel source (>2ch):
+'   Strips ALL stereo-output codecs (aac, mp3, flac, alac, pcm, lpcm, wav, vorbis). Without this,
+'   Jellyfin's HLS muxer offers BOTH the surround codec AND a stereo fallback as separate variants
+'   in the master playlist, and Roku's HLS player has been observed (via in-house testing on
+'   physical hardware; no upstream tracking issue at time of writing) to pick the stereo variant —
+'   defeating the entire point of having surround passthrough hardware. Caller must already have
+'   verified the device has surround passthrough before invoking with channelCount > 2.
+'
+' Stereo source (≤2ch):
+'   Strips surround passthrough codecs (eac3, ac3, dts) plus aac so transcoding falls through to
+'   mp3. Avoids handing the server a surround target codec for content that's only 2ch anyway.
+'   If filtering empties a previously non-empty list, falls back to "mp3" (the intended target).
+'
+' Multichannel surround target (issue #573):
+'   For a >2ch source, the stripped list MUST lead with a server-encodeable surround codec.
+'   Two failure modes this prevents, both observed on Jellyfin 10.11 via PlaybackInfo probes:
+'     - Empty list: Jellyfin's StreamBuilder omits the audioCodec query param, the server's
+'       InferAudioCodec falls through to the container name ("m3u8"), ffmpeg gets
+'       `-codec:a:0 m3u8` and exits 8. Happens when passthrough is detected only via codecs
+'       not in surroundPriority (truehd/dtshd-only) so no surround codec is in the list.
+'     - On-device-decode leak: a list like "truehd,opus" (truehd un-encodeable for a non-truehd
+'       source; opus on-device-decode only) resolves server-side to opus, silently abandoning
+'       the user's surround/passthrough intent for a decoded stereo-ish path.
+'   Fix: prepend the user's preferred multichannel codec (playbackPreferredMultichannelCodec),
+'   clamped to a reliably-encodeable HLS surround target — eac3 or ac3 (dts is excluded: the
+'   server emits no audio stream for a dts transcode target). This is a no-op for healthy
+'   profiles (their stripped list already leads with eac3/ac3) and only rescues the degenerate
+'   truehd/dtshd-only shape.
+sub optimizeAudioCodecListForSource(deviceProfile as object, channelCount as integer, preferredMultichannelCodec = "eac3" as string)
+  ' Validate inputs
+  if not isValid(deviceProfile) then return
+  if not isValid(deviceProfile.TranscodingProfiles) then return
 
-    for each rule in deviceProfile.TranscodingProfiles
-      if isValid(rule.Type) and rule.Type = "Video"
-        if isValid(rule.AudioCodec)
-          codecList = rule.AudioCodec.split(",")
-          newCodecList = []
+  ' Codecs that, as a server transcode target, can't carry surround channels — strip these for
+  ' multichannel sources so the server is forced to pick a surround codec from the remaining list.
+  ' Note: this list is intentionally distinct from `stereoOutputCodecs` in deviceCapabilities.bs;
+  ' that list represents Roku decode-path behavior (different concept), so the contents differ.
+  stereoOnlyCodecs = ["aac", "mp3", "flac", "alac", "pcm", "lpcm", "wav", "vorbis"]
+  ' Surround passthrough codecs — pointless for stereo sources, strip them.
+  surroundCodecs = ["eac3", "ac3", "dts"]
 
-          for each codec in codecList
-            skipCodec = false
+  for each rule in deviceProfile.TranscodingProfiles
+    if isValid(rule.Type) and rule.Type = "Video"
+      if isValid(rule.AudioCodec)
+        codecList = rule.AudioCodec.split(",")
+        newCodecList = []
 
-            if channelCount > 2 and arrayHasValue(stereoOnlyCodecs, codec)
-              skipCodec = true
-            end if
+        for each codec in codecList
+          skipCodec = false
 
-            if channelCount <= 2 and (codec = "aac" or arrayHasValue(surroundCodecs, codec))
-              skipCodec = true
-            end if
+          if channelCount > 2 and arrayHasValue(stereoOnlyCodecs, codec)
+            skipCodec = true
+          end if
 
-            if not skipCodec
-              newCodecList.push(codec)
+          if channelCount <= 2 and (codec = "aac" or arrayHasValue(surroundCodecs, codec))
+            skipCodec = true
+          end if
+
+          if not skipCodec
+            newCodecList.push(codec)
+          end if
+        end for
+
+        if channelCount > 2 and rule.AudioCodec <> ""
+          ' Multichannel with a real source list: guarantee a user-preferred, server-encodeable
+          ' surround codec leads the list so the server can never resolve to an empty list (→ m3u8)
+          ' or an on-device-decode codec (opus/aac). See block comment above for the server-side
+          ' bugs this prevents. (An originally-empty AudioCodec is left untouched — optimize rescues
+          ' lists it would otherwise empty, it doesn't invent a codec where the profile had none.)
+          surroundTarget = resolveMultichannelSurroundTarget(preferredMultichannelCodec)
+          finalList = [surroundTarget]
+          for each codec in newCodecList
+            if codec <> surroundTarget
+              finalList.push(codec)
             end if
           end for
-
-          if channelCount > 2 and rule.AudioCodec <> ""
-            ' Multichannel with a real source list: guarantee a user-preferred, server-encodeable
-            ' surround codec leads the list so the server can never resolve to an empty list (→ m3u8)
-            ' or an on-device-decode codec (opus/aac). See block comment above for the server-side
-            ' bugs this prevents. (An originally-empty AudioCodec is left untouched — optimize rescues
-            ' lists it would otherwise empty, it doesn't invent a codec where the profile had none.)
-            surroundTarget = resolveMultichannelSurroundTarget(preferredMultichannelCodec)
-            finalList = [surroundTarget]
-            for each codec in newCodecList
-              if codec <> surroundTarget
-                finalList.push(codec)
-              end if
-            end for
-            rule.AudioCodec = finalList.join(",")
-          else if channelCount <= 2
-            ' Stereo AAC-profile case: if filtering emptied a previously non-empty list, fall back
-            ' to "mp3" (the intended fallthrough target) rather than re-emitting an empty AudioCodec.
-            if newCodecList.count() = 0 and rule.AudioCodec <> ""
-              newCodecList = ["mp3"]
-            end if
-            rule.AudioCodec = newCodecList.join(",")
-          else
-            ' Multichannel but the profile had an originally-empty AudioCodec — leave it empty
-            ' (handled gracefully; optimize does not invent a codec where the profile had none).
-            rule.AudioCodec = newCodecList.join(",")
+          rule.AudioCodec = finalList.join(",")
+        else if channelCount <= 2
+          ' Stereo AAC-profile case: if filtering emptied a previously non-empty list, fall back
+          ' to "mp3" (the intended fallthrough target) rather than re-emitting an empty AudioCodec.
+          if newCodecList.count() = 0 and rule.AudioCodec <> ""
+            newCodecList = ["mp3"]
           end if
+          rule.AudioCodec = newCodecList.join(",")
+        else
+          ' Multichannel but the profile had an originally-empty AudioCodec — leave it empty
+          ' (handled gracefully; optimize does not invent a codec where the profile had none).
+          rule.AudioCodec = newCodecList.join(",")
         end if
       end if
-    end for
-  end sub
-
-  ' Resolve the surround transcode target for a multichannel source from the user's preferred
-  ' multichannel codec setting (playbackPreferredMultichannelCodec). Clamped to the reliably-
-  ' encodeable HLS surround targets: eac3 (default) and ac3. dts is intentionally excluded — the
-  ' Jellyfin server emits no audio stream for a dts transcode target (verified on 10.11), so a dts
-  ' fallback would itself re-trigger the issue #573 failure. Both eac3 and ac3 are valid HLS audio
-  ' targets in every video transcoding container (ts and mp4), so no per-container clamp is needed.
-  function resolveMultichannelSurroundTarget(preferredMultichannelCodec as string) as string
-    if isValidAndNotEmpty(preferredMultichannelCodec) and LCase(preferredMultichannelCodec) = "ac3"
-      return "ac3"
     end if
-    return "eac3"
-  end function
+  end for
+end sub
+
+' Resolve the surround transcode target for a multichannel source from the user's preferred
+' multichannel codec setting (playbackPreferredMultichannelCodec). Clamped to the reliably-
+' encodeable HLS surround targets: eac3 (default) and ac3. dts is intentionally excluded — the
+' Jellyfin server emits no audio stream for a dts transcode target (verified on 10.11), so a dts
+' fallback would itself re-trigger the issue #573 failure. Both eac3 and ac3 are valid HLS audio
+' targets in every video transcoding container (ts and mp4), so no per-container clamp is needed.
+function resolveMultichannelSurroundTarget(preferredMultichannelCodec as string) as string
+  if isValidAndNotEmpty(preferredMultichannelCodec) and LCase(preferredMultichannelCodec) = "ac3"
+    return "ac3"
+  end if
+  return "eac3"
+end function

--- a/source/replayRoute.bs
+++ b/source/replayRoute.bs
@@ -137,224 +137,224 @@ sub replayAfterLogin()
     ' homeFirst: land on Home (the back-stack root) THEN validate. An invalid id just toasts on
     ' Home — good post-login UX. A valid id navigates on from Home.
     m.scene.callFunc("resolveDeepLink", {
-        itemId: deepLink.itemId,
-        action: deepLink.action,
-        isPlayback: isDeepLinkPlaybackAction(deepLink.action),
-        homeFirst: true,
-        replacePlayer: false,
-        detailsRoute: deepLinkDetailsRoute(deepLink)
-      })
-      return
-    end if
+      itemId: deepLink.itemId,
+      action: deepLink.action,
+      isPlayback: isDeepLinkPlaybackAction(deepLink.action),
+      homeFirst: true,
+      replacePlayer: false,
+      detailsRoute: deepLinkDetailsRoute(deepLink)
+    })
+    return
+  end if
 
-    stashed = m.global.AuthManager.stashedRoute
-    m.global.AuthManager.stashedRoute = ""
-    m.scene.callFunc("replayRoutedDeepLink", buildReplayRoutes(stashed))
-  end sub
+  stashed = m.global.AuthManager.stashedRoute
+  m.global.AuthManager.stashedRoute = ""
+  m.scene.callFunc("replayRoutedDeepLink", buildReplayRoutes(stashed))
+end sub
 
-  ' Runtime replay (app already signed in, deep link for the active server). Unlike the post-login
-  ' path above, this does NOT prepend Home — an in-app cast shouldn't flash through the Home screen.
-  '   - already on the target item's LOADED details -> launch the action in place (no fetch, no
-  '     re-mount); for "open" we're already showing it, so nothing to do. The itemContent guard
-  '     matters: a lingering empty details would otherwise swallow the cast.
-  '   - otherwise -> hand the intent to JRScene.resolveDeepLink, which VALIDATES the id (a fetch)
-  '     BEFORE navigating. An invalid id never disturbs the active session — it just toasts. A valid
-  '     id then navigates (replacing an active player for a playback cast, else a plain push).
-  sub replayDeepLinkRuntime()
-    deepLink = m.global.AuthManager.stashedDeepLink
-    if not isValid(deepLink) or not isValidAndNotEmpty(deepLink.itemId) then return
+' Runtime replay (app already signed in, deep link for the active server). Unlike the post-login
+' path above, this does NOT prepend Home — an in-app cast shouldn't flash through the Home screen.
+'   - already on the target item's LOADED details -> launch the action in place (no fetch, no
+'     re-mount); for "open" we're already showing it, so nothing to do. The itemContent guard
+'     matters: a lingering empty details would otherwise swallow the cast.
+'   - otherwise -> hand the intent to JRScene.resolveDeepLink, which VALIDATES the id (a fetch)
+'     BEFORE navigating. An invalid id never disturbs the active session — it just toasts. A valid
+'     id then navigates (replacing an active player for a playback cast, else a plain push).
+sub replayDeepLinkRuntime()
+  deepLink = m.global.AuthManager.stashedDeepLink
+  if not isValid(deepLink) or not isValidAndNotEmpty(deepLink.itemId) then return
+  m.global.AuthManager.stashedDeepLink = invalid
+
+  isPlayback = isDeepLinkPlaybackAction(deepLink.action)
+  active = m.global.activeRoutedView
+
+  onLoadedDetails = isValid(active) and active.subtype() = "ItemDetails" and active.itemId = deepLink.itemId and isValid(active.itemContent) and isValidAndNotEmpty(active.itemContent.id)
+  if onLoadedDetails
+    ' Already on this item's loaded details — no need to re-validate. Launch in place; "open" no-op.
+    if isPlayback then active.callFunc("playFromDeepLink", deepLink.action)
+    return
+  end if
+
+  replacePlayer = isPlayback and isValid(active) and isDeepLinkPlayerView(active.subtype())
+  m.scene.callFunc("resolveDeepLink", {
+    itemId: deepLink.itemId,
+    action: deepLink.action,
+    isPlayback: isPlayback,
+    homeFirst: false,
+    replacePlayer: replacePlayer,
+    detailsRoute: deepLinkDetailsRoute(deepLink)
+  })
+end sub
+
+' Active routed views that ARE a media player (a deep link arriving over one must tear it down
+' before launching the next, not stack on top).
+function isDeepLinkPlayerView(subtype as string) as boolean
+  return subtype = "PlayerHostView" or subtype = "AudioPlayerView" or subtype = "VideoPlayerView"
+end function
+
+' Build the /details route for a deep link. The :type is just a display hint (ItemDetails
+' resolves the REAL type from the fetched item). The ?deeplink=<action> query does double duty:
+' it marks this as an untrusted deep-link entry (so ItemDetails validates the id, sending an
+' invalid one back to Home per cert), AND it carries the intent — "open" lands on the springboard;
+' "play"/"shuffle"/"trailer" auto-launch the matching action once the item resolves. The intent is
+' the SENDER'S explicit choice (the route decides), never inferred from the resolved item.
+' The "Playing <title>" toast is fired by the player on mount using the REAL resolved title
+' (ItemDetails sets m.global.deepLinkOpeningTitle) — not the sender's param, which may be a
+' placeholder. So nothing is toasted here.
+function deepLinkDetailsRoute(deepLink as object) as string
+  base = "/details/" + deepLink.mediaType + "/" + deepLink.itemId + "?deeplink="
+  if isValidAndNotEmpty(deepLink.action) then return base + deepLink.action
+  return base + "open"
+end function
+
+' Toast shown when a deep link arrives but the user must authenticate first — it explains why
+' nothing happened yet and that the content will open after sign-in. No-op if nothing stashed.
+sub notifyDeepLinkDeferred()
+  dl = m.global.AuthManager.stashedDeepLink
+  if isValid(dl) and isValidAndNotEmpty(dl.itemId)
+    displayToast(translate(translationKeys.MessageDeepLinkAfterSignIn), "info")
+  end if
+end sub
+
+' Pure: turn a guard-stashed path into the ordered route chain to replay. Home is always
+' first (back-stack root); a /play path additionally inserts its Details screen between Home
+' and the player (the details path is the play path minus the trailing "/play").
+function buildReplayRoutes(stashed as dynamic) as object
+  if not isValidAndNotEmpty(stashed) then return ["/"]
+
+  ' Separate the base path from any query string.
+  basePath = stashed
+  q = Instr(1, stashed, "?")
+  if q > 0 then basePath = Left(stashed, q - 1)
+
+  if basePath.endsWith("/play")
+    detailsPath = Left(basePath, Len(basePath) - Len("/play"))
+    return ["/", detailsPath, stashed]
+  end if
+
+  return ["/", stashed]
+end function
+
+' ---------------------------------------------------------------------------
+' Server resolution — a deep link's contentId may name a serverId (GUID). The whole app
+' is one-server-at-a-time, so a link for a DIFFERENT server means switching (a full re-auth,
+' like Change Server). We only have URLs for SAVED servers, so an unknown GUID can't be
+' fulfilled. See docs/architecture/navigation.md ("Deep links").
+' ---------------------------------------------------------------------------
+
+' Look up a saved server entry by its Jellyfin server id (GUID). Returns the entry
+' ({ name, id, baseUrl, originalUrl, ... }) or invalid. The pure match logic lives in
+' config.bs (findServerInList) next to the saved_servers shape it matches.
+function findSavedServerByGuid(guid as string) as object
+  return findServerInList(getSetting("saved_servers"), guid)
+end function
+
+' COLD start: if the stashed deep link names a saved server, point the login at it BEFORE
+' beginLogin runs (no prompt — there is no active session to disrupt). An unknown/absent
+' GUID is left alone: login proceeds normally and the deep link validates on whatever server
+' we land on (graceful error -> Home if the item isn't there).
+sub steerColdStartDeepLinkServer()
+  dl = m.global.AuthManager.stashedDeepLink
+  if not isValid(dl) or not isValidAndNotEmpty(dl.serverGuid) then return
+  entry = findSavedServerByGuid(dl.serverGuid)
+  if isValid(entry) and isValidAndNotEmpty(entry.originalUrl)
+    setSetting("server", entry.originalUrl)
+  end if
+end sub
+
+' RUNTIME (app already signed in): resolve the stashed deep link's server and act.
+'   - no/absent server, or it's the active one -> replay now.
+'   - a different SAVED server -> prompt to switch.
+'   - an unknown server -> can't connect; toast + discard.
+' When NOT signed in (user at pre-login), do nothing: the stash rides until login and
+' validates on whatever server they sign into.
+sub onRuntimeDeepLink()
+  if not isValidAndNotEmpty(m.global.user.authToken)
+    notifyDeepLinkDeferred()
+    return
+  end if
+
+  dl = m.global.AuthManager.stashedDeepLink
+  guid = ""
+  if isValid(dl) then guid = dl.serverGuid
+
+  if not isValidAndNotEmpty(guid) or guid = LCase(m.global.server.id)
+    replayDeepLinkRuntime()
+    return
+  end if
+
+  entry = findSavedServerByGuid(guid)
+  if isValid(entry)
+    promptServerSwitch(entry)
+    return
+  end if
+
+  m.global.AuthManager.stashedDeepLink = invalid
+  displayToast(translate(translationKeys.MessageContentOnUnknownServer), "error")
+end sub
+
+' Ask before switching servers (it signs the user out of the current one). The choice comes
+' back through SceneManager.returnData -> main.bs's isDataReturned handler (the same bridge
+' the exit dialog uses), which calls performServerSwitch on confirm.
+sub promptServerSwitch(entry as object)
+  m.pendingSwitchServer = entry
+  m.global.sceneManager.isPendingServerSwitch = true
+
+  ' Name what's being cast when the sender provided a title, so the user can tell a real cast
+  ' from a stray/accidental one; fall back to a server-named, provenance-aware message otherwise.
+  dl = m.global.AuthManager.stashedDeepLink
+  itemName = ""
+  if isValid(dl) and isValidAndNotEmpty(dl.itemName) then itemName = dl.itemName
+  if isValidAndNotEmpty(itemName)
+    message = Substitute(translate(translationKeys.MessageSwitchServerToPlayTitled), itemName, entry.name)
+  else
+    message = Substitute(translate(translationKeys.MessageSwitchServerToPlay), entry.name)
+  end if
+
+  m.global.sceneManager.callFunc("showConfirmationDialog", translate(translationKeys.LabelChangeServer), [message], [translate(translationKeys.ButtonCancel), translate(translationKeys.ButtonSwitch)])
+end sub
+
+' Perform the confirmed switch. Pre-flight the target FIRST (non-destructive) so an offline
+' server never strands the user. The probe runs on a Task thread (ServerReachableTask) so the
+' up-to-8s reachability check can't freeze remote input; the switch itself continues in
+' onServerProbeDone once the verdict lands back on the main loop.
+sub performServerSwitch(entry as object)
+  m.pendingSwitchServer = invalid
+  if not isValid(entry) then return
+
+  startLoadingSpinner()
+  ' Hold the entry for the async callback — the probe outcome decides whether we tear down the
+  ' session, and the result arrives later via the main loop's "reachable" handler.
+  m.serverSwitchEntry = entry
+  task = CreateObject("roSGNode", "ServerReachableTask")
+  task.baseUrl = entry.baseUrl
+  task.observeField("reachable", m.port)
+  m.serverReachableTask = task
+  task.control = "RUN"
+end sub
+
+' Continuation of performServerSwitch once the off-thread reachability probe returns. On an
+' unreachable target, surface the error and discard the deep link. On success, reuse the
+' Change-Server machinery (resetRouter -> point at the new server -> SignOut -> reenterLogin);
+' the stashed deep link survives the teardown and replays once the new server's login completes.
+sub onServerProbeDone(reachable as boolean)
+  entry = m.serverSwitchEntry
+  m.serverSwitchEntry = invalid
+  if not isValid(entry) then return
+
+  if not reachable
+    stopLoadingSpinner()
     m.global.AuthManager.stashedDeepLink = invalid
+    displayToast(Substitute(translate(translationKeys.MessageCouldNotReachServer), entry.name), "error")
+    return
+  end if
 
-    isPlayback = isDeepLinkPlaybackAction(deepLink.action)
-    active = m.global.activeRoutedView
+  ' Tell the user what's happening — the switch tears down the session and re-logs into the
+  ' new server, so Home re-loading from scratch (the "everything's changing" moment) has context.
+  displayToast(Substitute(translate(translationKeys.MessageSwitchingToServer), entry.name), "info")
 
-    onLoadedDetails = isValid(active) and active.subtype() = "ItemDetails" and active.itemId = deepLink.itemId and isValid(active.itemContent) and isValidAndNotEmpty(active.itemContent.id)
-    if onLoadedDetails
-      ' Already on this item's loaded details — no need to re-validate. Launch in place; "open" no-op.
-      if isPlayback then active.callFunc("playFromDeepLink", deepLink.action)
-      return
-    end if
-
-    replacePlayer = isPlayback and isValid(active) and isDeepLinkPlayerView(active.subtype())
-    m.scene.callFunc("resolveDeepLink", {
-        itemId: deepLink.itemId,
-        action: deepLink.action,
-        isPlayback: isPlayback,
-        homeFirst: false,
-        replacePlayer: replacePlayer,
-        detailsRoute: deepLinkDetailsRoute(deepLink)
-      })
-    end sub
-
-    ' Active routed views that ARE a media player (a deep link arriving over one must tear it down
-    ' before launching the next, not stack on top).
-    function isDeepLinkPlayerView(subtype as string) as boolean
-      return subtype = "PlayerHostView" or subtype = "AudioPlayerView" or subtype = "VideoPlayerView"
-    end function
-
-    ' Build the /details route for a deep link. The :type is just a display hint (ItemDetails
-    ' resolves the REAL type from the fetched item). The ?deeplink=<action> query does double duty:
-    ' it marks this as an untrusted deep-link entry (so ItemDetails validates the id, sending an
-    ' invalid one back to Home per cert), AND it carries the intent — "open" lands on the springboard;
-    ' "play"/"shuffle"/"trailer" auto-launch the matching action once the item resolves. The intent is
-    ' the SENDER'S explicit choice (the route decides), never inferred from the resolved item.
-    ' The "Playing <title>" toast is fired by the player on mount using the REAL resolved title
-    ' (ItemDetails sets m.global.deepLinkOpeningTitle) — not the sender's param, which may be a
-    ' placeholder. So nothing is toasted here.
-    function deepLinkDetailsRoute(deepLink as object) as string
-      base = "/details/" + deepLink.mediaType + "/" + deepLink.itemId + "?deeplink="
-      if isValidAndNotEmpty(deepLink.action) then return base + deepLink.action
-      return base + "open"
-    end function
-
-    ' Toast shown when a deep link arrives but the user must authenticate first — it explains why
-    ' nothing happened yet and that the content will open after sign-in. No-op if nothing stashed.
-    sub notifyDeepLinkDeferred()
-      dl = m.global.AuthManager.stashedDeepLink
-      if isValid(dl) and isValidAndNotEmpty(dl.itemId)
-        displayToast(translate(translationKeys.MessageDeepLinkAfterSignIn), "info")
-      end if
-    end sub
-
-    ' Pure: turn a guard-stashed path into the ordered route chain to replay. Home is always
-    ' first (back-stack root); a /play path additionally inserts its Details screen between Home
-    ' and the player (the details path is the play path minus the trailing "/play").
-    function buildReplayRoutes(stashed as dynamic) as object
-      if not isValidAndNotEmpty(stashed) then return ["/"]
-
-      ' Separate the base path from any query string.
-      basePath = stashed
-      q = Instr(1, stashed, "?")
-      if q > 0 then basePath = Left(stashed, q - 1)
-
-      if basePath.endsWith("/play")
-        detailsPath = Left(basePath, Len(basePath) - Len("/play"))
-        return ["/", detailsPath, stashed]
-      end if
-
-      return ["/", stashed]
-    end function
-
-    ' ---------------------------------------------------------------------------
-    ' Server resolution — a deep link's contentId may name a serverId (GUID). The whole app
-    ' is one-server-at-a-time, so a link for a DIFFERENT server means switching (a full re-auth,
-    ' like Change Server). We only have URLs for SAVED servers, so an unknown GUID can't be
-    ' fulfilled. See docs/architecture/navigation.md ("Deep links").
-    ' ---------------------------------------------------------------------------
-
-    ' Look up a saved server entry by its Jellyfin server id (GUID). Returns the entry
-    ' ({ name, id, baseUrl, originalUrl, ... }) or invalid. The pure match logic lives in
-    ' config.bs (findServerInList) next to the saved_servers shape it matches.
-    function findSavedServerByGuid(guid as string) as object
-      return findServerInList(getSetting("saved_servers"), guid)
-    end function
-
-    ' COLD start: if the stashed deep link names a saved server, point the login at it BEFORE
-    ' beginLogin runs (no prompt — there is no active session to disrupt). An unknown/absent
-    ' GUID is left alone: login proceeds normally and the deep link validates on whatever server
-    ' we land on (graceful error -> Home if the item isn't there).
-    sub steerColdStartDeepLinkServer()
-      dl = m.global.AuthManager.stashedDeepLink
-      if not isValid(dl) or not isValidAndNotEmpty(dl.serverGuid) then return
-      entry = findSavedServerByGuid(dl.serverGuid)
-      if isValid(entry) and isValidAndNotEmpty(entry.originalUrl)
-        setSetting("server", entry.originalUrl)
-      end if
-    end sub
-
-    ' RUNTIME (app already signed in): resolve the stashed deep link's server and act.
-    '   - no/absent server, or it's the active one -> replay now.
-    '   - a different SAVED server -> prompt to switch.
-    '   - an unknown server -> can't connect; toast + discard.
-    ' When NOT signed in (user at pre-login), do nothing: the stash rides until login and
-    ' validates on whatever server they sign into.
-    sub onRuntimeDeepLink()
-      if not isValidAndNotEmpty(m.global.user.authToken)
-        notifyDeepLinkDeferred()
-        return
-      end if
-
-      dl = m.global.AuthManager.stashedDeepLink
-      guid = ""
-      if isValid(dl) then guid = dl.serverGuid
-
-      if not isValidAndNotEmpty(guid) or guid = LCase(m.global.server.id)
-        replayDeepLinkRuntime()
-        return
-      end if
-
-      entry = findSavedServerByGuid(guid)
-      if isValid(entry)
-        promptServerSwitch(entry)
-        return
-      end if
-
-      m.global.AuthManager.stashedDeepLink = invalid
-      displayToast(translate(translationKeys.MessageContentOnUnknownServer), "error")
-    end sub
-
-    ' Ask before switching servers (it signs the user out of the current one). The choice comes
-    ' back through SceneManager.returnData -> main.bs's isDataReturned handler (the same bridge
-    ' the exit dialog uses), which calls performServerSwitch on confirm.
-    sub promptServerSwitch(entry as object)
-      m.pendingSwitchServer = entry
-      m.global.sceneManager.isPendingServerSwitch = true
-
-      ' Name what's being cast when the sender provided a title, so the user can tell a real cast
-      ' from a stray/accidental one; fall back to a server-named, provenance-aware message otherwise.
-      dl = m.global.AuthManager.stashedDeepLink
-      itemName = ""
-      if isValid(dl) and isValidAndNotEmpty(dl.itemName) then itemName = dl.itemName
-      if isValidAndNotEmpty(itemName)
-        message = Substitute(translate(translationKeys.MessageSwitchServerToPlayTitled), itemName, entry.name)
-      else
-        message = Substitute(translate(translationKeys.MessageSwitchServerToPlay), entry.name)
-      end if
-
-      m.global.sceneManager.callFunc("showConfirmationDialog", translate(translationKeys.LabelChangeServer), [message], [translate(translationKeys.ButtonCancel), translate(translationKeys.ButtonSwitch)])
-    end sub
-
-    ' Perform the confirmed switch. Pre-flight the target FIRST (non-destructive) so an offline
-    ' server never strands the user. The probe runs on a Task thread (ServerReachableTask) so the
-    ' up-to-8s reachability check can't freeze remote input; the switch itself continues in
-    ' onServerProbeDone once the verdict lands back on the main loop.
-    sub performServerSwitch(entry as object)
-      m.pendingSwitchServer = invalid
-      if not isValid(entry) then return
-
-      startLoadingSpinner()
-      ' Hold the entry for the async callback — the probe outcome decides whether we tear down the
-      ' session, and the result arrives later via the main loop's "reachable" handler.
-      m.serverSwitchEntry = entry
-      task = CreateObject("roSGNode", "ServerReachableTask")
-      task.baseUrl = entry.baseUrl
-      task.observeField("reachable", m.port)
-      m.serverReachableTask = task
-      task.control = "RUN"
-    end sub
-
-    ' Continuation of performServerSwitch once the off-thread reachability probe returns. On an
-    ' unreachable target, surface the error and discard the deep link. On success, reuse the
-    ' Change-Server machinery (resetRouter -> point at the new server -> SignOut -> reenterLogin);
-    ' the stashed deep link survives the teardown and replays once the new server's login completes.
-    sub onServerProbeDone(reachable as boolean)
-      entry = m.serverSwitchEntry
-      m.serverSwitchEntry = invalid
-      if not isValid(entry) then return
-
-      if not reachable
-        stopLoadingSpinner()
-        m.global.AuthManager.stashedDeepLink = invalid
-        displayToast(Substitute(translate(translationKeys.MessageCouldNotReachServer), entry.name), "error")
-        return
-      end if
-
-      ' Tell the user what's happening — the switch tears down the session and re-logs into the
-      ' new server, so Home re-loading from scratch (the "everything's changing" moment) has context.
-      displayToast(Substitute(translate(translationKeys.MessageSwitchingToServer), entry.name), "info")
-
-      m.scene.callFunc("resetRouter")
-      setSetting("server", entry.originalUrl)
-      SignOut(false)
-      reenterLogin()
-    end sub
+  m.scene.callFunc("resetRouter")
+  setSetting("server", entry.originalUrl)
+  SignOut(false)
+  reenterLogin()
+end sub

--- a/tests/source/unit/utils/misc-toBoolean.spec.bs
+++ b/tests/source/unit/utils/misc-toBoolean.spec.bs
@@ -88,7 +88,7 @@ namespace tests
 
       ' Verify it's actually boolean type
       m.assertTrue(Type(result) = "roBoolean" or Type(result) = "Boolean",
-        `toBoolean('${input}') should return boolean type but got ${Type(result)}`)
+      `toBoolean('${input}') should return boolean type but got ${Type(result)}`)
       m.assertEqual(result, expected,
       `toBoolean('${input}') should return ${expected} but got ${result}`)
 
@@ -130,7 +130,7 @@ namespace tests
 
       ' Should remain a string since they're not exactly "true" or "false"
       m.assertTrue(Type(result) = "roString" or Type(result) = "String",
-        `toBoolean('${value}') should return string type but got ${Type(result)}`)
+      `toBoolean('${value}') should return string type but got ${Type(result)}`)
       m.assertEqual(result, value)
     end function
 

--- a/tests/source/unit/utils/misc.spec.bs
+++ b/tests/source/unit/utils/misc.spec.bs
@@ -94,15 +94,15 @@ namespace tests
 
     @it("returns true for valid array of associative arrays")
     @params(
-      [
-        {
-          Title: "The Notebook",
-          releaseDate: "2000"
-        },
-        {
-          Title: "Caddyshack",
-          releaseDate: "1976"
-        }
+    [
+      {
+        Title: "The Notebook",
+        releaseDate: "2000"
+      },
+      {
+        Title: "Caddyshack",
+        releaseDate: "1976"
+      }
     ], true)
     function _(value, expectedassertResult)
       m.assertEqual(isValid(value), expectedassertResult)
@@ -256,27 +256,27 @@ namespace tests
 
     @it("validates all values in array of associative arrays")
     @params(
-      [
-        {
-          Title: "The Notebook",
-          releaseDate: "2000"
-        },
-        {
-          Title: "Caddyshack",
-          releaseDate: "1976"
-        }
+    [
+      {
+        Title: "The Notebook",
+        releaseDate: "2000"
+      },
+      {
+        Title: "Caddyshack",
+        releaseDate: "1976"
+      }
     ], true)
     @params(
-      [
-        {
-          Title: "The Notebook",
-          releaseDate: "2000"
-        },
-        {
-          Title: "Caddyshack",
-          releaseDate: "1976"
-        },
-        invalid
+    [
+      {
+        Title: "The Notebook",
+        releaseDate: "2000"
+      },
+      {
+        Title: "Caddyshack",
+        releaseDate: "1976"
+      },
+      invalid
     ], false)
     function _(value, expectedassertResult)
       m.assertEqual(isAllValid(value), expectedassertResult)


### PR DESCRIPTION
# Overview

brighterscript-formatter 1.7.28 ([#140](https://github.com/rokucommunity/brighterscript-formatter/pull/140) "Multi-line Function parameters") has an indentation regression: after a **multi-line associative-array call argument** (e.g. `fetchJson(GetApi().Build...({ ... }))`, `m.log.warn("...", { ... })` spanning lines — ubiquitous in this codebase), the formatter never pops the indent level, so every following statement is over-indented by 2, cascading *past* `end sub`/`end function` into the next top-level declaration. It's cosmetic (BrightScript blocks are keyword-delimited, so it compiles — which is why #678's CI was green) but `bsfmt --check` enforces the corrupted output, and it landed across 12 files via #678.

This pins back to 1.7.27 and reformats, restoring the exact pre-#678 formatting.

## Changes

- Downgrade `brighterscript-formatter` 1.7.28 → **1.7.27** (`package.json` + lockfile).
- `npm run format` — reverts the over-indentation in the 12 files #678 had reformatted. Verified the working tree exactly matches the pre-#678 state (empty diff vs the commit before #678 merged); `bsfmt --check` passes under 1.7.27.
- Add a `signals-backlog` watch row (`bsfmt-multiline-indent-regression`) for a fixed release after 1.7.28.

**Repro** (1.7.27 keeps `end sub` + the next top-level `function` at column 0; 1.7.28 pushes both to column 2):
```brightscript
sub doThing()
  if foo
    m.log.warn("msg", {
      videoID: m.top.videoID
    })
  end if
end sub

function nextTopLevel()
  x = 1
end function
```

## Follow-ups

None — the watch for a fixed release is in `docs/signals-backlog.md` (`bsfmt-multiline-indent-regression`). No `renovate.json` version hold: Renovate will re-propose 1.7.28 as a patch; close that PR without merging until a fixed release ships (then verify the repro under it before merging).

## Issues

None

## Docs / context updates

- [x] None — this PR doesn't change any architecture doc / dev how-to / CLAUDE.md / ADR / tech-debt entry. `source/replayRoute.bs` is in `user-journey.md`'s related-files but the change to it is whitespace-only (indentation revert) — no shape/why change, so that doc is intentionally untouched. (`docs/signals-backlog.md` is a journal capture, not one of the listed doc categories.)

<!-- /pr render: sha=24457bc56f752ed445585f7981a13cda3503fa2a ts=2026-06-28T23:55:00Z -->