### PR TITLE
Restore navigation loading spinners lost in the `sgRouter` migration

### DIFF
--- a/components/CLAUDE.md
+++ b/components/CLAUDE.md
@@ -21,6 +21,7 @@ Roku Scene Graph (RSG) components — XML interface + paired BrighterScript back
 - Override `onScreenShown()` — restore focus, refresh data on revisit.
 - Override `onScreenHidden()` — pause Tasks, hide UI, but keep state.
 - Override `onDestroy()` — release Task nodes, unobserve fields, drop large data structures. The base `onDestroy()` is a no-op; missing it leaks observers and tasks across navigation. Two BSC plugins enforce this; opt-out comments are documented in [build-and-tooling.md](../docs/architecture/build-and-tooling.md).
+- **A routed screen owns its own load spinner.** If a screen fetches data on open, it `startLoadingSpinner()`s when the fetch begins and `stopLoadingSpinner()`s when data arrives — callers just navigate. Don't stop a spinner synchronously right after a `navigateTo` to a *different* view: the nav is async (settles at `NavigationEnd`) so `activeRoutedView` is still the outgoing view, and stopping re-shows it for a frame. See [navigation.md → Loading spinners across navigation](../docs/architecture/navigation.md).
 
 ## Render thread protection
 

--- a/components/ItemDetails.bs
+++ b/components/ItemDetails.bs
@@ -727,6 +727,14 @@ sub onItemIdChanged()
   m.loadDetailsTask.unobserveField("content")
   m.loadDetailsTask.control = "STOP"
 
+  ' Show the loading spinner during the metadata fetch (onDetailsLoaded stops it). Restores the
+  ' pre-#677 behavior: the removed showScenes.CreateItemDetailsGroup factory started the spinner
+  ' before pushScene; under the router the bare sgrouter.navigateTo at the call sites (Home / grid /
+  ' search) doesn't, so the spinner has to start here — the one place that owns the fetch. itemId's
+  ' onChange is a synchronous scoped observer (fires inside loadFromRoute during onScreenShown), so
+  ' the spinner is up before the empty springboard renders a frame.
+  startLoadingSpinner()
+
   m.loadDetailsTask.itemId = itemId
   m.loadDetailsTask.shouldForceRefresh = false
   m.loadDetailsTask.observeField("content", "onDetailsLoaded")

--- a/components/JRScene.bs
+++ b/components/JRScene.bs
@@ -364,16 +364,25 @@ end function
 ' settle drain (folds in finding A4: a rejected nav must re-assert focus, never strand the remote).
 ' routePath is dynamic: a string path for most calls, or a named-route AA ({ name, ... }) from
 ' routeForItem on the deep-link container path. sgRouter.navigateTo accepts both.
-sub navigateThenFocus(routePath as dynamic, context = {} as object)
+' clearSpinner: set by the login paths only. A blocking login spinner (started by the login
+' coordinator on the OUTGOING pre-login view) is kept up across this async nav and cleared HERE,
+' once the destination view has mounted (navigateTo resolves at NavigationEnd). Clearing it
+' synchronously before the nav settles re-shows the outgoing pre-login view for a frame — the
+' #677 login flash. Mirrors the ItemDetails -> player pattern (spinner stays up across the nav,
+' the destination clears it).
+sub navigateThenFocus(routePath as dynamic, context = {} as object, clearSpinner = false as boolean)
   options = {}
   if isValidAndNotEmpty(context) then options = { context: context }
-  promises.chain(sgrouter.navigateTo(routePath, options), { routePath: routePath }).then(sub(_result as object, _ctx as object)
+  promises.chain(sgrouter.navigateTo(routePath, options), { routePath: routePath, clearSpinner: clearSpinner }).then(sub(_result as object, ctx as object)
+    if ctx.clearSpinner then stopLoadingSpinner()
     sgrouter.setFocus({ focus: true })
   end sub).catch(sub(err as object, ctx as object)
     ' navigateTo rejects when a nav is already in progress (transient) or the route isn't
     ' registered (a programming error). Re-assert focus so a rejected nav can't strand the remote,
     ' and surface the reason instead of dropping it silently.
     m.log.warn("navigateThenFocus failed; re-asserting focus", ctx.routePath, err.message)
+    ' Clear the spinner even on a rejected login nav so a failure can't strand it up.
+    if ctx.clearSpinner then stopLoadingSpinner()
     sgrouter.setFocus({ focus: true })
   end sub)
 end sub
@@ -382,9 +391,9 @@ end sub
 ' the mounted view remote focus. Called from main.bs / loginRouter (main thread) to drive
 ' BOTH the pre-login flow (/server, /users, /login) and the transition to Home ("/").
 ' context is forwarded as route context (e.g. a prefilled username for /login).
-sub routerNavigate(routePath as string, context = {} as object)
+sub routerNavigate(routePath as string, context = {} as object, clearSpinner = false as boolean)
   initRouter()
-  navigateThenFocus(routePath, context)
+  navigateThenFocus(routePath, context, clearSpinner)
 end sub
 
 ' Replay a (deferred) deep link after login by navigating a SEQUENCE of routes, each step
@@ -397,27 +406,37 @@ end sub
 sub replayRoutedDeepLink(routes as object)
   initRouter()
   if not isValidAndNotEmpty(routes) then routes = ["/"]
-  navigateChainStep(routes, 0)
+  ' Post-login replay: the blocking login spinner is still up on the outgoing pre-login view.
+  ' Keep it up across the async nav and clear it when the FINAL route settles (clearLoginSpinnerOnEnd
+  ' -> navigateThenFocus clearSpinner). Clearing it synchronously in createAndShowHomeGroup re-showed
+  ' the outgoing view for a frame before Home mounted — the #677 login flash.
+  navigateChainStep(routes, 0, true)
 end sub
 
 ' Navigate routes[index], then chain to the next step once it settles (sgRouter's
 ' navigateTo promise resolves at NavigationEnd, so each .then() defers until the previous
 ' route is fully mounted). The final step takes remote focus. Context carries routes/index
 ' (BrightScript closures can't capture locals).
-sub navigateChainStep(routes as object, index as integer)
+' clearLoginSpinnerOnEnd: threaded through to the FINAL step's navigateThenFocus so the login
+' replay (replayRoutedDeepLink) keeps the blocking spinner up across the whole chain and clears it
+' only once the last route mounts. The runtime-cast caller (replayDeepLinkReplacingPlayer) leaves
+' it false — no login spinner is up there.
+sub navigateChainStep(routes as object, index as integer, clearLoginSpinnerOnEnd = false as boolean)
   if index >= routes.count() then return
   ' Final step: navigate + take focus + catch is exactly the shared settle tail.
   if index = routes.count() - 1
-    navigateThenFocus(routes[index])
+    navigateThenFocus(routes[index], {}, clearLoginSpinnerOnEnd)
     return
   end if
   ' Intermediate step: navigate, then chain to the next once it settles. A rejection stops the
   ' chain (a later step would build on a route that never mounted) and takes focus on whatever IS
   ' mounted, so a failed deep-link replay can't strand the remote.
-  promises.chain(sgrouter.navigateTo(routes[index]), { routes: routes, index: index }).then(sub(_result as object, ctx as object)
-    navigateChainStep(ctx.routes, ctx.index + 1)
+  promises.chain(sgrouter.navigateTo(routes[index]), { routes: routes, index: index, clearSpinner: clearLoginSpinnerOnEnd }).then(sub(_result as object, ctx as object)
+    navigateChainStep(ctx.routes, ctx.index + 1, ctx.clearSpinner)
   end sub).catch(sub(err as object, ctx as object)
     m.log.warn("deep-link route chain step failed; stopping chain", ctx.routes[ctx.index], err.message)
+    ' If this was the login replay, don't leave the blocking spinner stranded on a failed chain.
+    if ctx.clearSpinner then stopLoadingSpinner()
     sgrouter.setFocus({ focus: true })
   end sub)
 end sub

--- a/docs/architecture/navigation.md
+++ b/docs/architecture/navigation.md
@@ -11,7 +11,7 @@ related-files:
   - components/data/SceneManager.bs
   - source/replayRoute.bs
   - source/loginRouter.bs
-last-reviewed: 2026-06-26
+last-reviewed: 2026-07-03
 ---
 
 # Navigation (sgRouter)
@@ -171,15 +171,27 @@ On a present token it returns `true` (allow). On absence it **stashes the reques
 
 | Function | What it does |
 |---|---|
-| `routerNavigate(path, context)` | `initRouter()` then `navigateThenFocus(path, context)`. The main-thread entry point for single navigation calls (pre-login flow + transition to Home). `context` carries route data (e.g. a populated username for `/login`). |
-| `navigateThenFocus(path, context)` | The shared navigate tail: `sgrouter.navigateTo` → on settle, `sgrouter.setFocus` → on reject, warn + re-assert focus (never strand the remote). Centralizes the navigate/focus/catch trio reused by `routerNavigate`, the final step of `navigateChainStep`, and the deep-link resolve calls. `path` is a string or a named-route AA. |
-| `replayRoutedDeepLink(routes)` | `initRouter()` then `navigateChainStep(routes, 0)` — a *sequential* route chain for deep-link replay (each step waits for the previous to settle). Defaults to `["/"]`. |
-| `navigateChainStep(routes, index)` | Navigates `routes[index]`, then chains to the next once it settles (`navigateTo`'s promise resolves at `NavigationEnd`). The final step takes remote focus. |
+| `routerNavigate(path, context, clearSpinner)` | `initRouter()` then `navigateThenFocus(path, context, clearSpinner)`. The main-thread entry point for single navigation calls (pre-login flow + transition to Home). `context` carries route data (e.g. a populated username for `/login`). `clearSpinner` (login paths only) — see "Loading spinners across navigation" below. |
+| `navigateThenFocus(path, context, clearSpinner)` | The shared navigate tail: `sgrouter.navigateTo` → on settle, `sgrouter.setFocus` → on reject, warn + re-assert focus (never strand the remote). Centralizes the navigate/focus/catch trio reused by `routerNavigate`, the final step of `navigateChainStep`, and the deep-link resolve calls. `path` is a string or a named-route AA. When `clearSpinner` is set, it `stopLoadingSpinner()`s at settle (`NavigationEnd`) / on reject — used to carry a blocking login spinner across the async nav (see below). |
+| `replayRoutedDeepLink(routes)` | `initRouter()` then `navigateChainStep(routes, 0, true)` — a *sequential* route chain for post-login replay (each step waits for the previous to settle). Defaults to `["/"]`. Passes `clearLoginSpinnerOnEnd = true` so the blocking login spinner is cleared only when the final route mounts. |
+| `navigateChainStep(routes, index, clearLoginSpinnerOnEnd)` | Navigates `routes[index]`, then chains to the next once it settles (`navigateTo`'s promise resolves at `NavigationEnd`). The final step takes remote focus (and clears the login spinner when `clearLoginSpinnerOnEnd` is set). The runtime-cast caller (`replayDeepLinkReplacingPlayer`) leaves it `false` — no login spinner is up there. |
 | `onPlaybackLaunchRequested()` | Reads `m.global.playbackLaunchRequest`; audio → `/audio`, every video-family type → `/details/<type>/<id>/play`. The queue is the source of truth for what plays. |
 | `onPhotoLaunchRequested()` | Reads `m.global.photoLaunchRequest`; navigates `/photo` carrying the launch AA through as route context (`PhotoDetails` reads it on mount). |
 | `reloadRoutedHome()` | `sgrouter.navigateTo("/")` — a fresh Home render after theme/locale change (Home's `clearStackOnResolve` rebuilds it, picking up new theme constants / translations). |
 | `routerGoBack()` | Main-thread wrapper for `sgrouter.goBack()` (e.g. after a delete confirmation leaves the now-deleted detail). |
 | `resetRouter()` | Removes the overhang/playback/photo observers, **drives `beforeViewClose` (→ `onScreenHidden` + `onDestroy`) on every mounted routed view** (`teardownRoutedViews` — both the active view and the suspended `keepAlive` views), then `sgrouter.destroy()`, clears `m.global.activeRoutedView`, hides the overhang. Called on sign-out / change-user / change-server before `reenterLogin`. The explicit teardown is required because `sgrouter.destroy()` removes the view *nodes* without running their lifecycle — without it a `keepAlive` view suspended at sign-out leaks its Tasks/observers and never abandons in-flight API promises. |
+
+### Loading spinners across navigation
+
+The scene-level loading spinner is toggled by `JRScene.onIsLoadingChanged` (fired by `startLoadingSpinner()` / `stopLoadingSpinner()` in `misc.bs`, which set `isLoading` + `isRemoteDisabled` on the scene). Crucially it also toggles the active view: `activeRoutedView.visible = not isRemoteDisabled`. So a **blocking** spinner (`isRemoteDisabled = true`) hides the current view; stopping it shows the current view again.
+
+**Convention: a routed destination screen owns its own load spinner.** The screen that loads data on open starts the spinner when its fetch begins and stops it when the data arrives; callers just `navigateTo`. This is the pattern the sgRouter migration established, and where a spinner "goes missing" it's almost always a screen that didn't get the memo.
+
+- **Self-starting screens** — `BaseGridView` (`loadInitialItems` → `prepareDataLoad`), `SearchResults` (`searchMedias`), the Live TV schedule: start *and* stop their own spinner.
+- **Launcher-started** — photo / player: `QueueManager.launchItem` (and the play/quickplay paths) start the spinner; the destination (`PhotoDetails` on mount, the player when content loads) stops it.
+- **`ItemDetails`** — starts the spinner in `onItemIdChanged` (right before the metadata fetch task), stops it in `onDetailsLoaded`. Its start used to live in the removed `showScenes.CreateItemDetailsGroup` factory; the migration didn't re-home it, so item opens showed no spinner until this was restored. `itemId`'s `onChange` is a synchronous scoped observer, so the spinner is up before the empty springboard renders a frame; the complete-context (deep-link) early-return shows no spinner for an already-loaded item.
+
+**Login is the one cross-screen exception.** The login coordinator starts a **blocking** spinner on the *outgoing* pre-login view (`onUserSelected` / `onCredentialsSubmitted`), then navigates to a **different** view. Because `navigateTo` is async (it resolves at `NavigationEnd`), `activeRoutedView` is still the outgoing view for the duration of the nav. Stopping the spinner synchronously *before* the nav settles resets `isRemoteDisabled` and re-shows that stale outgoing view for a frame before the destination mounts — the visible "login flash" #677 introduced. The fix is to **keep the spinner up across the nav and clear it at settle** via the `clearSpinner` flag on `navigateThenFocus` (login→Home rides it through `replayRoutedDeepLink` → `navigateChainStep`; the password-required `/login` hop rides it through `routerNavigate`). This mirrors the launcher-started pattern — the destination's mount is what clears the spinner, never a synchronous stop mid-transition.
 
 ## The back arbiter & exit confirmation
 

--- a/source/loginRouter.bs
+++ b/source/loginRouter.bs
@@ -306,10 +306,12 @@ sub onUserSelected()
     return
   end if
 
-  ' Password required — go to manual sign-in with the username prefilled.
+  ' Password required — go to manual sign-in with the username prefilled. Keep the blocking spinner
+  ' up across the async nav and clear it when LoginScene mounts (clearSpinner=true). Stopping it
+  ' here first re-shows the UserSelect row for a frame before LoginScene mounts — the same #677
+  ' flash class as the login -> Home path.
   print "Auth failed. Password required"
-  stopLoadingSpinner()
-  routerNav("/login", { username: userSelected })
+  routerNav("/login", { username: userSelected }, true)
 end sub
 
 ' Back from UserSelect → change server. Mirrors LoginFlow 114-119.
@@ -406,7 +408,9 @@ sub finishLogin()
   loadHomeScreen()
 end sub
 
-' Thin main-thread → render-thread navigation bridge.
-sub routerNav(routePath as string, context as object)
-  m.scene.callFunc("routerNavigate", routePath, context)
+' Thin main-thread → render-thread navigation bridge. clearSpinner (login paths only) keeps a
+' blocking login spinner up across the async nav and clears it when the destination view mounts —
+' see JRScene.navigateThenFocus.
+sub routerNav(routePath as string, context as object, clearSpinner = false as boolean)
+  m.scene.callFunc("routerNavigate", routePath, context, clearSpinner)
 end sub

--- a/source/main.bs
+++ b/source/main.bs
@@ -376,8 +376,14 @@ sub createAndShowHomeGroup()
   ' deferred/cold-start play deep link (decision #3). Home self-loads its libraries in its own
   ' onViewOpen. (exit + activeRoutedView + the pre-login intent bridge are observed once during
   ' bootstrap, not here.)
+  ' The blocking login spinner (started on the outgoing pre-login view) is intentionally NOT
+  ' stopped here. replayAfterLogin() only KICKS OFF the async router nav to Home (sgRouter resolves
+  ' at NavigationEnd), so the outgoing UserSelect/LoginScene is still the active routed view at this
+  ' point — stopping the spinner now resets isRemoteDisabled and re-shows that view for a frame
+  ' before Home mounts (the #677 login flash). The spinner is cleared when the Home nav settles
+  ' (replayRoutedDeepLink -> navigateChainStep clearLoginSpinnerOnEnd). The deep-link branch owns
+  ' its own spinner via resolveDeepLink/onDeepLinkResolved.
   replayAfterLogin()
-  stopLoadingSpinner()
 
   ' update lastRunVersion but only on prod
   if not m.global.app.isDev


### PR DESCRIPTION
# Overview

The #677 `sgRouter` migration changed how loading spinners interact with navigation, introducing three small but repeatable visual regressions in the pre-login and item-details flows. This PR fixes all three and documents the convention the migration implicitly established — a routed destination screen owns its own load spinner — so it isn't re-lost in a future refactor.

Root cause is shared: `JRScene.onIsLoadingChanged` ties `activeRoutedView.visible` to `isRemoteDisabled`, and `sgrouter.navigateTo` is async (resolves at `NavigationEnd`). So stopping a blocking spinner synchronously *before* a nav settles re-shows the stale outgoing view for a frame; and any spinner-start that lived in a deleted `showScenes` factory simply went missing.

## Changes

- **Login → Home flash** — `createAndShowHomeGroup` no longer stops the spinner synchronously after kicking off the async Home nav. The blocking login spinner now stays up across the transition and clears at `NavigationEnd` via a `clearSpinner` flag threaded through `navigateThenFocus` / `navigateChainStep` / `replayRoutedDeepLink`. Fixes the user row briefly re-appearing between the spinner and Home.
- **Password-required nav flash** — `onUserSelected`'s password-required branch routes through the same `clearSpinner` path (`routerNavigate`) instead of stopping the spinner before navigating to `/login`, removing the equivalent flash of the `UserSelect` row.
- **Missing item-details spinner** — `ItemDetails.onItemIdChanged` starts the spinner right before the metadata fetch (paired with the existing stop in `onDetailsLoaded`). Its start previously lived in the removed `showScenes.CreateItemDetailsGroup` factory and was never re-homed, so opening any item from Home / grid / search showed no spinner.
- **Documentation** — adds a "Loading spinners across navigation" section to `navigation.md` (with the `clearSpinner` param on the nav-helper table) and a discoverability pointer in `components/CLAUDE.md`.

## Follow-ups

None

## Issues

Ref #677

## Docs / context updates

- [x] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [x] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [ ] None — this PR doesn't change any of the above

<!-- /pr render: sha=353524e5149582390cc95775211092ae9827e6cf ts=2026-07-03T16:03:16Z -->