### PR TITLE
fix: Stop `Home` from clobbering the foreground backdrop when opening deep-link

### DIFF
--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -1,6 +1,7 @@
 ' bsc-disable-file print-locations — legacy print() sites; migration to m.log.* tracked by tech-debt.md#legacy-print-statements
 import "pkg:/source/constants/itemAspectRatio.bs"
 import "pkg:/source/translationKeys.bs"
+import "pkg:/source/utils/backdrop.bs"
 import "pkg:/source/utils/itemImageUrl.bs"
 import "pkg:/source/utils/misc.bs"
 import "pkg:/source/utils/rowListWrap.bs"
@@ -789,6 +790,15 @@ end sub
 ' Handles all validation and edge cases
 ' Used by: onItemFocused observer and row update functions after replaceChild
 sub updateBackdropForFocusedItem()
+  ' Don't clobber the foreground view's backdrop when Home is no longer the active routed view. On a
+  ' cold deep-link launch (Home -> ItemDetails), Home's rows finish loading LATE and this observer can
+  ' fire after ItemDetails is showing; without this guard the shared global backdrop (last-writer-wins)
+  ' gets blanked out under the deep-linked item. See backgroundWriteIsStale (source/utils/backdrop.bs).
+  active = m.global.activeRoutedView
+  activeSubtype = invalid
+  if isValid(active) then activeSubtype = active.subtype()
+  if backgroundWriteIsStale(activeSubtype, "Home") then return
+
   focusedItem = getItemAtIndices(m.top.rowItemFocused)
 
   ' Always call setBackgroundImage so the backdrop clears when the focused item has none.

--- a/docs/architecture/tech-debt.md
+++ b/docs/architecture/tech-debt.md
@@ -85,6 +85,12 @@ The `npm run lint:docs` checker validates every `tech-debt.md#<anchor>` referenc
 - **issue**: Settings change → `applyThemeColorOverrides` (writes to `m.global.constants`) → `sceneManager.callFunc("refreshThemeColors")` (re-applies styles) → `sceneManager.callFunc("reloadHome")` (rebuilds home rows) is a 3-step manual chain that every theme-changing call site must invoke in order. Components that cache theme colors at construction time miss updates entirely unless the home is rebuilt.
 - **direction**: Either (a) all components read from `m.global.constants` in event handlers (not `init`), or (b) define a "theme observable" — a node on `m.global` whose updates fire observers — that components opt into instead of relying on `reloadHome` as a blunt rebuild.
 
+#### `backdrop-ownership-guard`
+
+- **area**: `components/JRScene.bs` (`setBackgroundImage`, `imageFader`), `components/ui/BackdropFader.*`, and every backdrop writer (`components/home/HomeRows.bs`, `components/ItemGrid/BaseGridView.bs`, `components/ItemDetails.bs`, search / favorites / player views).
+- **issue**: The app has a SINGLE global backdrop node (`JRScene.imageFader`) and `setBackgroundImage` is last-writer-wins with no notion of which routed view owns the screen. Any view whose async data lands *after* it is no longer the active routed view can clobber the foreground view's backdrop. Surfaced as the cold-launch bug where Home's late row load blanked a deep-linked `ItemDetails` backdrop — fixed narrowly in `HomeRows.updateBackdropForFocusedItem` via `backgroundWriteIsStale` (`source/utils/backdrop.bs`), but every other async backdrop writer has the same latent hazard. Also `forceBackdrop` (login clear) resets `imageFader.uri` without resetting `m.lastBackdropUri`, so cross-phase dedup state can go stale.
+- **direction**: Move the ownership guard INTO `JRScene.setBackgroundImage`, keyed to `m.global.activeRoutedView` — reject a write from any view that is not the active routed view — then drop the now-redundant per-caller `backgroundWriteIsStale` guard from `HomeRows`. Reset `m.lastBackdropUri` on the `forceBackdrop` clear.
+
 ### Low
 
 #### `screenshot-osd-frame-quality`

--- a/source/utils/backdrop.bs
+++ b/source/utils/backdrop.bs
@@ -31,3 +31,29 @@ function resolveShowBackdrop(userSettings as object, userConfig as object) as bo
 
   return defaultValue
 end function
+
+' backgroundWriteIsStale: true when a global-backdrop write should be SUPPRESSED because the writing
+' screen is no longer the active routed view.
+'
+' The app has a SINGLE global backdrop node (JRScene.imageFader, last-writer-wins, no ownership guard).
+' A view whose async data lands AFTER it has been backgrounded can otherwise clobber the foreground
+' view's backdrop. The concrete case: on a cold deep-link launch the app routes Home -> ItemDetails,
+' but Home's row Tasks finish loading LATE and its rowItemFocused observer fires a backdrop write after
+' ItemDetails is already showing — blanking the item the user was deep-linked to. Warm navigation
+' doesn't hit this because Home's rows are already loaded before it is backgrounded.
+'
+' Suppress only when a DIFFERENT valid view owns the screen. An unset/empty active subtype (early
+' mount, before m.global.activeRoutedView is assigned) is allowed through, so a legitimate first paint
+' is never dropped. Pure so the rule is unit-testable.
+'
+' NOTE (tech-debt: backdrop-ownership-guard): the durable fix is to move this check INTO
+' JRScene.setBackgroundImage keyed to m.global.activeRoutedView, so EVERY late writer (not just Home)
+' is guarded. This helper is the isolated fix for the observed HomeRows cold-launch clobber.
+'
+' @param {dynamic} activeSubtype - m.global.activeRoutedView.subtype() (or invalid when none/unset)
+' @param {string} owningSubtype - the subtype of the screen attempting the write (e.g. "Home")
+' @returns {boolean} - true to SUPPRESS the write (a different view is active)
+function backgroundWriteIsStale(activeSubtype as dynamic, owningSubtype as string) as boolean
+  if not isValidAndNotEmpty(activeSubtype) then return false
+  return activeSubtype <> owningSubtype
+end function

--- a/tests/source/unit/utils/backgroundWriteIsStale.spec.bs
+++ b/tests/source/unit/utils/backgroundWriteIsStale.spec.bs
@@ -1,0 +1,53 @@
+import "pkg:/source/utils/backdrop.bs"
+
+namespace tests
+
+  @suite("backdrop - backgroundWriteIsStale()")
+  class BackgroundWriteIsStaleTests extends tests.BaseTestSuite
+
+    protected override function setup()
+      super.setup()
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("suppresses a write when a DIFFERENT view is active")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    ' The cold deep-link race: Home routes on to ItemDetails, then Home's late row load fires a backdrop
+    ' write while ItemDetails (or a player) is the active routed view — that write must be dropped.
+    @it("suppresses Home's write when the active view is not Home")
+    @params("ItemDetails")
+    @params("VideoPlayerView")
+    @params("PlayerHostView")
+    @params("Search")
+    function _(activeSubtype)
+      m.assertTrue(backgroundWriteIsStale(activeSubtype, "Home"))
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("allows a write when the owning view is (or may be) active")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("allows the write when the active view IS the owning view")
+    function _()
+      m.assertFalse(backgroundWriteIsStale("Home", "Home"))
+    end function
+
+    ' An unset/empty active subtype means the router hasn't assigned activeRoutedView yet (early mount).
+    ' A legitimate first paint must not be dropped, so these pass through.
+    @it("allows the write when the active subtype is unset/empty (early mount)")
+    @params(invalid)
+    @params("")
+    function _(activeSubtype)
+      m.assertFalse(backgroundWriteIsStale(activeSubtype, "Home"))
+    end function
+
+    @it("is owner-agnostic: matches any owning subtype against the active view")
+    function _()
+      m.assertFalse(backgroundWriteIsStale("ItemDetails", "ItemDetails"))
+      m.assertTrue(backgroundWriteIsStale("Home", "ItemDetails"))
+    end function
+
+  end class
+
+end namespace


### PR DESCRIPTION
# Overview

On a cold deep-link launch the app routes Home → ItemDetails, but Home's row Tasks finish loading late and its `rowItemFocused` observer fires a backdrop write *after* ItemDetails is already showing. The backdrop is a single global node (`JRScene.imageFader`, last-writer-wins), so that late write blanked the item the user was deep-linked to — most visibly a blank backdrop when cold-launching into an episode via cast/deep-link. Warm navigation avoids it because Home's rows are already loaded before it is backgrounded. This guards the write so a backgrounded `Home` no longer owns the shared backdrop.

Verified on a real Roku: the full unit suite (2473 tests) passes, and the cold-launch repro now shows the backdrop loading correctly.

## Changes
- Add a pure `backgroundWriteIsStale(activeSubtype, owningSubtype)` rule in `source/utils/backdrop.bs`: suppress a global-backdrop write when a *different* valid routed view owns the screen; allow it when the owner is active or the active view is unset (early mount).
- Guard `HomeRows.updateBackdropForFocusedItem` with that rule so a late `rowItemFocused` from a backgrounded `Home` can't blank the foreground view's backdrop.
- Add a parameterized unit test for the rule (`backgroundWriteIsStale.spec.bs`).

## Follow-ups
- [`backdrop-ownership-guard`](docs/architecture/tech-debt.md#backdrop-ownership-guard) — move the ownership guard into `JRScene.setBackgroundImage` (keyed to `m.global.activeRoutedView`) so every async backdrop writer is covered, not just `Home`.

## Issues
None

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [x] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up

<!-- /pr render: sha=5af38401275b49df9bb2d2c02ee443570eba9f72 ts=2026-07-17T01:23:19Z -->