### PR TITLE
feat(remote-control): ack long-poll commands for at-least-once delivery

### DIFF
--- a/components/remotecontrol/RemoteControlTask.bs
+++ b/components/remotecontrol/RemoteControlTask.bs
@@ -194,11 +194,19 @@ sub runLongPollReceiver(serverUrl as string)
   end if
   m.log.info("long-poll plugin present; starting poll loop")
 
-  pollUrl = remoteProtocol.buildLongPollUrl(serverUrl, POLL_WAIT_MS)
-  if pollUrl = "" then return
+  if remoteProtocol.buildLongPollUrl(serverUrl, POLL_WAIT_MS) = "" then return
 
   ' Snapshot the token so a poll can detect a server-side rotation and stop cleanly (mirrors the ws path).
   m.openedWithToken = m.global.user.authToken
+
+  ' At-least-once delivery state (contract v1). m.lastAckId is our cumulative ack — the newest MessageId
+  ' we've received — sent on every poll so the plugin can drop confirmed commands and redeliver the rest.
+  ' m.dispatchedIds/order is a small dedupe ring so a REDELIVERED command (a poll whose response we lost,
+  ' resent by the plugin) can't double-apply a relative verb like NextTrack. Both reset per receiver start;
+  ' a fresh receiver pairs with a fresh server-side session, so there's nothing to carry over.
+  m.lastAckId = ""
+  m.dispatchedIds = {}
+  m.dispatchedOrder = []
 
   attempt = 0
   while true
@@ -209,6 +217,9 @@ sub runLongPollReceiver(serverUrl as string)
       m.log.info("session ended; long-poll receiver stopping")
       return
     end if
+
+    ' Rebuilt each poll: the URL carries our current cumulative ackId, which advances as we receive.
+    pollUrl = remoteProtocol.buildLongPollUrl(serverUrl, POLL_WAIT_MS, m.lastAckId)
 
     ' Time the poll so an abnormally fast EMPTY response (a plugin that doesn't honor the hold) can be
     ' floored below — a compliant plugin holds ~POLL_WAIT_MS, so the floor never fires on it.
@@ -284,11 +295,43 @@ end function
 function dispatchEnvelope(envelope as object) as boolean
   if not isValid(envelope) then return false
   command = remoteCommand.parseMessage(envelope)
+
+  ' Advance the cumulative ack to the newest id we've received — of ANY kind, including ignore/keepalive —
+  ' so the plugin can drop it too. The body arrived atomically (roUrlTransfer is all-or-nothing), so the
+  ' last id in the array acks the whole batch on our next poll.
+  if isValidAndNotEmpty(command.messageId) then m.lastAckId = command.messageId
+
   kind = command.kind
   if kind = "ignore" or kind = "keepalive" then return false
+
+  ' Dedupe: at-least-once redelivers a batch whose response we lost, so a command we've ALREADY enacted
+  ' can arrive again — drop it, or a relative verb (NextTrack/Rewind/FastForward) would double-apply.
+  if hasDispatched(command.messageId) then return false
+
   marshalCommand(command)
+  recordDispatched(command.messageId)
   return true
 end function
+
+' Dedupe ring for at-least-once redelivery. Records ids we've actually dispatched and evicts the oldest
+' past a bounded window — a duplicate only ever arrives back-to-back (a redelivery on the very next poll),
+' so a small window is ample. An empty id (the ws path, or a malformed envelope) is never tracked, so it's
+' never deduped — those transports/paths don't redeliver.
+function hasDispatched(messageId as dynamic) as boolean
+  if not isValidAndNotEmpty(messageId) then return false
+  return m.dispatchedIds.doesExist(messageId)
+end function
+
+sub recordDispatched(messageId as dynamic)
+  DEDUPE_WINDOW = 64
+  if not isValidAndNotEmpty(messageId) or m.dispatchedIds.doesExist(messageId) then return
+  m.dispatchedIds[messageId] = true
+  m.dispatchedOrder.push(messageId)
+  if m.dispatchedOrder.count() > DEDUPE_WINDOW
+    oldest = m.dispatchedOrder.shift()
+    m.dispatchedIds.delete(oldest)
+  end if
+end sub
 
 ' Hot-loop floor for an abnormally fast EMPTY poll. A compliant plugin holds an empty poll for
 ' ~POLL_WAIT_MS, so this never fires against it; a misbehaving plugin that returns an empty 200/204

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -32,6 +32,8 @@ AAs
 ABI
 Accessors
 ack
+ack-aware
+acks
 ADR
 ADR's
 ADR-flavored
@@ -145,12 +147,15 @@ crossfade
 crowdsourced
 CSV
 CSVs
+cutover
 Daniele
 datagram
 decision-shape
 decrypting
 dedup
 Dedup
+dedupe
+dedupes
 deduplicated
 dep
 deps
@@ -424,6 +429,7 @@ recurse
 Reddit
 re-derive
 re-derived
+redelivery
 refetching
 regen
 Re-init
@@ -542,6 +548,7 @@ TTL
 tvchannel
 UI
 UIs
+unacked
 Unfavorite
 ungated
 unit-tests-tdd

--- a/docs/architecture/remote-control-longpoll-contract.md
+++ b/docs/architecture/remote-control-longpoll-contract.md
@@ -5,7 +5,7 @@ related-files:
   - components/remotecontrol/RemoteControlTask.bs
   - source/remotecontrol/remoteCommand.bs
   - source/api/baseRequest.bs
-last-reviewed: 2026-07-13
+last-reviewed: 2026-07-21
 ---
 
 # Long-poll wire contract — HTTPS "Cast to JellyRock" (#667)
@@ -52,7 +52,7 @@ trusted over the authenticated identity.
 JellyRock treats any non-200 as "no usable plugin" and stays dark on `https` (no cast target advertised).
 `contractVersion` lets JellyRock refuse a plugin that speaks a newer/older contract it can't handle.
 
-### `GET /JellyRock/RemoteControl/poll?waitMs=<n>` — the long-poll command channel
+### `GET /JellyRock/RemoteControl/poll?waitMs=<n>[&ack=1][&ackId=<guid>]` — the long-poll command channel
 
 Long-holds the request until a command is queued **or** `waitMs` elapses.
 
@@ -66,6 +66,17 @@ Long-holds the request until a command is queued **or** `waitMs` elapses.
 `waitMs` is JellyRock's requested hold ceiling (e.g. `25000`). The server MAY cap it. JellyRock's own
 client-side timeout is set **longer** than `waitMs` (plus margin) so a `204` always arrives before the
 transfer times out.
+
+`ack=1` and `ackId` are the **at-least-once acknowledgment** (see [At-least-once delivery](#at-least-once-delivery)),
+an additive, opt-in extension that does **not** bump `contractVersion`:
+
+- `ack=1` — the client's capability flag, present on **every** poll from an ack-aware client (including the
+  first). It tells the plugin "retain delivered commands until I confirm them." A plugin that predates this
+  ignores the flag and stays at-most-once; a client that omits it (an older build) likewise gets at-most-once.
+  So a new/old mix on either side degrades cleanly — neither regresses.
+- `ackId=<guid>` — the client's **cumulative** ack: the last `MessageId` it durably received. Omitted until
+  the client has received a command. The plugin drops every retained command up to and including this id and
+  **redelivers the rest** on this poll. An absent or unrecognized `ackId` acks nothing.
 
 ## Command envelope
 
@@ -92,13 +103,46 @@ socket**, so [`remoteCommand.parseMessage`](../../source/remotecontrol/remoteCom
   because its action defaults and the payload is `ItemIds` — so test a `Playstate` verb, not `Play`, when
   validating serialization. (A plugin serializing `Data` with `System.Text.Json` needs a `JsonStringEnumConverter`.)
   Field-name casing is free (the client reads case-insensitively); only the enum *values* are load-bearing.
-- `MessageId` — the server-assigned message GUID; carried for future ack/idempotency. JellyRock does not
-  ack in Phase 1 (commands are idempotent enough at this scope), but the field is reserved so an at-least-once
-  guarantee can be layered on without a contract break.
+- `MessageId` — the server-assigned message GUID; the **ack key** for [at-least-once delivery](#at-least-once-delivery).
+  The client echoes the last id it received back as the next poll's cumulative `ackId`, and dedupes by it. A
+  client that doesn't ack simply ignores it (at-most-once). Always present on this channel.
 - **Batch semantics:** the queue drains **FIFO** into the array; commands that pile up between polls are
   delivered in order in a single `200`. JellyRock dispatches them in array order.
 - **`KeepAlive` / `ForceKeepAlive` are not sent** on this channel — the poll request itself is the
   keepalive (see liveness). A plugin MUST NOT enqueue them.
+
+## At-least-once delivery
+
+The plugin removes a batch from its queue to write it into the `200` response. HTTP gives the server no
+signal that the client actually received those bytes, so a client that disconnects between *drain* and
+*delivery* would lose that batch. `ack=1` + `ackId` close that gap; it is **opt-in and additive** (contract
+still `1`), realizing the hook the `MessageId` field was reserved for.
+
+**Mechanism (cumulative ack + redelivery):**
+
+1. An ack-aware client sends `ack=1` on every poll. The plugin then **retains** each delivered command
+   (delivered-but-unacked) instead of dropping it.
+2. When the client's poll response arrives, it records the last `MessageId` and sends it as `ackId` on the
+   **next** poll. The plugin drops everything up to and including that id.
+3. Anything still unacked is **redelivered** ahead of new commands. So a lost response self-heals on the next
+   poll: the commands the client never saw come back, keyed off an `ackId` that didn't advance past them.
+
+**The client MUST dedupe by `MessageId`.** At-least-once means a redelivered batch can contain a command the
+client already enacted (e.g. its ack was lost, or two polls briefly overlapped). Most commands are idempotent,
+but the **relative** transport verbs — `NextTrack`, `PreviousTrack`, `Rewind`, `FastForward` — are not:
+replaying one double-applies. JellyRock keeps a small ring of recently-dispatched ids and skips a repeat.
+
+**Ordering & bounds:** redelivery preserves FIFO order. The retained buffer is bounded like the queue
+(oldest-dropped past a cap): a client that receives but never acks is buggy or gone — it is about to lapse
+out of the cast list anyway — so the plugin favors the newest commands rather than growing without limit.
+
+**Cumulative, not per-message:** the client acks the newest id it received, which implicitly acks everything
+before it. This is sufficient because the transport is whole-response-or-nothing (`roUrlTransfer` yields the
+full body or a timeout, never a partial array) and the client dispatches the array in strict order.
+
+> A plugin or client that implements neither side of this stays at **at-most-once**, exactly as contract v1
+> shipped — the tiny drain→deliver window remains, and the user re-issues the rare lost command. Mixed
+> versions are safe in every direction.
 
 ## Liveness — the closed-app requirement
 
@@ -136,3 +180,9 @@ Consulted in [`RemoteControlTask.runReceiver`](../../components/remotecontrol/Re
 `contractVersion` starts at **1**. A backward-compatible addition (new optional field, new `MessageType`
 JellyRock already ignores) does not bump it. A breaking change (renamed field, changed status semantics)
 bumps it; JellyRock refuses a `contractVersion` it doesn't implement and stays dark rather than risk acting on a command it might misread.
+
+The [at-least-once ack](#at-least-once-delivery) (`ack=1` / `ackId`) is a deliberate example of a
+version-**free** addition: the request params are optional, an unrecognized side just ignores them, and the
+guarantee degrades to the v1 at-most-once behavior on any mismatch. Both sides could therefore ship
+independently. Bumping to `2` would instead force a hard cutover — a client hard-gates on an exact version
+match and goes dark on a mismatch — which is unwarranted for a change this additive.

--- a/source/remotecontrol/remoteCommand.bs
+++ b/source/remotecontrol/remoteCommand.bs
@@ -17,9 +17,14 @@ namespace remoteCommand
   '   keepalive -> intervalSeconds
   '   ignore    -> KeepAlive / Sessions / volume / directional / unknown — parsed but not enacted
   function parseMessage(envelope as object) as object
-    result = { kind: "ignore", raw: invalid }
+    result = { kind: "ignore", raw: invalid, messageId: "" }
     if not isValid(envelope) or not isValidAndNotEmpty(envelope.MessageType) then return result
     result.raw = envelope.Data
+    ' The server-assigned id, present on the long-poll transport ({ MessageType, Data, MessageId }) and
+    ' the ack key for at-least-once delivery. Captured for EVERY kind — even "ignore"/"keepalive" — so the
+    ' long-poll receiver can ack past them (letting the plugin drop them) and dedupe a redelivered command.
+    ' The ws:// transport omits it; it stays "" there and is simply unused. See remote-control-longpoll-contract.md.
+    if isValidAndNotEmpty(envelope.MessageId) then result.messageId = envelope.MessageId
 
     messageType = envelope.MessageType
     if messageType = "Play" then return parsePlay(envelope.Data, result)

--- a/source/remotecontrol/remoteProtocol.bs
+++ b/source/remotecontrol/remoteProtocol.bs
@@ -38,11 +38,19 @@ namespace remoteProtocol
   ' Build the plugin's long-poll command-channel URL for a server base URL. Returns "" for a blank
   ' server URL. waitMs is JellyRock's requested hold ceiling; the client-side transfer timeout is set
   ' longer so a 204 (empty hold) always arrives before the transfer itself times out.
-  '   https://host  ->  https://host/JellyRock/RemoteControl/poll?waitMs=<n>
-  function buildLongPollUrl(serverUrl as dynamic, waitMs as integer) as string
+  '
+  ' ack=1 is the at-least-once opt-in flag (contract v1, additive): it tells the plugin this client will
+  ' acknowledge receipt, so the plugin retains delivered commands and redelivers any we didn't confirm.
+  ' It is present on EVERY poll (including the first) — a plugin that doesn't understand it just ignores
+  ' it and stays at-most-once. ackId is our cumulative ack: the last MessageId we durably received (""
+  ' until we've received one, and omitted then). GUIDs are URL-safe, so no encoding is needed.
+  '   https://host  ->  https://host/JellyRock/RemoteControl/poll?waitMs=<n>&ack=1[&ackId=<guid>]
+  function buildLongPollUrl(serverUrl as dynamic, waitMs as integer, ackId = "" as dynamic) as string
     base = pluginBaseUrl(serverUrl)
     if base = "" then return ""
-    return base + "/poll?waitMs=" + waitMs.ToStr()
+    url = base + "/poll?waitMs=" + waitMs.ToStr() + "&ack=1"
+    if isValidAndNotEmpty(ackId) then url = url + "&ackId=" + ackId
+    return url
   end function
 
   ' Build the plugin presence/version probe URL (200 = plugin present, 404 = absent). Returns "" for a

--- a/tests/source/unit/remotecontrol/remoteCommand.spec.bs
+++ b/tests/source/unit/remotecontrol/remoteCommand.spec.bs
@@ -182,6 +182,29 @@ namespace tests
     end function
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("parseMessage() — MessageId (the at-least-once ack key)")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("captures the long-poll MessageId on the normalized command, of any kind")
+    function _()
+      ' A dispatchable command carries it...
+      play = remoteCommand.parseMessage({ MessageType: "Play", Data: { ItemIds: ["x"] }, MessageId: "id-play" })
+      m.assertEqual(play.messageId, "id-play")
+
+      ' ...and so does an ignored one, so the receiver can still ack (let the plugin drop) past it.
+      ignored = remoteCommand.parseMessage({ MessageType: "Sessions", Data: {}, MessageId: "id-ignore" })
+      m.assertEqual(ignored.kind, "ignore")
+      m.assertEqual(ignored.messageId, "id-ignore")
+    end function
+
+    @it("defaults messageId to empty when absent (the ws:// path omits it) — never invalid")
+    function _()
+      cmd = remoteCommand.parseMessage({ MessageType: "Playstate", Data: { Command: "Pause" } })
+      m.assertEqual(cmd.messageId, "")
+      m.assertEqual(remoteCommand.parseMessage(invalid).messageId, "")
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     @describe("ticksToSeconds()")
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/tests/source/unit/remotecontrol/remoteProtocol.spec.bs
+++ b/tests/source/unit/remotecontrol/remoteProtocol.spec.bs
@@ -48,16 +48,30 @@ namespace tests
     @describe("buildLongPollUrl() — HTTPS long-poll channel (no token in URL)")
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-    @it("builds the poll URL with the requested waitMs and carries no token")
+    @it("builds the poll URL with waitMs + the ack=1 opt-in flag, and carries no token")
     function _()
       url = remoteProtocol.buildLongPollUrl("https://jellyfin.example.com", 25000)
-      m.assertEqual(url, "https://jellyfin.example.com/JellyRock/RemoteControl/poll?waitMs=25000")
+      m.assertEqual(url, "https://jellyfin.example.com/JellyRock/RemoteControl/poll?waitMs=25000&ack=1")
     end function
 
     @it("trims a single trailing slash so it never emits //")
     function _()
       url = remoteProtocol.buildLongPollUrl("https://jellyfin.example.com/", 25000)
-      m.assertEqual(url, "https://jellyfin.example.com/JellyRock/RemoteControl/poll?waitMs=25000")
+      m.assertEqual(url, "https://jellyfin.example.com/JellyRock/RemoteControl/poll?waitMs=25000&ack=1")
+    end function
+
+    @it("appends the cumulative ackId when we have one to acknowledge")
+    function _()
+      url = remoteProtocol.buildLongPollUrl("https://jellyfin.example.com", 25000, "abc-123-guid")
+      m.assertEqual(url, "https://jellyfin.example.com/JellyRock/RemoteControl/poll?waitMs=25000&ack=1&ackId=abc-123-guid")
+    end function
+
+    @it("omits ackId when it is blank/invalid (e.g. the first poll, nothing received yet)")
+    @params("")
+    @params(invalid)
+    function _(ackId)
+      url = remoteProtocol.buildLongPollUrl("https://jellyfin.example.com", 25000, ackId)
+      m.assertEqual(url, "https://jellyfin.example.com/JellyRock/RemoteControl/poll?waitMs=25000&ack=1")
     end function
 
     @it("returns empty for a missing/blank server URL")


### PR DESCRIPTION
Server side: jellyrock/jellyfin-plugin-jellyrock#2

## What
On the HTTPS long-poll transport, acknowledge received commands so the companion Jellyfin plugin can stop dropping a batch whose poll response was lost (the plugin drains before it can confirm delivery).

- `remoteProtocol.buildLongPollUrl` adds the `ack=1` opt-in flag (sent on every poll) and an optional cumulative `ackId` (the last MessageId received).
- `remoteCommand.parseMessage` captures `MessageId` on the normalized command for every kind, defaulting to "" on the ws:// path that omits it.
- `RemoteControlTask` tracks the cumulative `ackId` and dedupes by `MessageId` (a small bounded ring) so a redelivered relative verb (NextTrack, Rewind, FastForward) cannot double-apply.
- Contract doc documents `ack=1` / `ackId`, retain/redeliver/prune, and the client dedupe requirement; stays contractVersion 1 (additive).

## Compatibility
Additive on contract v1. Degrades to at-most-once against an old plugin, and an old client keeps at-most-once against a new plugin. No version bump. Targets the 2.24.0 release.

## Testing
- 2509/2509 rooibos unit tests on a real Roku, including new specs for the ack URL, MessageId capture, and cumulative ackId.
- Verified on real hardware end to end: this build polling the companion plugin over HTTPS received and dispatched DisplayMessage and GoToSearch.

Pairs with the plugin server change (retain buffer plus cumulative ack).
