### PR TITLE
fix(osd): Offer manual segment-skip button on replay after one-time auto-skip

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1098,13 +1098,12 @@ sub checkMediaSegments()
     if segmentId = "" then return
 
     segmentType = segment.Type ?? ""
-    action = resolveSegmentAction(segmentType, userSession.settings, userSession.config)
+    ' Already-skipped Skip segments degrade to AskToSkip so replay still offers the
+    ' manual button without re-triggering the one-shot auto-skip (see resolveEffectiveSegmentAction).
+    action = resolveEffectiveSegmentAction(segmentType, userSession.settings, userSession.config, m.skippedSegments.DoesExist(segmentId))
     m.log.verbose("Active segment found", segmentType, segmentId, "action:", action)
 
     if action = MediaSegmentAction.SKIP
-      ' Auto-skip only fires once per segment
-      if m.skippedSegments.DoesExist(segmentId) then return
-
       ' Auto-skip: seek to end of segment immediately
       seekPosition = segmentTicksToSeconds(segment.EndTicks)
 
@@ -1123,6 +1122,11 @@ sub checkMediaSegments()
       m.top.seek = seekPosition
       m.skippedSegments[segmentId] = true
       m.activeSegmentId = ""
+      ' Treat the skip as a dismissal: suppress the manual button until the user
+      ' leaves this segment and returns. Without this, the post-seek buffering window
+      ' (position still lagging inside the segment) would flash the manual button now
+      ' that an already-skipped Skip segment degrades to AskToSkip.
+      m.dismissedSegmentId = segmentId
     else if action = MediaSegmentAction.ASK_TO_SKIP
       ' Dismissed this visit — don't re-show until user leaves and re-enters the segment
       if segmentId = m.dismissedSegmentId then return
@@ -1197,6 +1201,10 @@ sub onSegmentNotificationAction()
 
       m.top.seek = seekPosition
       m.skippedSegments[m.activeSegmentId] = true
+      ' Treat the skip as a dismissal so the button doesn't re-flash during the
+      ' post-seek buffering (position still lags inside the segment); the button
+      ' returns only if the user leaves this segment and re-enters it.
+      m.dismissedSegmentId = m.activeSegmentId
     else
       m.log.warn("Active segment not found for skip", m.activeSegmentId)
     end if

--- a/source/utils/mediaSegments.bs
+++ b/source/utils/mediaSegments.bs
@@ -49,6 +49,25 @@ function resolveSegmentAction(segmentType as string, userSettings as object, use
   return defaultValue
 end function
 
+' resolveEffectiveSegmentAction: Resolves the action for a segment, accounting for
+' whether it has already been auto-skipped this playback session.
+'
+' A Skip-configured segment auto-seeks only on its first pass. Once skipped, rewinding
+' back into it must NOT re-skip (that would trap the user in a rewind loop) — but the
+' user should still get the *manual* Skip button. So an already-skipped Skip segment
+' degrades to AskToSkip; all other actions pass through unchanged.
+'
+' @param {string} segmentType - MediaSegmentType value ("Intro", "Outro", etc.)
+' @param {object} userSettings - JellyfinUserSettings node (JellyRock settings)
+' @param {object} userConfig - JellyfinUserConfiguration node (web client settings)
+' @param {boolean} alreadySkipped - true if this segment already auto-skipped this session
+' @returns {string} - MediaSegmentAction value ("None", "AskToSkip", "Skip")
+function resolveEffectiveSegmentAction(segmentType as string, userSettings as object, userConfig as object, alreadySkipped as boolean) as string
+  action = resolveSegmentAction(segmentType, userSettings, userConfig)
+  if action = MediaSegmentAction.SKIP and alreadySkipped then return MediaSegmentAction.ASK_TO_SKIP
+  return action
+end function
+
 ' findActiveSegment: Finds the media segment containing the current playback position.
 '
 ' Linear scan over the segments array (typically 2-5 items).

--- a/tests/source/unit/utils/mediaSegments-resolveEffectiveSegmentAction.spec.bs
+++ b/tests/source/unit/utils/mediaSegments-resolveEffectiveSegmentAction.spec.bs
@@ -1,0 +1,102 @@
+import "pkg:/source/enums/MediaSegmentAction.bs"
+import "pkg:/source/enums/MediaSegmentType.bs"
+import "pkg:/source/utils/mediaSegments.bs"
+
+namespace tests
+
+  @suite("mediaSegments.bs - resolveEffectiveSegmentAction()")
+  class ResolveEffectiveSegmentActionTests extends tests.BaseTestSuite
+
+    ' Helper to create mock user settings
+    private function createMockSettings(overrides = {} as object) as object
+      return overrides
+    end function
+
+    ' Helper to create mock user config
+    private function createMockConfig(overrides = {} as object) as object
+      return overrides
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("first pass — not yet skipped — passes the resolved action through")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("returns Skip for a Skip-configured segment on its first pass")
+    function _()
+      settings = m.createMockSettings({ playbackSegmentActionIntro: "skip" })
+      result = resolveEffectiveSegmentAction(MediaSegmentType.INTRO, settings, m.createMockConfig(), false)
+      m.assertEqual(result, MediaSegmentAction.SKIP)
+    end function
+
+    @it("returns AskToSkip for an AskToSkip-configured segment on its first pass")
+    function _()
+      settings = m.createMockSettings({ playbackSegmentActionIntro: "askToSkip" })
+      result = resolveEffectiveSegmentAction(MediaSegmentType.INTRO, settings, m.createMockConfig(), false)
+      m.assertEqual(result, MediaSegmentAction.ASK_TO_SKIP)
+    end function
+
+    @it("returns None for a None-configured segment on its first pass")
+    function _()
+      settings = m.createMockSettings({ playbackSegmentActionIntro: "none" })
+      result = resolveEffectiveSegmentAction(MediaSegmentType.INTRO, settings, m.createMockConfig(), false)
+      m.assertEqual(result, MediaSegmentAction.NONE)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("replay — already skipped — a Skip segment degrades to AskToSkip")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("degrades a Skip-configured segment to AskToSkip once already skipped (issue #737)")
+    function _()
+      settings = m.createMockSettings({ playbackSegmentActionIntro: "skip" })
+      result = resolveEffectiveSegmentAction(MediaSegmentType.INTRO, settings, m.createMockConfig(), true)
+      m.assertEqual(result, MediaSegmentAction.ASK_TO_SKIP)
+    end function
+
+    @it("degrades a web-client-resolved Skip to AskToSkip once already skipped")
+    function _()
+      settings = m.createMockSettings({ playbackSegmentActionOutro: "webclient" })
+      config = m.createMockConfig({ segmentActionOutro: MediaSegmentAction.SKIP })
+      result = resolveEffectiveSegmentAction(MediaSegmentType.OUTRO, settings, config, true)
+      m.assertEqual(result, MediaSegmentAction.ASK_TO_SKIP)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("alreadySkipped only affects Skip — other actions pass through unchanged")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("leaves an AskToSkip-configured segment unchanged even when already skipped")
+    function _()
+      settings = m.createMockSettings({ playbackSegmentActionIntro: "askToSkip" })
+      result = resolveEffectiveSegmentAction(MediaSegmentType.INTRO, settings, m.createMockConfig(), true)
+      m.assertEqual(result, MediaSegmentAction.ASK_TO_SKIP)
+    end function
+
+    @it("leaves a None-configured segment unchanged even when already skipped")
+    function _()
+      settings = m.createMockSettings({ playbackSegmentActionIntro: "none" })
+      result = resolveEffectiveSegmentAction(MediaSegmentType.INTRO, settings, m.createMockConfig(), true)
+      m.assertEqual(result, MediaSegmentAction.NONE)
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("all 6 segment types degrade Skip -> AskToSkip on replay")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    @it("degrades Skip to AskToSkip on replay for each segment type")
+    @params("Intro", "playbackSegmentActionIntro")
+    @params("Outro", "playbackSegmentActionOutro")
+    @params("Commercial", "playbackSegmentActionCommercial")
+    @params("Preview", "playbackSegmentActionPreview")
+    @params("Recap", "playbackSegmentActionRecap")
+    @params("Unknown", "playbackSegmentActionUnknown")
+    function _(segmentType, settingKey)
+      settings = {}
+      settings[settingKey] = "skip"
+      result = resolveEffectiveSegmentAction(segmentType, settings, m.createMockConfig(), true)
+      m.assertEqual(result, MediaSegmentAction.ASK_TO_SKIP)
+    end function
+
+  end class
+
+end namespace


### PR DESCRIPTION
# Overview

A media segment configured to auto-skip (e.g. an Intro) correctly fires its auto-skip only once per playback session. But the old `checkMediaSegments()` SKIP branch returned early on every later pass, before any UI — so on replay (rewind back into the segment) the user got neither an auto-skip (correct) nor the manual "Skip <segment>" button (the bug). This PR makes later passes offer the manual button while keeping the one-shot auto-skip and its rewind-trap protection.

## Changes
- Split the two decisions the SKIP branch conflated — "auto-seek?" (once per session) vs "show a skip affordance?" (every pass). An already-skipped Skip segment now degrades to `AskToSkip`, so the first pass auto-skips and later passes show the manual button. No rewind-trap (the degraded path never re-seeks).
- Added a pure helper `resolveEffectiveSegmentAction()` in `source/utils/mediaSegments.bs` that carries this decision, mirroring the existing `resolveSegmentAction()` seam so the regressed behavior gets a red/green unit gate.
- Marked a skip (auto **and** manual) as a dismissal via `m.dismissedSegmentId`, so the manual button doesn't flash during the post-seek buffering window (position still lags inside the segment). The existing "left segment" branch clears it once the seek lands, re-arming the button only for a genuine replay.
- Added unit coverage for `resolveEffectiveSegmentAction` (first-pass pass-through, already-skipped degrade, non-Skip actions unchanged, all 6 segment types).

## Follow-ups
None

## Issues
Fixes #737

## Docs / context updates

- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=6d36bc20b6eca5b5ac9e86e66f72a98bb7ab0ef4 ts=2026-07-23T18:13:22Z -->