### PR TITLE
fix: Remove invalid `focusable` attribute from `<component>` elements

### DIFF
--- a/components/OverviewDialog.xml
+++ b/components/OverviewDialog.xml
@@ -2,7 +2,7 @@
 <!-- OverviewDialog: Custom full-screen overlay for reading long overview text.
      Appended directly to the scene by FocusableOverview; dismisses itself via removeChild +
      returnFocusTo. Supports vertical scrolling. -->
-<component name="OverviewDialog" extends="JRGroup" focusable="true">
+<component name="OverviewDialog" extends="JRGroup">
   <children>
     <!-- Dimmed background overlay -->
     <Rectangle id="dimBackground" width="1920" height="1080" color="0x000000" opacity="0.75" />

--- a/components/ui/button/IconButton.xml
+++ b/components/ui/button/IconButton.xml
@@ -5,7 +5,7 @@
   Example: If aligning to x=90, the button will actually appear at x=96 (90 + 6px offset).
   For RIGHT-aligned components: add 6px to account for text extension.
 -->
-<component name="IconButton" extends="Group" focusable="true">
+<component name="IconButton" extends="Group">
   <children>
     <Poster id="buttonBackground" uri="pkg:/images/9patch/filled-rounded.9.png" />
     <Poster id="buttonBorder" uri="pkg:/images/9patch/border-6px.9.png" />

--- a/components/ui/button/JROverhangIcon.xml
+++ b/components/ui/button/JROverhangIcon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="JROverhangIcon" extends="Group" focusable="true">
+<component name="JROverhangIcon" extends="Group">
   <children>
     <Poster id="buttonBackground" uri="pkg:/images/9patch/filled-rounded.9.png" visible="false" />
     <Poster id="buttonBorder" uri="pkg:/images/9patch/border-6px.9.png" visible="false" />

--- a/components/ui/button/TextButton.xml
+++ b/components/ui/button/TextButton.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="TextButton" extends="Group" focusable="true">
+<component name="TextButton" extends="Group">
   <children>
     <Poster id="buttonBackground" uri="pkg:/images/9patch/filled-rounded.9.png" visible="false" />
     <Poster id="buttonBorder" uri="pkg:/images/9patch/border-6px.9.png" visible="false" />

--- a/components/ui/dropdown/JRDropdown.xml
+++ b/components/ui/dropdown/JRDropdown.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="JRDropdown" extends="Group" focusable="true">
+<component name="JRDropdown" extends="Group">
   <children>
     <!-- Trigger button area -->
     <Poster id="buttonBackground" uri="pkg:/images/9patch/filled-rounded.9.png" visible="false" />

--- a/components/ui/dropdown/TrackDropdown.xml
+++ b/components/ui/dropdown/TrackDropdown.xml
@@ -19,7 +19,7 @@
     - LEFT/RIGHT          -> close menu, fires requestFocusExit
     - BACK                -> close menu
 -->
-<component name="TrackDropdown" extends="Group" focusable="true">
+<component name="TrackDropdown" extends="Group">
   <children>
     <!-- Trigger background: always visible (unfocused filled with colorBackgroundSecondary
          so the dropdown affords interactivity). Border toggles on focus. -->

--- a/components/ui/label/FocusableOverview.xml
+++ b/components/ui/label/FocusableOverview.xml
@@ -3,7 +3,7 @@
      Shows overview/description text with ellipsis. Supports an optional tagline
      displayed above the description. When focused, displays a themed border.
      Pressing OK opens an OverviewDialog to read the full text. -->
-<component name="FocusableOverview" extends="Group" focusable="true">
+<component name="FocusableOverview" extends="Group">
   <children>
     <RectangleBackgroundSecondary id="background" />
     <Poster id="focusBorder" uri="pkg:/images/9patch/border-6px.9.png" visible="false" />


### PR DESCRIPTION
# Overview

Seven components declared `focusable="true"` on the `<component>` element itself. That attribute is not valid there — Roku's schema ([`RokuSceneGraph.xsd`](https://devtools.web.roku.com/schema/RokuSceneGraph.xsd)) permits only `name`, `extends`, `initialFocus` and `version`, with no wildcard. `focusable` is a field on the Node class, not a component-element attribute.

Roku OS 15 silently ignores the unknown attribute, so it was invisible in local testing. Older Roku OS treats it as a hard parse error and refuses to install the app entirely, which is the install failure reported in #689 on an OS 12.5 device:

```
Found 1 parse error in XML file TextButton.xml
--- Line 2: Unknown attribute "focusable" specified for <component> element
```

The seven parse errors in that report map exactly to the seven files carrying the attribute. `ResumeButton` and `JRTab` then fail with "Extends type does not exist" as knock-on damage from `IconButton` and `TextButton` failing to parse. The first of these attributes landed in August 2025, before `v1.0.0`, which is why every release the reporter tried failed identically.

## Changes

- Remove the invalid `focusable` attribute from the `<component>` root element of `TextButton`, `IconButton`, `JROverhangIcon`, `JRDropdown`, `TrackDropdown`, `OverviewDialog` and `FocusableOverview`
- No BrightScript changes — the attribute was never honoured, so there is nothing to port to `init()`

## Follow-ups

None

## Issues

Fixes #689

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

## Verification

Removing the attribute is behaviour-neutral, verified rather than assumed:

- Querying the live node graph on an OS 15.2.4 device (`/query/sgnodes/all`) shows these components report `focusable = false` at runtime *despite* the XML declaring `true`. The attribute was already being discarded, so it has never had any effect on any OS version.
- Focus on these components is driven entirely by explicit `setFocus()` calls; nothing in the codebase reads `.focusable`.
- `npm run validate` and `npm run build` clean; transpiled output confirmed free of `<component ... focusable>`, with the *valid* child-node `focusable` on `OverviewDialog`'s `<Group id="textClip">` correctly preserved.
- `npm run test:scripts`: 909 passed / 53 files.
- `npm run test:rta` on device: 36/36 passed. Baseline without this change failed 2/36 on unrelated flakes, so the suite is noisy but this change does not regress it.

Not verified: whether the app installs *and runs* on OS 12.5 once this parse error is gone. Roku reports parse errors in batches and there may be more behind these. No OS 12.5 hardware is available to confirm.

<!-- /pr render: sha=2727e70dd68df6774f989b7d221896c9a2124627 ts=2026-08-03T17:52:17Z -->