### PR TITLE
Stop `progress-cursor-nudge` reading Recently-shipped as the cursor

### DIFF
--- a/scripts/lint/progress-cursor-nudge.cjs
+++ b/scripts/lint/progress-cursor-nudge.cjs
@@ -162,7 +162,15 @@ function readProgress() {
   const lastUpdatedMatch = fmMatch && fmMatch[1].match(/^last-updated:\s*(\d{4}-\d{2}-\d{2})/m);
   const lastUpdated = lastUpdatedMatch ? lastUpdatedMatch[1] : null;
 
-  const runningMatch = content.match(/##\s+Currently running\s*\n([\s\S]*?)(?=\n##\s|$)/);
+  // `[^\S\n]*\n` — trailing spaces then EXACTLY ONE newline, deliberately not
+  // `\s*\n`. `\s` matches newlines, so on an EMPTY cursor (`## Currently running`
+  // immediately followed by a blank line and the next `##`) the greedy form ate
+  // the blank line, leaving the lookahead with no `\n` to anchor on. The lazy
+  // group then ran past `## Recently shipped` to the section after it, and the
+  // whole recently-shipped list was returned as "the cursor" — so
+  // checkCursorShipped compared recent commits against recently-shipped bullets
+  // and reported a token overlap on an empty cursor, every time.
+  const runningMatch = content.match(/##\s+Currently running[^\S\n]*\n([\s\S]*?)(?=\n##\s|$)/);
   const cursor = runningMatch ? runningMatch[1].trim().replace(/\s+/g, ' ') : '';
 
   return { lastUpdated, cursor };

--- a/tests/scripts/unit/lint/progress-cursor-nudge.test.js
+++ b/tests/scripts/unit/lint/progress-cursor-nudge.test.js
@@ -115,3 +115,74 @@ describe('progress-cursor-nudge --json — temporal staleness', () => {
     expect(runJson(fixture).json.stale).toBeNull();
   });
 });
+
+describe('progress-cursor-nudge --json — cursor extraction', () => {
+  let fixture;
+  const todayIso = () => new Date().toISOString().slice(0, 10);
+
+  afterEach(() => {
+    fixture?.cleanup();
+    fixture = undefined;
+  });
+
+  // The cursor-shipped heuristic compares the `## Currently running` paragraph
+  // against recent commit subjects. Extracting that paragraph is the load-bearing
+  // step: get it wrong and the heuristic fires on text that isn't the cursor.
+  // TWO recently-shipped bullets, each mirroring a commit made below. That is what
+  // makes the empty-cursor case actually reproduce the bug: checkCursorShipped only
+  // fires at `matchingSubjects.length >= 2`, so a fixture with one overlapping
+  // bullet returns null either way and the test passes for the wrong reason.
+  const withSections = (lastUpdated, cursorBody) =>
+    `---\nlast-updated: ${lastUpdated}\n---\n# Progress\n\n` +
+    `## Currently running\n${cursorBody}\n` +
+    `## Recently shipped\n\n` +
+    `- 2026-08-06 — pipeline the genre sample fetches\n` +
+    `- 2026-08-05 — assert each genre row holds its own items\n\n` +
+    `## Open followups\n\n- nothing\n`;
+
+  /** Two commits whose subjects overlap the recently-shipped bullets above. */
+  const commitTwoShippedLookalikes = (fix) => {
+    fix.commit('perf(grid): pipeline the genre sample fetches instead of back to back');
+    fix.commit('test(rta): assert each genre row holds its own items');
+  };
+
+  it('reports no cursor-shipped overlap when the cursor is EMPTY', () => {
+    // Regression: `\s*\n` after the heading greedily ate the blank line of an
+    // empty cursor, so the lookahead had no `\n##` to anchor on and the capture
+    // ran on through `## Recently shipped`. The recently-shipped bullets were then
+    // treated as the cursor and matched against recent commits — a permanent false
+    // positive on every repo whose cursor is empty (i.e. right after a merge).
+    // Mutation-checked: reverting the regex turns this red.
+    fixture = withDocsDir(createGitFixture());
+    fixture.commit('chore: seed', { 'docs/progress.md': withSections(todayIso(), '') });
+    commitTwoShippedLookalikes(fixture);
+    const { exitCode, json } = runJson(fixture);
+    expect(exitCode).toBe(0);
+    expect(json.cursorShipped).toBeNull();
+  });
+
+  it('still reports an overlap when a NON-empty cursor matches recent commits', () => {
+    // The other half of the fix: narrowing the newline match must not stop the
+    // heuristic working on a real cursor. Two matching subjects are required —
+    // checkCursorShipped only fires at `matchingSubjects.length >= 2`.
+    fixture = withDocsDir(createGitFixture());
+    fixture.commit('chore: seed', {
+      'docs/progress.md': withSections(todayIso(), '\npipeline the genre sample fetches\n'),
+    });
+    fixture.commit('perf(grid): pipeline the genre sample fetches instead of back to back');
+    fixture.commit('test(rta): assert each genre row holds its own genre sample');
+    const { json } = runJson(fixture);
+    expect(json.cursorShipped).not.toBeNull();
+    expect(json.cursorShipped.cursor).toBe('pipeline the genre sample fetches');
+  });
+
+  it('does not swallow the following section into a non-empty cursor', () => {
+    fixture = withDocsDir(createGitFixture());
+    fixture.commit('chore: seed', {
+      'docs/progress.md': withSections(todayIso(), '\nworking on the thing\n'),
+    });
+    fixture.commit('feat: unrelated subject with no shared words');
+    const { json } = runJson(fixture);
+    expect(json.cursorShipped).toBeNull();
+  });
+});


### PR DESCRIPTION
# Overview

`progress-cursor-nudge.cjs` reported a "Currently running cursor overlaps with N recent commit subject(s)" nudge against a `## Currently running` section that was verifiably **empty**. Observed on a real pre-push run: three matching subjects reported, blank cursor.

The cause is the cursor-extraction regex. `readProgress` used `##\s+Currently running\s*\n(...)`, and `\s` matches newlines — so on an empty cursor the greedy `\s*` consumed the blank line separating the heading from the next section, leaving the `(?=\n##\s|$)` lookahead with no `\n` to anchor on. The lazy group then ran straight past `## Recently shipped` and returned that entire section as "the cursor". `checkCursorShipped` compared recent commit subjects against the recently-shipped bullets — which describe the same work, so they share tokens by construction — and fired.

This was not confined to the local hook: the same value feeds the weekly [`docs-stale-tracker.yml`](../../.github/workflows/docs-stale-tracker.yml) through `--json`, so the tracker issue was getting the same false signal.

## Changes

- **Match exactly one newline after the heading** (`[^\S\n]*\n` instead of `\s*\n`), so an empty cursor leaves the lookahead able to anchor on the following `\n##` and the capture stays empty. A non-empty cursor is unaffected — the blank line before its text is inside the lazy group either way.
- **Three cursor-extraction tests**, covering the empty cursor, a non-empty cursor that legitimately overlaps recent commits, and a non-empty cursor that does not.

## Follow-ups

None

## Issues

None

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

Two architecture docs claim `scripts/lint/progress-cursor-nudge.cjs` in their `related-files:` — `build-and-tooling.md` and `system-shape.md`. **Neither changed shape or why:** both describe the nudge as an advisory, always-exit-0 signal that also feeds the weekly tracker via `--json`, and all of that is still true. The fix makes the script behave the way those docs already describe. `last-reviewed` not bumped on either.

`tech-debt.md`'s `tokenize()`-duplication entry lists this file in its area, but this PR doesn't touch `tokenize()` — that entry still applies unchanged.

## Verification

- `npm run test:scripts` — **941/941** (938 before; +3 here)
- **The empty-cursor test is mutation-checked**: with the regex reverted it fails, with the fix it passes. Worth recording *why* that check mattered — the first draft of the test passed with the bug still in place. `checkCursorShipped` only fires at `matchingSubjects.length >= 2`, and the fixture had a single overlapping recently-shipped bullet, so it returned `null` either way and tested nothing. The committed fixture has two bullets and two matching commits; the trap is documented inline so it isn't re-laid.
- **Dogfooded on this repo**: with `## Currently running` empty, `node scripts/lint/progress-cursor-nudge.cjs` is now silent and `--json` reports `cursorShipped: null`. The pre-push run that pushed this branch printed no nudge, where the previous push did.
- `eslint`, `prettier` via lint-staged; full pre-push hook

<!-- /pr render: sha=af7ba91be7a8ac3ab1c9c3f08ad72d84c2e57075 ts=2026-08-06T15:08:39Z -->
