### PR TITLE
test(rta): restore the device session when a capture run is interrupted

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -148,6 +148,7 @@ crossfade
 crowdsourced
 CSV
 CSVs
+Ctrl-C
 cutover
 Daniele
 datagram
@@ -277,6 +278,7 @@ injectable
 in-repo
 instantiation
 interpolators
+interruptible
 invariants
 IPs
 JavaScript
@@ -490,6 +492,7 @@ sideload
 Sideload
 sideloaded
 sideloads
+SIGINT
 signals-schema-invalid
 slow-decay
 socio-economic
@@ -591,6 +594,7 @@ viewport
 virtuals
 Vitest
 .vscode
+Vitest's
 vscode
 VSCode
 VTT

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -247,6 +247,18 @@ Ruled out: **a blocking modal** (the prior behavior), which was not merely worse
 
 It was implemented, measured and reverted. Across six independent comparisons on three device tiers (n=30 on a 512 MB Stick over four separate build/deploy passes, n=10 each on a Stick 4K and an Ultra, same server, 11 libraries) it was slower every time and never faster — roughly 1-3%, sign test p=0.031. Per-device Mann-Whitney was not significant, so this is evidence of NO BENEFIT rather than proof of harm, and the original justification (a 2673 to 2586 ms median at n=4) did not reproduce. Two things worth knowing before re-opening it: the per-column split is noise-dominated at these sample sizes — at n=10 `wait` appeared to confirm the mechanism and at n=30 it reversed — and the method resolves only ~120 ms and up, so a genuine sub-1% win would be invisible either way. Re-propose it only with a measurement that clears that floor.
 
+## decision-id: rta-interrupt-restore-scripts-only
+
+**date**: 2026-08-07
+**status**: accepted
+**related-files**: `tests/rta/lib/seed.js`, `scripts/capture-screenshots.js`, `tests/rta/demos/run.mjs`
+
+`armSessionRestoreOnInterrupt` is armed only from MAIN-PROCESS scripts — `scripts/capture-screenshots.js` and `tests/rta/demos/run.mjs` — and deliberately NOT from the Vitest specs, even though all five call `snapshotSession` and all five are interruptible. Without this note the omission looks like one someone should "finish".
+
+Measured 2026-08-07 rather than assumed. Vitest 4 runs specs in forked child processes (`isMainThread=true`, `ppid != pid`) that share the parent's process group, so a terminal Ctrl-C genuinely reaches them — the handler is not unreachable. It is simply too slow: Vitest tears the child down before a ~30s restore (cold restart plus verify) can complete. A deliberately interrupted run — SIGINT to the whole process group, matching Ctrl-C — produced no restore output and left the device signed into `demo.jellyfin.org`. Arming there would read as protection that does not exist, which is the failure mode this repo has already paid for twice (a code comment guarding the seed path in the `relaunch`/`hardRelaunch` split, and the same shape again in `findHomeLibraryTile`).
+
+The fix that WOULD work is moving the session lifecycle out of the three per-spec `snapshotSession`/`restoreSession` pairs into `globalSetup`, which runs in Vitest's main process. Declined for now, and this is a closed decision rather than an open followup: the exposure is a Ctrl-C during an otherwise unattended 13-minute suite, and recovery is a two-minute registry rewrite that the handler's snapshot-print makes mechanical. **Tripwire:** re-open if a device is actually stranded by an interrupted spec run, or if the suite becomes something people routinely sit and watch.
+
 ## Migrated to ADRs
 
 These decisions were promoted to numbered ADRs on the operating-model

--- a/scripts/capture-screenshots.js
+++ b/scripts/capture-screenshots.js
@@ -64,6 +64,7 @@ import {
   snapshotSession,
   restoreSession,
   assertSeedTookEffect,
+  armSessionRestoreOnInterrupt,
 } from '../tests/rta/lib/seed.js';
 import { SCREENS } from '../tests/rta/screens.js';
 import { generateIndex } from './screenshots-index.js';
@@ -264,6 +265,9 @@ async function main() {
   // Good citizen: snapshot the device's current session so we can restore it after
   // (capturing logs the device into the demo server; we put it back the way we found it).
   const savedSession = await snapshotSession();
+  // A ~15-minute matrix run is the most likely thing anyone Ctrl-Cs, and the
+  // `finally` below is not reached when the process is killed.
+  armSessionRestoreOnInterrupt(savedSession);
 
   console.log(`Authenticating ${CONFIG.server.username}@${CONFIG.server.url} ...`);
   const session = await authenticate(CONFIG.server);

--- a/tests/rta/demos/run.mjs
+++ b/tests/rta/demos/run.mjs
@@ -22,6 +22,7 @@ import {
   seedHomeWithSavedServers,
   snapshotSession,
   restoreSession,
+  armSessionRestoreOnInterrupt,
 } from '../lib/seed.js';
 import { setupRtaEnv, relaunch, hardRelaunch, ecp, odc } from '../lib/driver.js';
 import {
@@ -214,6 +215,7 @@ async function main() {
   // call — snapshotSession is an ODC call and would fail on a suspended/relaunched device.
   await relaunch();
   const saved = await snapshotSession(); // restore the real session afterward, no matter what
+  armSessionRestoreOnInterrupt(saved); // ...including when the operator Ctrl-Cs a recording
   let cleanlyRestored = false;
   try {
     const sessions = {};

--- a/tests/rta/lib/seed.js
+++ b/tests/rta/lib/seed.js
@@ -263,7 +263,10 @@ export async function restoreSession(saved, { attempts = 3 } = {}) {
     // `null` in the snapshot means "the key was absent"; a deleted key reads back
     // as undefined, so normalise both sides before comparing.
     const wrong = keys.filter((k) => (observed[k] ?? null) !== (saved[k] ?? null));
-    if (wrong.length === 0) return;
+    if (wrong.length === 0) {
+      armed = null; // nothing left for the interrupt handler to do
+      return;
+    }
 
     if (attempt === attempts) {
       throw new Error(
@@ -275,4 +278,78 @@ export async function restoreSession(saved, { attempts = 3 } = {}) {
       );
     }
   }
+}
+
+// ── Interrupt-safe restore ──────────────────────────────────────────────────
+//
+// `restoreSession` normally runs from a `finally` / `afterAll`. Neither is
+// reached when the process is KILLED — a Ctrl-C during a ~15-minute capture or
+// suite run terminates before the handler, and the device is left signed into
+// the seeded (demo) server. That is not hypothetical: it is how this repo has
+// stranded devices three times, most recently an interrupted screenshot matrix
+// that left `.177` on demo.jellyfin.org with no snapshot left in memory to
+// restore from.
+//
+// Arming registers signal handlers that run the SAME verified restore before
+// exiting. Idempotent, and self-disarming once a normal restore succeeds.
+let armed = null;
+let restoring = false;
+let handlersInstalled = false;
+
+/**
+ * Restore `saved` if this process is interrupted. Call right after
+ * `snapshotSession()`; a successful `restoreSession()` disarms it automatically.
+ *
+ * A second interrupt abandons the restore and exits immediately — so a wedged
+ * device can never trap someone in an un-killable process. If the restore
+ * fails, the snapshot is printed so it can be reapplied by hand (reconstructing
+ * it from a console log is what the incident that prompted this actually cost).
+ *
+ * ⚠️ MAIN-PROCESS SCRIPTS ONLY — do NOT arm this from a Vitest spec. Measured
+ * 2026-08-07: Vitest runs specs in forked children that DO share the parent's
+ * process group (so a terminal Ctrl-C does reach them), but Vitest tears the
+ * child down before a ~30s restore can finish. A real interrupted run produced
+ * no restore output and left the device on demo.jellyfin.org. Arming there is
+ * not merely useless, it reads as protection that does not exist.
+ *
+ * Making the specs safe needs the session lifecycle moved out of the three
+ * per-spec snapshot/restore pairs and into `globalSetup`, which runs in
+ * Vitest's MAIN process. Deliberately NOT done: the exposure is a Ctrl-C during
+ * an otherwise unattended 13-minute suite, and recovery is a two-minute
+ * registry rewrite (the snapshot print above covers it). Revisit only if
+ * someone is actually stranded that way.
+ */
+export function armSessionRestoreOnInterrupt(saved) {
+  armed = saved;
+  if (handlersInstalled) return;
+  handlersInstalled = true;
+
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+    process.on(signal, () => {
+      if (!armed) process.exit(130);
+      if (restoring) {
+        console.log(`\n[restore] second ${signal} — abandoning restore, exiting now.`);
+        console.log(`[restore] restore by hand from: ${JSON.stringify(armed)}`);
+        process.exit(130);
+      }
+      restoring = true;
+      const saving = armed;
+      console.log(
+        `\n[restore] ${signal} received — restoring the device session before exit.` +
+          ' This takes ~30s (cold restart + verify). Ctrl-C again to abandon.',
+      );
+      restoreSession(saving, { attempts: 2 })
+        .then(() => console.log('[restore] VERIFIED CLEAN — device left as found.'))
+        .catch((e) => {
+          console.error(`[restore] FAILED: ${e.message}`);
+          console.error(`[restore] restore by hand from: ${JSON.stringify(saving)}`);
+        })
+        .finally(() => process.exit(130));
+    });
+  }
+}
+
+/** Drop the interrupt-restore arming (e.g. after restoring by another path). */
+export function disarmSessionRestoreOnInterrupt() {
+  armed = null;
 }


### PR DESCRIPTION
# Overview

`restoreSession` runs from a `finally`. That is never reached when the process is **killed** — so a Ctrl-C during a ~15-minute screenshot matrix leaves the device signed into the seeded demo server, and the in-memory snapshot dies with the process, leaving nothing to restore *from*.

That happened today. Recovering `.177` meant reconstructing the real server URL and user id out of a BrightScript console log that happened to still be open. It is also the third appearance of this hazard: `docs/progress.md` records it stranding two devices, and #774 fixed the *seed* half of the same problem.

## Changes

- **`armSessionRestoreOnInterrupt(saved)`** registers `SIGINT` / `SIGTERM` / `SIGHUP` handlers that run the **same verified `restoreSession`** before exiting. A successful normal restore disarms it, so it cannot double-fire.
- **On failure it prints the snapshot.** Arguably the highest-value line in the PR — a by-hand restore should never again require console-log archaeology.
- **A second interrupt abandons and exits**, so a wedged device can never produce an un-killable process.
- Armed from `scripts/capture-screenshots.js` and `tests/rta/demos/run.mjs`.
- **`docs/decisions.md`** records the Vitest-side fix as *declined with a tripwire* (see below).

### Armed only where it works — and that is measured, not assumed

An earlier revision of this branch armed the three Vitest specs too. **It was removed after testing proved it does nothing there.**

Vitest 4 runs specs in forked child processes that *do* share the parent's process group (`isMainThread=true`, `ppid != pid`), so a terminal Ctrl-C genuinely reaches them — the handler is not unreachable. It is simply too slow: Vitest tears the child down before a ~30 s restore (cold restart + verify) completes. A deliberately interrupted run — SIGINT to the whole **process group**, matching Ctrl-C rather than signalling only the parent — produced no restore output and left the device on `demo.jellyfin.org`.

Shipping it there would have read as protection that does not exist. That is the exact failure mode this repo has now paid for twice in two days: a code comment guarding the seed path in the `relaunch`/`hardRelaunch` split (#774), and the same shape again in `findHomeLibraryTile` (#775). Hence: armed only in the two main-process scripts, with the limitation documented at the point of use.

Those two are also the runs people actually interrupt — a matrix run you sit and watch, and an operator-driven recorder that pauses for ENTER. **The case that bit us today is the covered one.**

## Verification

- **Handler fires** on SIGINT → attempts restore → exits `130`.
- **Second-interrupt escape verified** by pointing the restore at an unroutable host (TEST-NET-1) so it stayed in flight long enough for a second signal to land: it abandons and prints the snapshot.
- **The negative result above, on a real device** — deliberately interrupted run, registry read afterwards confirming the device was left on demo. Device subsequently restored and cold-start verified.
- `eslint`, `prettier`, `lint:docs` (89 clean), `lint:markdown`, `lint:spelling`, `lint:dictionary`.

**No RTA suite re-run.** Stated explicitly rather than skipped quietly: the three specs are now **byte-identical to `main`**, and the one `restoreSession` change they touch (`armed = null` on success) was present in the clean **36/36 · 796 s** run earlier today. Both halves are already covered, and removing the spec arming only deletes code that ran fine.

## Follow-ups

None — deliberately. See the decision note.

## Issues

None

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [x] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [ ] None — this PR doesn't change any of the above

`docs/decisions.md` gains `rta-interrupt-restore-scripts-only` — sub-architectural, so a note rather than an ADR. It records the omission as a **decision, not an oversight**, because otherwise the missing spec arming reads like something someone should "finish".

Crucially it is **declined with a tripwire, not filed as debt**: the fix that would work (moving the session lifecycle out of the three per-spec snapshot/restore pairs into `globalSetup`, which runs in Vitest's main process) is a real refactor, the exposure is a Ctrl-C during an otherwise unattended 13-minute suite, and recovery is a two-minute registry rewrite that the snapshot-print makes mechanical. Re-open only if a device is actually stranded that way, or if the suite becomes something people routinely watch.

Two architecture docs claim files touched here — `build-and-tooling.md` (← `dictionary.txt`, four spellchecker words) and `system-shape.md` (← `docs/decisions.md`, one note). **Neither changed shape or why**; `last-reviewed` not bumped on either.

Typed **`test(rta):`** so it stays out of the user-facing changelog; no user-visible effect.

<!-- /pr render: sha=65ccc7fa57c841a4c7b7c8c325c4e062b30927b0 ts=2026-08-07T14:45:20Z -->
