### PR TITLE
Record the border-weight convention — 3px static, 6px focusable

### DIFF
--- a/components/CLAUDE.md
+++ b/components/CLAUDE.md
@@ -76,6 +76,10 @@ Users can re-theme every one of these (Settings → Theme → Custom), so a colo
 picked for its appearance in the default theme will be wrong in someone else's.
 Pick by meaning and it survives any palette.
 
+### Border weights — 3px static, 6px focusable
+
+Same principle for the 9-patch border assets: the weight encodes interaction state. `border-3px.9.png` is for **static panel edges** — the `components/dialogs/` family and `OverviewDialog`'s panel. `border-6px.9.png` is for **focusable things** — `TextButton`'s focus ring, `FocusableOverview`, grid focus indicators. The thick border is part of the "you can focus this" signal; keep the weights distinct so it stays readable.
+
 ## Common patterns
 
 - **`isValid(x)`** for nil/invalid checks — never compare to `invalid` directly with `=`.


### PR DESCRIPTION
# Overview
One-commit docs follow-up to #757 that missed the squash by minutes: records the border-weight convention in `components/CLAUDE.md` beside the theme-color table — `border-3px.9.png` marks static panel edges (the `components/dialogs/` family + `OverviewDialog`), `border-6px.9.png` marks focusable rings (`TextButton`, `FocusableOverview`, grid indicators). The 3px asset and `JRDialog`'s use of it already landed in #757.

## Changes
- `components/CLAUDE.md`: new "Border weights — 3px static, 6px focusable" subsection under the theme-color convention

## Follow-ups
None

## Issues
Ref #288

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [x] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [ ] None — this PR doesn't change any of the above

<!-- /pr render: sha=3d2c87c00289dfba3e210a20a6c9142aebc49a36 ts=2026-08-10T02:18:39Z -->