### PR TITLE
fix: Scope resume queries to video items so Jellyfin 12.0 folders stay out of Continue Watching

### DIFF
--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -68,10 +68,6 @@ sub loadItems()
     activeUser = globalUser.id
     if isValid(activeUser)
       params = {}
-      params["recursive"] = true
-      params["SortBy"] = "DatePlayed"
-      params["SortOrder"] = "Descending"
-      params["Filters"] = "IsResumable"
       params["EnableTotalRecordCount"] = false
 
       data = fetchJson(GetApi().BuildGetResumeItemsRequest(params), "continue")
@@ -238,11 +234,7 @@ sub loadItems()
     ' Uses the same endpoint as the Continue Watching home row so the Resume button is consistent with it.
     resumeData = fetchJson(GetApi().BuildGetResumeItemsRequest({
       ParentId: m.top.itemId,
-      Filters: "IsResumable",
-      SortBy: "DatePlayed",
-      SortOrder: "Descending",
       Limit: 1,
-      recursive: true,
       Fields: "PrimaryImageAspectRatio",
       EnableTotalRecordCount: false
     }), "seriesResume")

--- a/components/tasks/QuickPlayTask.bs
+++ b/components/tasks/QuickPlayTask.bs
@@ -171,11 +171,7 @@ function doSeries(input as object, items as object) as longinteger
   ' Check for a resumable (in-progress) episode first
   resumeData = fetchJson(GetApi().BuildGetResumeItemsRequest({
     "parentId": input.id,
-    "Filters": "IsResumable",
-    "SortBy": "DatePlayed",
-    "SortOrder": "Descending",
     "Limit": 1,
-    "recursive": true,
     "ImageTypeLimit": 1,
     "EnableTotalRecordCount": false
   }), "qp_seriesResume")
@@ -251,10 +247,6 @@ function doSeason(input as object, items as object) as longinteger
       ' try to find a "continue watching" episode
       continueData = fetchJson(GetApi().BuildGetResumeItemsRequest({
         "parentId": input.id,
-        "SortBy": "DatePlayed",
-        "recursive": true,
-        "SortOrder": "Descending",
-        "Filters": "IsResumable",
         "EnableTotalRecordCount": false
       }), "qp_seasonContinue")
 

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -466,6 +466,7 @@ repo-scoped
 reproducibility
 repo-size
 repo-wide
+resumable
 retry-with-backoff
 revalidation
 reverse-proxied

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -266,6 +266,7 @@ hardcode
 Hardcode
 hardcoded
 Hardcoded
+hardcodes
 Hardcoding
 HD
 HDR
@@ -372,7 +373,9 @@ OSS-readability
 outro
 PARA
 parallelize
+param
 params
+Params
 PascalCase
 PD-textlogo
 PDF

--- a/docs/architecture/api-usage-manifest.json
+++ b/docs/architecture/api-usage-manifest.json
@@ -991,6 +991,12 @@
       ]
     },
     {
+      "name": "MediaTypes",
+      "sourceFiles": [
+        "source/api/ApiClient.bs"
+      ]
+    },
+    {
       "name": "MinSegments",
       "sourceFiles": [
         "source/api/items.bs"
@@ -3058,7 +3064,7 @@
     },
     "counts": {
       "endpoints": 70,
-      "requestFields": 40,
+      "requestFields": 41,
       "responseFields": 214,
       "unresolvedEndpointSinks": 2
     },

--- a/docs/architecture/server-upgrade-automation.md
+++ b/docs/architecture/server-upgrade-automation.md
@@ -26,7 +26,7 @@ related-files:
   - docs/signals-backlog.md
   - docs/dev/jellyfin-server-versioning.md
   - source/api/ApiClient.bs
-last-reviewed: 2026-06-07
+last-reviewed: 2026-08-09
 ---
 
 # Jellyfin Server-Upgrade Automation
@@ -147,6 +147,56 @@ the floor spec. They can never double-report a given endpoint, and a genuinely
 modern-only endpoint (absent from the floor — a real 10.9+ feature) is flagged
 by neither. Both over-capture in a known way the agent dispositions (backward via
 capability guards; symmetry via an unlinked V1 dispatch sibling).
+
+## Known limitations — what this pipeline cannot catch
+
+Everything above compares **signatures**: which endpoints exist, which params and
+schema fields they declare, what those fields are typed as. That is the pipeline's
+reach, and two whole classes of breakage fall outside it. Both are structural, not
+bugs to be fixed — knowing where the wall is beats trusting a clean report too far.
+
+**1. Behavior changes behind an unchanged signature.** A release can keep an
+endpoint's parameter list byte-identical and still change what it *returns*. The
+fingerprint sees nothing, the diff emits nothing, and CI reports the release as
+mechanically clean.
+
+The worked example is [#784](https://github.com/jellyrock/jellyrock/issues/784).
+`GET /UserItems/Resume` declares the same 15 parameters in 10.7.0, 10.11.8 and
+12.0-rc4 — no additions, no removals, no retypes. But the server-side `IsResumable`
+predicate changed from "this item has playback position > 0" to "…or this *folder*
+has an in-progress descendant", so Continue Watching went from 4 items to 253, and
+the series Resume button started targeting a Season instead of an episode. A clean
+spec diff was a true statement about the signature and a useless one about the app.
+
+**2. How we call an endpoint, as opposed to which ones we call.**
+[`api-usage-manifest.json`](api-usage-manifest.json) does record a `requestFields`
+list, but two properties of it keep the obvious check out of reach. It is **flat and
+repo-wide** — `{name, sourceFiles}` with no endpoint association — so it can say
+"something, somewhere sends `MediaTypes`" but never "this endpoint is sent these
+params". And its scan scope is **`source/**` only**, so a param passed at a component
+call site is not in the manifest at all; all four of #784's call sites live under
+`components/`. Nothing in the pipeline can therefore compare the params we *send*
+against the params an endpoint *declares*, in either direction:
+
+- **Params we send that don't exist.** The four call sites in #784 each sent
+  `recursive`, `SortBy`, `SortOrder` and `Filters` to an endpoint that has never
+  accepted any of them (the server hardcodes all four internally, identically from
+  10.7.0 through master). Harmless, but they read as load-bearing for years and
+  sent every reader looking in the wrong place.
+- **Narrowing params we omit.** The same endpoint's `mediaTypes` is the only filter
+  a client controls there. Every other Jellyfin client passes it; we didn't, which
+  is precisely what left us exposed when the default widened.
+
+Making both of these checks possible needs two changes together: bind request fields to the
+endpoint they're sent to, and widen the scan past `source/**` to the component call
+sites. That's the obvious next phase if this class recurs. It hasn't yet — #784 is
+one data point, so this is recorded rather than built.
+
+**What actually catches these:** running the app against a pre-release server. The
+[pre-release channels](#pre-release-channels-rc--unstablemaster) section covers
+fetching RC and master specs; #784 was found by pointing a client at a real 12.0-rc4
+server, not by reading one. Treat a mechanically-clean report as "no *signature*
+changed", and keep a pre-release server in the loop for the rest.
 
 ## Data-flow pipeline
 

--- a/docs/architecture/server-upgrade-automation.md
+++ b/docs/architecture/server-upgrade-automation.md
@@ -161,22 +161,29 @@ fingerprint sees nothing, the diff emits nothing, and CI reports the release as
 mechanically clean.
 
 The worked example is [#784](https://github.com/jellyrock/jellyrock/issues/784).
-`GET /UserItems/Resume` declares the same 15 parameters in 10.7.0, 10.11.8 and
-12.0-rc4 — no additions, no removals, no retypes. But the server-side `IsResumable`
-predicate changed from "this item has playback position > 0" to "…or this *folder*
-has an in-progress descendant", so Continue Watching went from 4 items to 253, and
-the series Resume button started targeting a Season instead of an episode. A clean
-spec diff was a true statement about the signature and a useless one about the app.
+`GET /UserItems/Resume` declares the same 15 parameters in 10.11.8 and 12.0-rc4 —
+no additions, no removals, no retypes across the release that broke us. (The floor
+is not identical: 10.7.0 serves the same endpoint at `/Users/{userId}/Items/Resume`
+with 14 parameters — no `excludeActiveSessions` — and types the three array params
+as `array<string>` rather than the `BaseItemKind` / `MediaType` enums. That is a
+signature change, and the pipeline does see it. The 12.0 break is the one it can't.)
+The server-side `IsResumable` predicate changed from "this item has playback position
+> 0" to "…or this *folder* has an in-progress descendant", so Continue Watching went
+from 4 items to 253, and the series Resume button started targeting a Season instead
+of an episode. A clean spec diff was a true statement about the signature and a
+useless one about the app.
 
 **2. How we call an endpoint, as opposed to which ones we call.**
 [`api-usage-manifest.json`](api-usage-manifest.json) does record a `requestFields`
 list, but two properties of it keep the obvious check out of reach. It is **flat and
 repo-wide** — `{name, sourceFiles}` with no endpoint association — so it can say
 "something, somewhere sends `MediaTypes`" but never "this endpoint is sent these
-params". And its scan scope is **`source/**` only**, so a param passed at a component
-call site is not in the manifest at all; all four of #784's call sites live under
-`components/`. Nothing in the pipeline can therefore compare the params we *send*
-against the params an endpoint *declares*, in either direction:
+params". And its scan scope is narrower than the endpoint scan's: `REQUEST_FIELD_GLOBS`
+is **`source/api/**/*.bs` only**, so a param set anywhere else — `source/data/`,
+`source/utils/`, or any `components/` call site — is not in the manifest at all. All
+four of #784's call sites live under `components/`. Nothing in the pipeline can
+therefore compare the params we *send* against the params an endpoint *declares*, in
+either direction:
 
 - **Params we send that don't exist.** The four call sites in #784 each sent
   `recursive`, `SortBy`, `SortOrder` and `Filters` to an endpoint that has never
@@ -187,9 +194,9 @@ against the params an endpoint *declares*, in either direction:
   a client controls there. Every other Jellyfin client passes it; we didn't, which
   is precisely what left us exposed when the default widened.
 
-Making both of these checks possible needs two changes together: bind request fields to the
-endpoint they're sent to, and widen the scan past `source/**` to the component call
-sites. That's the obvious next phase if this class recurs. It hasn't yet — #784 is
+Making both of these checks possible needs two changes together: bind request fields to
+the endpoint they're sent to, and widen the scan past `source/api/**` to the component
+call sites. That's the obvious next phase if this class recurs. It hasn't yet — #784 is
 one data point, so this is recorded rather than built.
 
 **What actually catches these:** running the app against a pre-release server. The

--- a/docs/architecture/tech-debt.md
+++ b/docs/architecture/tech-debt.md
@@ -320,6 +320,12 @@ The `npm run lint:docs` checker validates every `tech-debt.md#<anchor>` referenc
 - **issue**: #733 fixed a teardown race in `onPositionChanged` by checking `m.isDestroyed` (set at the top of `onDestroy`) before dotting into notification refs. The same class of race — a native-engine or Task callback firing after `onDestroy` starts but before `unobserveField` actually detaches it — is structurally possible for the other observers `onDestroy` tears down (`state`, `content`, `selectedSubtitle`, `audioIndex`, `mediaSourceId`, `shouldAllowCaptions`, `subtitleTrack`, `globalCaptionMode`, the `playbackTimer`/`bufferCheckTimer` `fire` callbacks, and task `content`/`refreshedItem`/`currentCaption`). Only the proven crashing path was guarded (isolate-the-fix); the others are unguarded but unobserved.
 - **direction**: If another handler in this set turns up in a crash report with the same shape (a torn-down ref accessed during teardown), add an early `if m.isDestroyed then return` to that handler rather than re-diagnosing from scratch. A blanket guard on every handler is deliberately *not* applied up front — only proven crash sites warrant it.
 
+#### `api-usage-manifest-no-per-endpoint-binding`
+
+- **area**: [`docs/architecture/api-usage-manifest.json`](api-usage-manifest.json), [`scripts/generate/api-usage-manifest.js`](../../scripts/generate/api-usage-manifest.js)
+- **issue**: `requestFields` is flat and repo-wide (`{name, sourceFiles}`, no endpoint association) and scans `source/**` only, so it can't compare the params we send against the params an endpoint declares, or see `components/**` call sites. #784 hit both blind spots at once — see [Known limitations](server-upgrade-automation.md#known-limitations--what-this-pipeline-cannot-catch).
+- **direction**: Bind request fields to the endpoint they're sent to and widen the scan past `source/**`. One data point so far; revisit if the class recurs.
+
 #### `ci-path-filters-unverified`
 
 - **area**: the `paths` filter in each `.github/workflows/_lint-*.yml` / `_test-*.yml`, plus [`scripts/lint/ci-parity-check.js`](../../scripts/lint/ci-parity-check.js)

--- a/docs/architecture/tech-debt.md
+++ b/docs/architecture/tech-debt.md
@@ -323,8 +323,8 @@ The `npm run lint:docs` checker validates every `tech-debt.md#<anchor>` referenc
 #### `api-usage-manifest-no-per-endpoint-binding`
 
 - **area**: [`docs/architecture/api-usage-manifest.json`](api-usage-manifest.json), [`scripts/generate/api-usage-manifest.js`](../../scripts/generate/api-usage-manifest.js)
-- **issue**: `requestFields` is flat and repo-wide (`{name, sourceFiles}`, no endpoint association) and scans `source/**` only, so it can't compare the params we send against the params an endpoint declares, or see `components/**` call sites. #784 hit both blind spots at once — see [Known limitations](server-upgrade-automation.md#known-limitations--what-this-pipeline-cannot-catch).
-- **direction**: Bind request fields to the endpoint they're sent to and widen the scan past `source/**`. One data point so far; revisit if the class recurs.
+- **issue**: `requestFields` is flat and repo-wide (`{name, sourceFiles}`, no endpoint association) and its `REQUEST_FIELD_GLOBS` scan covers `source/api/**/*.bs` only — narrower than the endpoint scan's `source/**` — so it can't compare the params we send against the params an endpoint declares, and can't see `components/**` (or `source/data/`, `source/utils/`) call sites. #784 hit both blind spots at once — see [Known limitations](server-upgrade-automation.md#known-limitations--what-this-pipeline-cannot-catch).
+- **direction**: Bind request fields to the endpoint they're sent to and widen the scan past `source/api/**`. One data point so far; revisit if the class recurs.
 
 #### `ci-path-filters-unverified`
 

--- a/docs/dev/api-layering-guide.md
+++ b/docs/dev/api-layering-guide.md
@@ -6,7 +6,7 @@ related-files:
   - source/api/imageHelpers.bs
   - source/api/items.bs
   - source/api/userAuth.bs
-last-reviewed: 2026-05-01
+last-reviewed: 2026-08-09
 ---
 
 # API Architecture Layering Guide
@@ -65,6 +65,12 @@ The following defaults are automatically applied to item fetching endpoints:
 - `Trickplay` - Added for `V2`+ servers (10.9+)
 
 These injections ensure consistent item data across all supported server versions without manual parameter management.
+
+**Endpoint-scoped injection:**
+
+| Builder | Parameter | Default | Why |
+|---|---|---|---|
+| `BuildGetResumeItemsRequest` | `MediaTypes` | `"Video"` | `MediaTypes` is the only narrowing `/UserItems/Resume` accepts — it hardcodes `Recursive` / `OrderBy` / `IsResumable` server-side. Since Jellyfin 12.0 a folder also counts as resumable when a descendant is in progress, so an unfiltered query returns Seasons and Series alongside episodes ([#784](https://github.com/jellyrock/jellyrock/issues/784)). Override by passing a comma-separated **string**; an array is silently dropped by `buildParams` ([`buildparams-no-array-support`](../architecture/tech-debt.md#buildparams-no-array-support)) and falls back to the default. |
 
 ### When to Use Layer 1
 

--- a/scripts/lib/signals-fetch.cjs
+++ b/scripts/lib/signals-fetch.cjs
@@ -67,6 +67,11 @@ function compareSemverBase(a, b) {
 // `jellyfin-openapi-X.Y.Z.json` (stable) or `jellyfin-openapi-X.Y.Z-rcN.json`
 // (release candidate). Pre-release also covers `-betaN` / `-alphaN` defensively.
 //
+// PATCH is optional: the 10.x line published three segments (10.12.0-rc1) but the
+// 12.0 line publishes two (12.0-rc4). Matching only three segments made the whole
+// 12.0 line invisible here — the discovery half of the same gap spec-fetch.cjs's
+// isStableVersion had. compareSemverBase already treats a missing PATCH as 0.
+//
 // "RC in flight" rule (per user spec): only count an RC when its base version
 // is GREATER than the latest stable. Otherwise the RCs are historical (already
 // shipped to stable) and we report null.
@@ -74,10 +79,16 @@ function compareSemverBase(a, b) {
 // Exported separately so unit tests can exercise the parser without network
 // mocking. The `fetchJellyfinVersions` wrapper just composes httpGet + this.
 function parseJellyfinIndex(html) {
-  const re = /jellyfin-openapi-(\d+\.\d+\.\d+)(?:-(rc\d+|beta\d+|alpha\d+))?\.json/g;
+  const re = /jellyfin-openapi-(\d+\.\d+(?:\.\d+)?)(?:-(rc\d+|beta\d+|alpha\d+))?\.json/g;
   const seen = new Set();
   const versions = [];
   for (let m; (m = re.exec(html));) {
+    // A two-segment base also matches the legacy unstable datestamp form
+    // (20240207.2). Those belong to unstable/ and must never be ranked as a
+    // stable version — an 8-digit MAJOR would out-sort every real release.
+    // Mirrors spec-fetch.cjs's isUnstableVersion, re-implemented rather than
+    // imported because spec-fetch already requires this module (cycle).
+    if (/^\d{8}(?:\.\d+)?$/.test(m[1])) continue;
     const key = m[1] + (m[2] ? '-' + m[2] : '');
     if (seen.has(key)) continue;
     seen.add(key);

--- a/scripts/lib/spec-fetch.cjs
+++ b/scripts/lib/spec-fetch.cjs
@@ -35,10 +35,20 @@ const CACHE_REL = '.api-watch/cache';
 // Specs are large; allow well beyond the signals-fetch 5s default.
 const SPEC_TIMEOUT_MS = 30000;
 
-// A stable-channel version: MAJOR.MINOR.PATCH with an optional pre-release suffix
+// A stable-channel version: MAJOR.MINOR(.PATCH) with an optional pre-release suffix
 // (-rcN / -betaN / -alphaN). RCs ship in the stable dir alongside finals.
+//
+// PATCH is optional because the archive does not always publish one: the 10.x line
+// used three segments (10.12.0-rc1), but the 12.0 line ships its RCs as `12.0-rc4`.
+// Requiring three segments made every 12.0 RC unfetchable, which blocked triaging the
+// whole next major. The `!isUnstableVersion` guard keeps the now-looser shape from
+// also swallowing the legacy datestamp form (20240207.2), which must route to unstable/.
 function isStableVersion(v) {
-  return typeof v === 'string' && /^\d+\.\d+\.\d+(?:-(?:rc|beta|alpha)\d+)?$/.test(v);
+  return (
+    typeof v === 'string' &&
+    /^\d+\.\d+(?:\.\d+)?(?:-(?:rc|beta|alpha)\d+)?$/.test(v) &&
+    !isUnstableVersion(v)
+  );
 }
 
 // An unstable-channel (master) build label: an 8-digit date, optionally followed

--- a/source/api/ApiClient.bs
+++ b/source/api/ApiClient.bs
@@ -101,7 +101,7 @@ class ApiClient
   ' SortBy / SortOrder / Filters, they are ignored. Since 12.0 a folder also matches
   ' IsResumable when a descendant is in progress, so an unfiltered query returns Seasons and
   ' Series (by design) mixed in with the episodes. Every JellyRock resume flow is video, so
-  ' default to Video; pass MediaTypes explicitly to widen it.
+  ' default to Video; pass MediaTypes as a comma-separated STRING to widen it.
   '
   ' @param params - Optional query parameters
   ' @returns Request AA: { method, url } or invalid if no userId
@@ -109,7 +109,14 @@ class ApiClient
     userId = m.getUserId()
     if userId = "" then return invalid
     mergedParams = m.injectDefaults(params)
-    if not mergedParams.DoesExist("MediaTypes") then mergedParams.MediaTypes = "Video"
+    ' MediaTypes has to come out a non-empty STRING, not merely present: buildParams()
+    ' silently skips roArray values (tech-debt `buildparams-no-array-support`), so an
+    ' array here would drop the only filter we control and send the query unnarrowed —
+    ' the exact #784 failure, reached through the documented way to widen it.
+    callerMediaTypes = mergedParams.MediaTypes
+    hasMediaTypes = (type(callerMediaTypes) = "String" or type(callerMediaTypes) = "roString")
+    if hasMediaTypes then hasMediaTypes = callerMediaTypes.trim() <> ""
+    if not hasMediaTypes then mergedParams.MediaTypes = "Video"
     if m.getApiVersion() >= 2
       queryParams = { userId: userId }
       queryParams.append(mergedParams)

--- a/source/api/ApiClient.bs
+++ b/source/api/ApiClient.bs
@@ -95,12 +95,21 @@ class ApiClient
 
   ' Build a request AA for GetResumeItems (Continue Watching), for use with fetchRes() or fetchJson().
   ' Mirrors GetResumeItems(): applies injectDefaults, version-aware endpoint.
+  '
+  ' The server hardcodes Recursive, OrderBy=DatePlayed and IsResumable on this endpoint, so
+  ' MediaTypes is the ONLY narrowing a client controls — don't bother sending recursive /
+  ' SortBy / SortOrder / Filters, they are ignored. Since 12.0 a folder also matches
+  ' IsResumable when a descendant is in progress, so an unfiltered query returns Seasons and
+  ' Series (by design) mixed in with the episodes. Every JellyRock resume flow is video, so
+  ' default to Video; pass MediaTypes explicitly to widen it.
+  '
   ' @param params - Optional query parameters
   ' @returns Request AA: { method, url } or invalid if no userId
   function BuildGetResumeItemsRequest(params = {} as object) as dynamic
     userId = m.getUserId()
     if userId = "" then return invalid
     mergedParams = m.injectDefaults(params)
+    if not mergedParams.DoesExist("MediaTypes") then mergedParams.MediaTypes = "Video"
     if m.getApiVersion() >= 2
       queryParams = { userId: userId }
       queryParams.append(mergedParams)

--- a/tests/scripts/unit/lib/spec-fetch.test.js
+++ b/tests/scripts/unit/lib/spec-fetch.test.js
@@ -38,6 +38,12 @@ describe('URL + path construction', () => {
     );
   });
 
+  it('routes a patchless RC to the stable dir (the 12.0 line drops PATCH)', () => {
+    expect(specUrl('12.0-rc4')).toBe(
+      'https://api.jellyfin.org/openapi/stable/jellyfin-openapi-12.0-rc4.json',
+    );
+  });
+
   it('routes an unstable datestamp to the unstable dir', () => {
     expect(specUrl('20240402201942')).toBe(
       'https://api.jellyfin.org/openapi/unstable/jellyfin-openapi-20240402201942.json',
@@ -63,6 +69,15 @@ describe('version classification', () => {
     expect(isStableVersion('20240402201942')).toBe(false);
   });
 
+  it('recognizes the patchless MAJOR.MINOR labels the 12.0 line publishes', () => {
+    expect(isStableVersion('12.0-rc4')).toBe(true);
+    expect(isStableVersion('12.0-beta1')).toBe(true);
+    expect(isStableVersion('12.0')).toBe(true);
+    // The legacy unstable datestamp is also MAJOR.MINOR-shaped; it must stay unstable-only
+    // or archiveBaseFor would route it to the wrong dir.
+    expect(isStableVersion('20240207.2')).toBe(false);
+  });
+
   it('recognizes unstable datestamps (modern + legacy)', () => {
     expect(isUnstableVersion('20240402201942')).toBe(true); // YYYYMMDDHHMMSS
     expect(isUnstableVersion('20240207.2')).toBe(true); // legacy <YYYYMMDD>.<N>
@@ -74,6 +89,7 @@ describe('version classification', () => {
     expect(isSpecVersion('10.11.10')).toBe(true);
     expect(isSpecVersion('10.12.0-rc1')).toBe(true);
     expect(isSpecVersion('20240402201942')).toBe(true);
+    expect(isSpecVersion('12.0-rc4')).toBe(true);
     expect(isSpecVersion('unstable')).toBe(false);
     expect(isSpecVersion('latest')).toBe(false);
   });

--- a/tests/scripts/unit/signals-fetch.test.js
+++ b/tests/scripts/unit/signals-fetch.test.js
@@ -55,6 +55,33 @@ describe('parseJellyfinIndex', () => {
     expect(parseJellyfinIndex(html).stable).toBe('10.11.0');
   });
 
+  it('sees the patchless RC labels the 12.0 line publishes', () => {
+    const html =
+      '<a href="jellyfin-openapi-10.11.8.json">stable</a>\n' +
+      '<a href="jellyfin-openapi-12.0-rc1.json">rc</a>\n' +
+      '<a href="jellyfin-openapi-12.0-rc3.json">rc</a>\n' +
+      '<a href="jellyfin-openapi-12.0-rc4.json">rc</a>\n';
+    // Three-segment matching made the whole 12.0 line invisible: rc came back null
+    // and the tracker never learned the next major had release candidates.
+    expect(parseJellyfinIndex(html)).toEqual({ stable: '10.11.8', rc: '12.0-rc4' });
+  });
+
+  it('ranks a patchless stable above a three-segment one', () => {
+    const html =
+      '<a href="jellyfin-openapi-10.11.8.json">x</a>\n' +
+      '<a href="jellyfin-openapi-12.0.json">x</a>\n';
+    expect(parseJellyfinIndex(html)).toEqual({ stable: '12.0', rc: null });
+  });
+
+  it('ignores a legacy unstable datestamp that strays into the stable listing', () => {
+    const html =
+      '<a href="jellyfin-openapi-10.11.8.json">x</a>\n' +
+      // Also MAJOR.MINOR-shaped. Ranked as a version its 8-digit major would beat
+      // every real release and pin latestStable to garbage.
+      '<a href="jellyfin-openapi-20240207.2.json">x</a>\n';
+    expect(parseJellyfinIndex(html)).toEqual({ stable: '10.11.8', rc: null });
+  });
+
   it('throws when no jellyfin-openapi-*.json filenames are present', () => {
     expect(() => parseJellyfinIndex('<html>nothing here</html>')).toThrow(/no jellyfin-openapi/);
   });

--- a/tests/source/unit/api/ApiClient.spec.bs
+++ b/tests/source/unit/api/ApiClient.spec.bs
@@ -719,6 +719,28 @@ namespace tests
       m.assertTrue(result.url.inStr("Video") = -1, "the Video default must not be appended alongside the override")
     end function
 
+    @it("falls back to the default when a caller passes an array buildParams would drop")
+    function _()
+      m.setApiVersion(2)
+
+      ' buildParams() silently skips roArray values, so honoring mere key presence here
+      ' would send the query with NO mediaTypes at all — the #784 bug, silently.
+      result = m.apiClient.BuildGetResumeItemsRequest({ MediaTypes: ["Video", "Audio"] })
+
+      m.assertNotInvalid(result)
+      m.assertTrue(result.url.inStr("mediatypes=Video") >= 0, "an unusable array must fall back to the Video default")
+    end function
+
+    @it("falls back to the default when a caller passes an empty MediaTypes")
+    function _()
+      m.setApiVersion(2)
+
+      result = m.apiClient.BuildGetResumeItemsRequest({ MediaTypes: "" })
+
+      m.assertNotInvalid(result)
+      m.assertTrue(result.url.inStr("mediatypes=Video") >= 0, "an empty MediaTypes must fall back to the Video default")
+    end function
+
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     @describe("ApiClient Instantiation")
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/tests/source/unit/api/ApiClient.spec.bs
+++ b/tests/source/unit/api/ApiClient.spec.bs
@@ -665,6 +665,61 @@ namespace tests
     end function
 
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    @describe("Resume Items - media-type narrowing")
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    ' The resume endpoint hardcodes Recursive/OrderBy/IsResumable server-side, so MediaTypes is
+    ' the only narrowing a client controls. Without it, Jellyfin 12.0 returns Seasons and Series
+    ' alongside the episodes, which floods Continue Watching and makes the series Resume button
+    ' target a folder. See issue #784.
+
+    @it("defaults MediaTypes to Video on the V2 resume endpoint")
+    function _()
+      m.setApiVersion(2)
+
+      result = m.apiClient.BuildGetResumeItemsRequest({})
+
+      m.assertNotInvalid(result)
+      m.assertTrue(result.url.inStr("/UserItems/Resume") >= 0, "V2 should use /UserItems/Resume path")
+      ' BrightScript lowercases AA keys in URLs; the value keeps its case.
+      m.assertTrue(result.url.inStr("mediatypes=Video") >= 0, "V2 resume query must narrow to MediaTypes=Video")
+    end function
+
+    @it("defaults MediaTypes to Video on the V1 resume endpoint")
+    function _()
+      m.setApiVersion(1)
+
+      result = m.apiClient.BuildGetResumeItemsRequest({})
+
+      m.assertNotInvalid(result)
+      m.assertTrue(result.url.inStr("/items/resume") >= 0, "V1 should use /users/{id}/items/resume path")
+      m.assertTrue(result.url.inStr("mediatypes=Video") >= 0, "V1 resume query must narrow to MediaTypes=Video too")
+    end function
+
+    @it("lets a caller widen MediaTypes instead of forcing the default")
+    function _()
+      m.setApiVersion(2)
+
+      result = m.apiClient.BuildGetResumeItemsRequest({ MediaTypes: "Video,Audio" })
+
+      m.assertNotInvalid(result)
+      m.assertTrue(result.url.inStr("Audio") >= 0, "a caller-supplied MediaTypes must win over the Video default")
+    end function
+
+    @it("treats a differently-cased caller key as the same override")
+    function _()
+      m.setApiVersion(2)
+
+      ' roAssociativeArray keys are case-insensitive, so the DoesExist guard must not
+      ' append a second, conflicting mediatypes param here.
+      result = m.apiClient.BuildGetResumeItemsRequest({ mediaTypes: "Audio" })
+
+      m.assertNotInvalid(result)
+      m.assertTrue(result.url.inStr("Audio") >= 0, "lowercase mediaTypes should override the default")
+      m.assertTrue(result.url.inStr("Video") = -1, "the Video default must not be appended alongside the override")
+    end function
+
+    '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     @describe("ApiClient Instantiation")
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
# Overview

On Jellyfin 12.0 the Continue Watching row fills with collections, seasons, series, albums and artists, and the series Resume button can target a Season instead of an episode.

`GET /UserItems/Resume` hardcodes `Recursive`, `OrderBy=DatePlayed` and `IsResumable` server-side, so `MediaTypes` is the only narrowing a client controls. JellyRock never sent it. That was survivable while the server's `IsResumable` predicate meant "this item has playback position > 0" (10.7.0 through 10.11.z, which only leaf media can satisfy), because folders were excluded implicitly. Jellyfin 12.0 widened the predicate to "…or this folder has an in-progress descendant", and the implicit exclusion disappeared.

Measured against a live 12.0-rc4 server, the Continue Watching query returned **253 items instead of 4**: 1 Movie, 3 Episodes, and 249 folders (121 MusicAlbum, 70 MusicArtist, 24 Season, 14 Folder, 13 Series, 7 BoxSet). The three `parentId` call sites that take `Items[0]` were worse: **9 of 13** partially-watched series returned a Season folder rather than an Episode, so the series Resume button and Quick Play were handed a folder.

Upstream [jellyfin/jellyfin#17523](https://github.com/jellyfin/jellyfin/pull/17523) (merged two days after the rc4 tag) narrows resumable folders to Series + Season, which fixes the collections half server-side. It deliberately keeps Seasons resumable, so the `Items[0]` bug is ours to fix regardless.

The PR also carries the api-watch tooling fixes that fell out of the investigation — the pipeline could neither fetch nor even *discover* a 12.0 spec — plus the record of why this class of break was invisible to it.

## Changes

- Default `MediaTypes` to `Video` inside `BuildGetResumeItemsRequest` rather than at each call site, so a fifth call site cannot silently regress. Callers can still widen it, by passing a comma-separated **string**. The builder requires a non-empty string rather than mere key presence: `buildParams` silently drops `roArray` values ([`buildparams-no-array-support`](docs/architecture/tech-debt.md#buildparams-no-array-support)), so honoring bare presence would send the query unnarrowed — this exact bug, reached through the documented way to widen it.
- Drop `recursive` / `SortBy` / `SortOrder` / `Filters` from all four resume call sites in `LoadItemsTask.bs` and `QuickPlayTask.bs`. None are declared parameters of this endpoint in the 10.7.0, 10.11.8 or 12.0-rc4 specs, and the controller hardcodes all four identically from `v10.7.0` through `master`.
- **api-watch — fetch:** accept patchless RC labels in `spec-fetch.cjs` (`12.0-rc4`). The archive publishes the whole 12.0 line with two segments, so `isSpecVersion` rejected every one of them and `/server-upgrade` could not fetch any 12.0 spec at all.
- **api-watch — discovery:** accept them in `parseJellyfinIndex` (`signals-fetch.cjs`) too. Fetching a label you already know is only half the job — the parser that reads the archive listing still required three segments, so against a listing carrying rc1/rc3/rc4 it returned `rc: null` and `server-upgrade-tracker.js` never learned the next major had release candidates. A patchless 12.0 *final* would have pinned `latestStable` at 10.11.x indefinitely. Both loosenings are guarded so the legacy datestamp form (`20240207.2`) can't be ranked as a stable version — unguarded, its 8-digit MAJOR out-sorts every real release.
- Add a "Known limitations" section to `server-upgrade-automation.md` recording the two ways this bug was invisible to the api-watch pipeline, and document the endpoint-scoped `MediaTypes` injection in `api-layering-guide.md`'s parameter-injection table.
- Tests: 6 new `ApiClient` cases (V2 default, V1 default, caller override, case-insensitive AA-key override, array fallback, empty-string fallback) and 6 new script cases (3 `spec-fetch`, 3 `parseJellyfinIndex`).

### No regression on older servers

- `mediaTypes` exists on the V1 endpoint at the 10.7.0 floor (`CommaDelimitedArrayModelBinder` over `string[]`), so both shims accept it.
- `MediaType` is a hardcoded `override` on the `Video` base class in both 10.7.0 and `master`, not derived from metadata, so no Movie / Episode / MusicVideo / Trailer / Recording can be filtered out.
- `buildParams` lowercases AA keys, so we actually emit `mediatypes=Video`. Verified against the live RC server that key and value binding are both case-insensitive.
- The only behavior change below 12.0 is that an in-progress **audio** item no longer appears in Continue Watching. Effectively a no-op: JellyRock has no audiobook support, and short audio tracks did not surface in the row in practice. Books were already skipped client-side.

## Follow-ups

- [`api-usage-manifest-no-per-endpoint-binding`](docs/architecture/tech-debt.md#api-usage-manifest-no-per-endpoint-binding) — bind manifest request fields to their endpoint and widen the scan past `source/api/**`, so params-vs-spec can be linted in both directions

## Issues

Fixes #784

## Docs / context updates

- [x] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [x] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [x] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [ ] None — this PR doesn't change any of the above

## Testing

- **2668/2668 unit tests pass on device** (Roku at `.178`; `.177` was holding the debug console).
- **952 script tests pass.**
- The new tests are proven load-bearing rather than vacuous: reverting the `MediaTypes` guard to its key-presence form fails exactly the 2 new cases on device (61 passed / 2 failed) and restores to 63/63; the patchless-RC parser case returns `rc: null` on the pre-fix regex.
- `validate`, `lint:docs`, `lint:markdown`, `lint:spelling`, `lint:dictionary`, `lint:js`, prettier, and the api-manifest drift gate are all clean.
- Server behavior confirmed against a live 12.0-rc4 instance, and against the `v10.7.0` / `master` controller sources for the floor claims.
- Spec claims re-checked independently against the committed fingerprints in `docs/architecture/spec-fingerprints/`: `mediaTypes` is declared on the resume endpoint at both the 10.7.0 floor and 10.11.8; `recursive` / `sortBy` / `sortOrder` / `filters` are declared in neither.

<!-- /pr render: sha=e92c6cee5727a0dd49064c803dedc1b9e4ae4b00 ts=2026-08-10T04:01:30Z -->
