### PR TITLE
ci: add a one-shot `device-lock-selftest` diagnostic workflow

### DIFF
--- a/.github/workflows/device-lock-selftest.yml
+++ b/.github/workflows/device-lock-selftest.yml
@@ -1,0 +1,84 @@
+# TEMPORARY DIAGNOSTIC — answers the two open questions blocking the device-lock
+# CI design, then can be deleted.
+#
+#   1. Can the GitHub App create/delete a git ref? (the acquire/release jobs
+#      depend on it, and no local test can answer it — the App private key is a
+#      repo secret.)
+#   2. Which Roku is `secrets.ROKU_DEVICE_IP` bound to? (the value can't be read
+#      back from the GitHub UI once set.)
+#
+# Deliberately leaks nothing: this repo is PUBLIC, so Actions logs are public.
+# It prints the device MODEL (generic) and the HASHED lock key — never the raw
+# ECP device-id (which partially encodes the serial) and never the IP.
+#
+# workflow_dispatch only fires for workflow files that exist on the DEFAULT
+# BRANCH, so this must land on `main` before it can be dispatched.
+
+name: Device Lock Self-Test (diagnostic)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Q1 — the App token path. No checkout, no fork code, GitHub API only.
+  app-can-write-refs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Create / read / delete a throwaway lock ref
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          probe() {
+            curl -s -o /tmp/out.json -w "%{http_code}" -X "$1" \
+              -H "authorization: Bearer $TOKEN" \
+              -H "accept: application/vnd.github+json" \
+              -H "x-github-api-version: 2022-11-28" \
+              -H "content-type: application/json" \
+              ${3:+-d "$3"} "https://api.github.com/repos/$REPO/$2"
+          }
+          SHA=$(curl -s -H "authorization: Bearer $TOKEN" \
+                "https://api.github.com/repos/$REPO/git/ref/heads/main" \
+                | sed -n 's/.*"sha": *"\([0-9a-f]*\)".*/\1/p' | head -1)
+          REF=refs/device-lock/ci-selftest
+          echo "create #1 (expect 201) : $(probe POST git/refs "{\"ref\":\"$REF\",\"sha\":\"$SHA\"}")"
+          echo "create #2 (expect 422) : $(probe POST git/refs "{\"ref\":\"$REF\",\"sha\":\"$SHA\"}")"
+          echo "delete    (expect 204) : $(probe DELETE git/refs/device-lock/ci-selftest)"
+
+      - name: Clean up if the run died mid-way
+        if: always()
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          curl -s -o /dev/null -X DELETE \
+            -H "authorization: Bearer $TOKEN" \
+            "https://api.github.com/repos/$REPO/git/refs/device-lock/ci-selftest" || true
+
+  # Q2 — which physical Roku CI drives. A read-only ECP query: no sideload, no
+  # channel restart, nothing interrupted on screen.
+  which-device:
+    runs-on: [self-hosted, roku-device]
+    steps:
+      - name: Report the bound device (model + hashed lock key only)
+        env:
+          ROKU_IP: ${{ secrets.ROKU_DEVICE_IP }}
+        run: |
+          set -euo pipefail
+          info=$(curl -s --max-time 5 "http://$ROKU_IP:8060/query/device-info" | tr -d '\n')
+          id=$(printf '%s' "$info" | sed -n 's/.*<device-id>\([^<]*\)<\/device-id>.*/\1/p')
+          model=$(printf '%s' "$info" | sed -n 's/.*<model-name>\([^<]*\)<\/model-name>.*/\1/p')
+          test -n "$id" || { echo "ECP returned no device-id"; exit 1; }
+          echo "model    : $model"
+          echo "lock key : $(printf '%s' "$id" | sha256sum | cut -c1-16)"

--- a/.github/workflows/device-lock-selftest.yml
+++ b/.github/workflows/device-lock-selftest.yml
@@ -11,13 +11,26 @@
 # It prints the device MODEL (generic) and the HASHED lock key — never the raw
 # ECP device-id (which partially encodes the serial) and never the IP.
 #
-# workflow_dispatch only fires for workflow files that exist on the DEFAULT
-# BRANCH, so this must land on `main` before it can be dispatched.
+# Triggers, and why there are two:
+#
+#   push (this branch only) — `push` reads the workflow file from the PUSHED
+#     COMMIT, explicitly including workflows not merged to the default branch,
+#     so this runs WITHOUT being merged first. That is the point: a throwaway
+#     diagnostic should not have to land on `main` to answer its question.
+#   workflow_dispatch — kept only so it stays re-runnable by hand IF it is ever
+#     merged. It does nothing on a branch: dispatch only fires for workflow
+#     files that exist on the default branch.
+#
+# The branch filter is deliberate. Without it this would fire on every push to
+# every branch, spending self-hosted runner time on a question already answered.
 
 name: Device Lock Self-Test (diagnostic)
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - ci/device-lock-selftest
 
 permissions:
   contents: read


### PR DESCRIPTION
# Overview

Two questions block the device-lock CI design, and neither can be answered from a developer machine: whether the repo's GitHub App can create and delete a git ref, and which physical Roku `secrets.ROKU_DEVICE_IP` is bound to. The App's private key is a repo secret, and a secret's value can't be read back from the UI once set — so the only way to find out is to ask from inside a workflow.

This adds one throwaway `workflow_dispatch` workflow that answers both in a single run, then gets deleted. It is a diagnostic, not infrastructure: nothing depends on it and it is not wired into any trigger other than manual dispatch.

It lands on `main` rather than riding the device-lock branch because `workflow_dispatch` only fires for workflow files that exist on the default branch (verified against GitHub's events reference).

## Changes

- Add `.github/workflows/device-lock-selftest.yml`, manual-dispatch only, `permissions: contents: read`.
- `app-can-write-refs` (ubuntu, no checkout, no fork code) mints the App token via the same pinned `actions/create-github-app-token` SHA the repo already uses, then runs create / conflict / delete against a throwaway `refs/device-lock/ci-selftest`, with an `always()` cleanup step so a mid-run failure can't leak the ref.
- `which-device` (self-hosted `roku-device`) performs a read-only ECP `query/device-info` — no sideload, no channel restart, nothing interrupted on screen.
- Privacy-preserving output: this repo is public, so its Actions logs are too. The device job prints the device **model** and a SHA-256-derived lock key, never the raw ECP `device-id` (which partially encodes the serial) and never the IP.

## Follow-ups

None

## Issues

None

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=b191f1b319233acf975f1086f5117a91bc0e8f80 ts=2026-08-10T20:53:03Z -->
