### PR TITLE
ci(rta): Make the leak gate reliable, tighten its budget, and give the resend one home

### DIFF
--- a/tests/rta/lib/nav.js
+++ b/tests/rta/lib/nav.js
@@ -27,6 +27,7 @@ import {
   waitFocusInside,
   waitHome,
   hasChildren,
+  resendIfSwallowed,
   sleep,
 } from './steps.js';
 
@@ -658,12 +659,7 @@ async function navHomeReturn(ctx, detailCount = 0) {
       label: `homeReturn detail ${i} title`,
       timeout: 20000,
       interval: 500,
-      action: async () => {
-        const focused = await odc.getFocusedNode({ includeNode: true }).catch(() => null);
-        if (typeof focused?.keyPath === 'string' && focused.keyPath.includes('#itemGrid')) {
-          await press(ecp.Key.Ok);
-        }
-      },
+      action: resendIfSwallowed(ecp.Key.Ok, '#itemGrid'),
     });
     await press(ecp.Key.Back);
     // Back on the grid. `loadState` is already "loaded" (the grid was suspended, not

--- a/tests/rta/lib/nav.js
+++ b/tests/rta/lib/nav.js
@@ -644,10 +644,26 @@ async function navHomeReturn(ctx, detailCount = 0) {
 
   for (let i = 0; i < detailCount; i++) {
     await focusGridTile(i);
+    // GUARDED press, not a bare one. `focusGridTile` ends on a focus gate, and focus is a
+    // PROXY for "the router is idle": sgrouter_showView's finally restores focus BEFORE it
+    // dispatches NavigationEnd, so an OK sent the instant the grid regains focus can land
+    // mid-navigation, be rejected, and simply vanish — after which this wait times out with
+    // `#videoTitle` never resolving (`last=undefined`). Observed on detail 1, 2026-08-15.
+    //
+    // Re-pressing only while the GRID still holds focus is what makes the retry safe: once
+    // the detail opens, focus has left #itemGrid, so this cannot double-press into it.
+    // Same mechanism and same idiom as the second back press in focus.spec.js.
     await press(ecp.Key.Ok);
     await waitFor('#videoTitle.text', (t) => typeof t === 'string' && t.length > 0, {
       label: `homeReturn detail ${i} title`,
       timeout: 20000,
+      interval: 500,
+      action: async () => {
+        const focused = await odc.getFocusedNode({ includeNode: true }).catch(() => null);
+        if (typeof focused?.keyPath === 'string' && focused.keyPath.includes('#itemGrid')) {
+          await press(ecp.Key.Ok);
+        }
+      },
     });
     await press(ecp.Key.Back);
     // Back on the grid. `loadState` is already "loaded" (the grid was suspended, not

--- a/tests/rta/lib/steps.js
+++ b/tests/rta/lib/steps.js
@@ -199,6 +199,57 @@ export async function waitFocusInside(containerId, { timeout = 12000, interval =
   });
 }
 
+/**
+ * An `action` for `waitFor` / `waitFocused` that RE-SENDS `key` when the previous press
+ * was swallowed.
+ *
+ * ## The failure it exists for
+ *
+ * `sgrouter_showView`'s `finally` restores focus BEFORE it dispatches `NavigationEnd`, so
+ * a key sent the instant focus lands can arrive while the router still reports itself
+ * navigating — `_goBack` rejects it and `JRScene`'s back arbiter swallows it. The key is
+ * then simply gone: no error, no retry, and whatever wait follows times out blaming the
+ * component it was watching rather than the input that never arrived. Measured twice on
+ * `.178` (2026-08-15): `focus.spec`'s second Back, and `navHomeReturn`'s OK on detail 1,
+ * the latter at roughly 1 run in 6.
+ *
+ * ## How it detects a swallow
+ *
+ * Focus still being INSIDE `containerId` means nothing navigated away, so the press did
+ * not take. That same test is what makes the retry safe against overshoot: once the press
+ * lands, focus has left the container and this stops pressing, so it cannot double-press
+ * into whatever just opened — the hazard `tests/rta/CLAUDE.md` warns about.
+ *
+ * ## Why it sits out the first tick
+ *
+ * `waitFor` / `waitFocused` invoke `action` BEFORE their first read, and any caller of
+ * this has just pressed. Re-sending there would fire within milliseconds of the original,
+ * before the app could possibly have answered — a double-press at exactly the moment a
+ * screen is mounting. Sitting out one tick spends the poll interval as the "did it land?"
+ * window instead.
+ *
+ * This is also why the skip lives HERE rather than in `waitFor`: an eager first action is
+ * *correct* for the focus WALKS (`focusGridTile`, `findHomeLibraryTile`, `focusOverhangIcon`),
+ * which want to start moving immediately. Only a resend needs to wait and see.
+ *
+ * @param {string} key - an `ecp.Key` value to re-send
+ * @param {string} containerId - `#id` of the container the press should navigate AWAY from
+ * @returns {() => Promise<void>} a fresh, single-use action (it carries per-wait state)
+ */
+export function resendIfSwallowed(key, containerId) {
+  let ticked = false;
+  return async () => {
+    if (!ticked) {
+      ticked = true;
+      return;
+    }
+    const focused = await odc.getFocusedNode({ includeNode: true }).catch(() => null);
+    if (typeof focused?.keyPath === 'string' && focused.keyPath.includes(containerId)) {
+      await press(key);
+    }
+  };
+}
+
 /** Home is ready once HomeRows has rendered its content. */
 export async function waitHome() {
   await waitFor('#homeRows.content.getChildCount()', hasChildren, {

--- a/tests/rta/lib/steps.test.js
+++ b/tests/rta/lib/steps.test.js
@@ -21,16 +21,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const getValues = vi.fn();
 const getFocusedNode = vi.fn();
+const sendKeypress = vi.fn();
 vi.mock('roku-test-automation', () => ({
   odc: {
     getValues: (...a) => getValues(...a),
     getValue: vi.fn(),
     getFocusedNode: (...a) => getFocusedNode(...a),
   },
-  ecp: { sendKeypress: vi.fn() },
+  ecp: { sendKeypress: (...a) => sendKeypress(...a) },
 }));
 
-const { getActiveVals } = await import('./steps.js');
+const { getActiveVals, resendIfSwallowed } = await import('./steps.js');
 
 beforeEach(() => {
   // NOTE the coupling these defaults model: the throw path runs through
@@ -107,5 +108,76 @@ describe('getActiveVals', () => {
   it('makes no device call at all for an empty list', async () => {
     await expect(getActiveVals([])).resolves.toEqual([]);
     expect(getValues).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The resend guard, gated without hardware.
+ *
+ * Two behaviours carry the whole helper and neither is visible by reading a call site:
+ * it must NOT press on the first tick (waitFor invokes `action` before its first read,
+ * and the caller has just pressed — resending there is a double-press into a screen
+ * that is still mounting), and it must STOP once focus has left the container (or the
+ * retry becomes the overshoot it was meant to avoid).
+ *
+ * Both were regressions waiting to happen: the two call sites this replaced were
+ * hand-rolled and had the first-tick bug, which no on-device run would report as
+ * anything but an occasional mystery.
+ */
+describe('resendIfSwallowed', () => {
+  beforeEach(() => {
+    getFocusedNode.mockReset();
+    sendKeypress.mockReset();
+  });
+
+  const focusedAt = (keyPath) => getFocusedNode.mockResolvedValue({ keyPath });
+
+  it('does not press on the first tick — the caller just pressed', async () => {
+    focusedAt('scene.#itemGrid.0');
+    const action = resendIfSwallowed('back', '#itemGrid');
+    await action();
+    expect(sendKeypress).not.toHaveBeenCalled();
+  });
+
+  it('resends once focus is still inside the container on a later tick', async () => {
+    focusedAt('scene.#itemGrid.0');
+    const action = resendIfSwallowed('back', '#itemGrid');
+    await action(); // first tick, sits out
+    await action();
+    await action();
+    expect(sendKeypress).toHaveBeenCalledTimes(2);
+    expect(sendKeypress).toHaveBeenCalledWith('back');
+  });
+
+  it('stops pressing once focus has left the container', async () => {
+    focusedAt('scene.#itemGrid.0');
+    const action = resendIfSwallowed('back', '#itemGrid');
+    await action();
+    await action();
+    expect(sendKeypress).toHaveBeenCalledTimes(1);
+    focusedAt('scene.#homeRows.2'); // the press landed; we navigated away
+    await action();
+    await action();
+    expect(sendKeypress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not press when the focus read fails — an unknown state is not a swallow', async () => {
+    getFocusedNode.mockRejectedValue(new Error('odc down'));
+    const action = resendIfSwallowed('back', '#itemGrid');
+    await action();
+    await action();
+    expect(sendKeypress).not.toHaveBeenCalled();
+  });
+
+  it('gives each wait its own first-tick budget', async () => {
+    focusedAt('scene.#itemGrid.0');
+    const first = resendIfSwallowed('back', '#itemGrid');
+    await first();
+    await first();
+    expect(sendKeypress).toHaveBeenCalledTimes(1);
+    // A second wait must sit out its OWN first tick rather than inherit the first's state.
+    const second = resendIfSwallowed('back', '#itemGrid');
+    await second();
+    expect(sendKeypress).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/rta/specs/focus.spec.js
+++ b/tests/rta/specs/focus.spec.js
@@ -16,7 +16,7 @@ import { authenticate, getLibraries, libraryIdFor } from '../lib/jellyfin.js';
 import { seedHome, assertSeedTookEffect } from '../lib/seed.js';
 import { hardRelaunch, ecp, odc } from '../lib/driver.js';
 import { navLibraryByType } from '../lib/nav.js';
-import { press, waitFor, waitFocused, waitHome } from '../lib/steps.js';
+import { press, resendIfSwallowed, waitFor, waitFocused, waitHome } from '../lib/steps.js';
 
 const LOCALE = RTA_CONFIG.languages[0]; // en_US
 
@@ -64,27 +64,15 @@ it('focus restoration: Home -> Library -> Detail -> back -> back', async () => {
 
   // Back -> Home resumes: focus must land back in Home's content (#homeRows), not lost.
   //
-  // The press is GUARDED rather than fired once, because the gate above is a proxy for the
-  // state this press actually needs. `showView`'s finally restores focus BEFORE it dispatches
-  // NavigationEnd (Router.brs), so the instant the grid regains focus the router can still be
-  // mid-navigation — where `_goBack` rejects the key and JRScene's arbiter swallows it
-  // (JRScene.onKeyEvent, `isRouterNavigating`). The key is then simply gone, and this wait
-  // times out with focus still on #itemGrid. Observed exactly that way on 2026-08-15.
-  //
-  // Re-pressing only while the GRID still holds focus is what makes the retry safe: once the
-  // pop actually starts, focus has left #itemGrid, so this can never double-press onto Home
-  // and raise the Exit dialog.
+  // The press is GUARDED rather than fired once: the gate above is a proxy for the state
+  // this press needs, so the Back can arrive mid-navigation and be swallowed. Mechanism,
+  // detection and the safety argument live with the helper in lib/steps.js.
   await press(ecp.Key.Back);
   await waitHome();
   await waitFocused((f) => typeof f.keyPath === 'string' && f.keyPath.includes('#homeRows'), {
     label: 'home content focus restored',
     timeout: 15000,
     interval: 500,
-    action: async () => {
-      const f = await odc.getFocusedNode({ includeNode: true }).catch(() => null);
-      if (typeof f?.keyPath === 'string' && f.keyPath.includes('#itemGrid')) {
-        await press(ecp.Key.Back);
-      }
-    },
+    action: resendIfSwallowed(ecp.Key.Back, '#itemGrid'),
   });
 });

--- a/tests/rta/specs/leaks.spec.js
+++ b/tests/rta/specs/leaks.spec.js
@@ -93,11 +93,21 @@ const NOTHING_RETAINED = Object.fromEntries(ROUTED_VIEWS.map((t) => [t, 0]));
  * magnitude under the failure and well over the noise from texture pools and the
  * recycled cell pools Home rebuilds on return.
  *
- * The observed delta is recorded as the `perVisitRootDelta` assertion on every run, so
- * the real spread accumulates in the run ledger instead of staying unknown. Tighten this
- * once a few green runs agree on a number — and do not raise it to make a run green.
+ * **Set from measurement, not from caution.** Nine runs on `.178` (2026-08-15, recorded as
+ * the `perVisitRootDelta` assertion) read `-5, +2, 0, 0, 1, 0, -1, 0` across the eight that
+ * were green — max magnitude 5, and negative as often as positive, which is the signature
+ * of pool jitter rather than of anything retained. 20 is 4x the observed noise.
+ *
+ * It stays this loose on purpose, because the gap it sits in is enormous: the delta spans
+ * SIX extra screen visits, and one leaked view is ~150 nodes, so the smallest real
+ * per-visit leak reads ~900. Anything between roughly 30 and 500 would catch the identical
+ * set of defects; 20 buys detection of the sub-view case (a stranded content-root island,
+ * which the per-type census structurally cannot see) without approaching the noise floor.
+ *
+ * Do not raise it to make a run green — a run that exceeds this is either a real leak or
+ * evidence the noise floor moved, and both deserve a look rather than a bigger number.
  */
-const PER_VISIT_ROOT_BUDGET = 100;
+const PER_VISIT_ROOT_BUDGET = 20;
 
 let session;
 let ctx;


### PR DESCRIPTION
# Overview

`PER_VISIT_ROOT_BUDGET` shipped at 100 with a comment admitting nobody had seen the real spread. Collecting that spread surfaced something more important first: the leak gate itself flaked at roughly **1 run in 6**, so this fixes the gate before touching the number. A gate that randomly reds is worse than one whose threshold is 5x too loose — the first teaches people to ignore it.

## Changes

- Guard the OK press in `navHomeReturn`. It fired the instant `focusGridTile` returned, and that focus gate is a **proxy** for "the router is idle": `sgrouter_showView`'s `finally` restores focus *before* dispatching `NavigationEnd`, so an OK sent there lands mid-navigation, is rejected, and vanishes — the wait then times out with `#videoTitle` never resolving. Same mechanism the second back press in `focus.spec.js` was fixed for, same documented idiom: re-press only while `#itemGrid` still holds focus, so it cannot double-press into an already-open detail.
- Tighten `PER_VISIT_ROOT_BUDGET` from 100 to **20**, set from measurement rather than caution, with the reasoning recorded next to the constant.
- Extract the resend into `resendIfSwallowed(key, containerId)` in [`lib/steps.js`](tests/rta/lib/steps.js), adopted by both call sites. `tests/rta/CLAUDE.md` asks for exactly this — *"put the retry in the shared helper so every caller inherits it instead of one call site"* — and giving it one home immediately exposed a bug present in **both** hand-rolled copies (below).

## Follow-ups

None

## Issues

None

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

## Verification

**The flake.** Measured at ~1 in 6 while collecting budget data (2026-08-15): `nav timed out waiting for homeReturn detail 1 title (last=undefined)` — `undefined` rather than `""`, i.e. `#videoTitle` never resolved, so the screen never opened and the key was swallowed. The full suite is 44/44 green after the fix (848s), and six leak-trio runs before it were green too, but that is *not* the argument: at a 1-in-6 rate, six clean runs happen by luck a third of the time. The argument is that the guarded retry does not **prevent** the swallow, it makes it **recoverable** — the failure mode is neutralized by construction.

**The first-tick bug the extraction found.** `waitFor` / `waitFocused` invoke `action` *before* their first read, and a resend's caller has just pressed — so both hand-rolled copies re-sent within milliseconds of the original press, double-pressing into a screen still mounting (the overshoot hazard `tests/rta/CLAUDE.md` warns about). The helper sits out its first tick.

That skip belongs in the helper, not in `waitFor`: of the nine `action:` sites, **six are focus walks** (`focusGridTile`, `findHomeLibraryTile`, `focusOverhangIcon`) that must press immediately to start moving. An eager first action is correct for a walk and wrong only for a resend, so generalising it upward would break the majority to fix the minority.

Five unit tests gate what no call site reveals: no press on the first tick, resends while focus stays inside the container, **stops** once focus leaves, treats a failed focus read as unknown rather than as a swallow, and gives each wait its own first-tick budget (the closure-state trap if an instance is reused).

`waitOsdUp` is deliberately left alone — it retries `Up` guarded on *state* rather than focus-in-container. Same family, different guard; converging them would mean generalising the predicate across two shapes to save nothing.

**The budget.** Fourteen green runs on `.178`, recorded as the `perVisitRootDelta` assertion:

| | samples | max magnitude |
|---|---|---|
| before the flake fix | `-5, +2, 0, 0, 1, 0, -1, 0` | 5 |
| after | `-1, 0, 1, 0, 0, -1` | 1 |

Negative as often as positive. Retention cannot be negative, so that symmetry is **pool jitter around zero** — a noise floor, not a small leak hiding under the old budget. A positive skew would have argued for more samples, or for leaving 100 alone.

20 stays deliberately loose because the gap is enormous: the delta spans six extra screen visits and one leaked view is ~150 nodes, so the smallest real per-visit leak reads **~900**. Anything from ~30 to ~500 catches the identical defects. What 20 buys over 100 is the sub-view case — a stranded content-root island with no routed view in it, which the per-type census structurally cannot see — dropping its detection floor from ~17 nodes per visit to ~3.

<!-- /pr render: sha=2a724e98fd2a5e272c947172e80eb3e99494dad7 ts=2026-08-15T18:12:14Z -->
