### PR TITLE
fix(overhang): stop long usernames rendering as a bare `...` in `JRDropdown`

### DIFF
--- a/components/ui/dropdown/JRDropdown.xml
+++ b/components/ui/dropdown/JRDropdown.xml
@@ -6,7 +6,9 @@
     <Poster id="buttonBorder" uri="pkg:/images/9patch/border-6px.9.png" visible="false" />
     <LayoutGroup id="triggerContent" layoutDirection="horz" itemSpacings="[9]">
       <Poster id="triggerIcon" visible="false" width="36" height="36" loadWidth="36" loadHeight="36" loadDisplayMode="limitSize" />
-      <LabelSecondaryMedium id="triggerLabel" width="150" horizAlign="left" vertAlign="center" ellipsizeOnBoundary="true" />
+      <!-- No ellipsizeOnBoundary: this label doesn't wrap, so whole-word ellipsizing
+           drops a too-long single-word value entirely and renders a bare "..." (#798). -->
+      <LabelSecondaryMedium id="triggerLabel" width="150" horizAlign="left" vertAlign="center" />
     </LayoutGroup>
 
     <!-- Dropdown menu (positioned below trigger, initially hidden) -->

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -907,6 +907,30 @@ is needed, leaving `node scripts/device-lock.js release` or a ~15-minute wait as
 out. Worth re-evaluating if the lock ever grows a "steal for repair" mode, which removes the
 objection entirely.
 
+## decision-id: overhang-username-trigger-stays-fixed-width
+
+**date**: 2026-08-16
+**status**: accepted
+**related-files**: `components/ui/dropdown/JRDropdown.xml`, `components/ui/dropdown/JRDropdown.bs`, `components/JROverhang.bs`
+
+The overhang user menu's trigger label keeps a fixed `width="150"`, and long usernames
+truncate mid-character. Both obvious improvements were measured and rejected. **Widening**
+is blocked on the right: the trigger is anchored at x=1450, putting its right edge at
+x=1660, and the clock's left edge sits at x=1691 for a two-digit hour — `31px` of gutter, so
+the cap cannot move while that anchor holds. **Shrinking the trigger to its text** is worse
+than it looks: the menu is left-aligned to the trigger and expands rightward at
+`max(300, buttonWidth)`, and in clock-hidden mode `JROverhang.positionUserDropdown` computes
+the left edge as `1824 - triggerWidth - 15`, so a narrower trigger pushes the menu *right* —
+a prototype put a short username's menu at 1678..1978, i.e. `58px` off a 1920 screen.
+
+The cost is a fixed `150px` box that reserves space short names don't use, which shows as a
+gap inside the focus highlight and as the name sitting left of the action-safe edge when the
+clock is hidden. That is accepted. Measured on device at `fontSizeMedium`, `150px` holds about
+9 mixed-case characters, so truncation is common rather than exceptional — the trigger must
+therefore never set `ellipsizeOnBoundary`, which drops a too-long single-word name entirely
+(issue #798). Worth re-evaluating if the trigger is ever re-anchored to grow leftward, which
+removes both objections at once but moves the search/settings icons with it.
+
 ## Migrated to ADRs
 
 These decisions were promoted to numbered ADRs on the operating-model

--- a/tests/source/unit/components/JRDropdown.spec.bs
+++ b/tests/source/unit/components/JRDropdown.spec.bs
@@ -181,6 +181,15 @@ namespace tests
       m.assertEqual(label.text, "TestUser")
     end function
 
+    @it("never ellipsizes the trigger on word boundaries")
+    function _()
+      ' #798: the label doesn't wrap, so whole-word ellipsizing drops a too-long
+      ' single-word username entirely and renders a bare "...". Measured on device:
+      ' ~10 mixed-case characters already overflow the 150px trigger.
+      label = m.dropdown.findNode("triggerLabel")
+      m.assertFalse(label.ellipsizeOnBoundary)
+    end function
+
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     @describe("Trigger icon")
     '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
# Overview

The overhang user menu rendered `...` in place of the username for any name long enough to overflow its trigger, on both Home and Settings. The cause is one attribute on the trigger label: `ellipsizeOnBoundary="true"` tells Roku to ellipsize by *whole words*, and since the label doesn't wrap, a single-word username that overflows has no word boundary to keep — every word is dropped and only the ellipsis renders.

Removing the attribute restores Roku's default character-level ellipsizing (`aknight2…`), which is already what the rest of the app does — `UserItem.xml`, `FocusableOverview.xml` and `MoviePresenter.bs` all ellipsize by character. The trigger label was the only site in the codebase pairing `ellipsizeOnBoundary="true"` with `wrap="false"`, i.e. the only place this failure was possible. (`GridItem`'s genreLabel and `JRRowItem`'s backdropText set the flag too, but both set `wrap="true"`, where an over-wide word is broken across lines instead of dropped.)

The attribute was never a deliberate choice: it has one commit in its history — `e353f55f`, the commit that created the component — with no rationale in the message and no linked discussion.

Measured on device (`fontSizeMedium`=32, `uiFontFallback`=false), the 150px trigger holds about 9 mixed-case characters, so this hit ordinary usernames rather than an edge case:

| username | chars | width | |
|---|---:|---:|---|
| `Ann` | 3 | 56px | fits |
| `charlie` | 7 | 95px | fits |
| `jellyfin` | 8 | 94px | fits |
| `aknight2015` | 11 | 180px | overflowed (the reporter) |
| `Christopherson` | 14 | 222px | overflowed |
| `MyVeryLongUsername1234` | 22 | 401px | overflowed |

## Changes

- Remove `ellipsizeOnBoundary="true"` from `JRDropdown`'s trigger label, with a comment recording why it must not come back
- Add a regression assertion in `JRDropdown.spec.bs` so the attribute can't silently return
- Record [`overhang-username-trigger-stays-fixed-width`](docs/decisions.md) — the two obvious follow-on "improvements" were both measured and rejected, and the note carries the numbers so they aren't re-proposed blind

## Follow-ups

None

## Issues

Fixes #798

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [x] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [ ] None — this PR doesn't change any of the above

<!-- /pr render: sha=332a4025ef38789fd9a410bd69963e9a630c37ae ts=2026-08-17T03:51:27Z -->