### PR TITLE
ci(rta): Fix `measure --deploy` deleting the run provenance it just wrote

### DIFF
--- a/scripts/run-record.js
+++ b/scripts/run-record.js
@@ -814,6 +814,28 @@ export function beginRun({ lock, run, cumulative = false }) {
     { run, startedAt, variant, commit, dirty, ...(cumulative ? { cumulative: true } : {}) },
     activeRunDir,
   );
+  // Read it straight back, so THIS PROCESS holds the record in memory for the rest of
+  // the run.
+  //
+  // `run-meta.json` lives under `out/`, and `measure --deploy` spawns `npm run build`
+  // AFTER this point — which opens with `rimraf build/ out/` and takes the file with it.
+  // Every later `runProvenance()` then read a path that no longer existed, caught, and
+  // degraded to nulls, so a `--deploy` series published no commit, no dirty flag, no
+  // deviceKey and no startedAt: exactly the attribution the ledger exists to carry. It
+  // also silently disabled `crossedHourBoundary`, which is derived from that startedAt.
+  //
+  // Measured rather than reasoned: on an independent 163-record ledger, 33 of 34 series
+  // with `deployedFromCheckout: true` carried a null commit, against 1 of 127 for the
+  // rest.
+  //
+  // This warms the EXISTING reader rather than assigning a hand-built object, so there is
+  // no second definition of the record to drift from `writeRunMeta`'s merge of
+  // `lock.meta`. The file stays the source of truth for every OTHER process.
+  //
+  // Note the header's rule already covers this hazard for the LEDGER ("it lives under
+  // `.device-runs/`, NOT `out/`, because every `build*` script starts with `rimraf out/`").
+  // `run-meta.json` is the one file that stayed behind; caching is what makes it safe.
+  runMeta();
   resetFailures();
   // Same contract as the failure records: a fold may only ever see THIS run's.
   resetAssertions();

--- a/tests/scripts/unit/run-record.test.js
+++ b/tests/scripts/unit/run-record.test.js
@@ -282,6 +282,35 @@ describe('the run lifecycle — where a run s records actually land', () => {
       run.close();
     });
 
+    it('survives the run directory being deleted mid-run, as `--deploy` deletes it', async () => {
+      // The regression: `run-meta.json` lives under `out/`, and `measure --deploy` runs
+      // `npm run build` AFTER opening the run — which starts with `rimraf build/ out/`.
+      // `runProvenance()` then read a file that no longer existed and degraded every
+      // field to null, so a `--deploy` measurement series published no commit, no dirty
+      // flag, no deviceKey and no startedAt.
+      //
+      // Deleting the whole directory is the honest reproduction: `rimraf out/` does not
+      // politely remove one file.
+      const { beginRun, runProvenance, getRunDir } = await fresh();
+      const run = beginRun({ lock: LOCK, run: 'measure' });
+
+      // NOTHING may read provenance before the delete. An earlier draft of this test
+      // took a `before` snapshot to compare against, which warmed the very cache the
+      // fix installs — so it passed with the fix REMOVED. The read has to be the first
+      // one of the run, exactly as it is in `measure.js`.
+      fs.rmSync(getRunDir(), { recursive: true, force: true });
+
+      const after = runProvenance();
+      expect(after.run).toBe('measure');
+      expect(after.startedAt).toBe(run.startedAt);
+      // `commit` / `dirty` are deliberately NOT asserted: `fresh()` runs in a temp cwd
+      // where git resolves nothing, so they are legitimately null here. `run` and
+      // `startedAt` are set by `beginRun` itself, so they isolate the cache from the
+      // environment — and they are two of the four fields that were null in production.
+      expect(after.variant).not.toBeUndefined();
+      run.close();
+    });
+
     it('clears the previous run s failures, so a fold sees only this run', async () => {
       const { beginRun, failuresPath, recordFailure, readFailures } = await fresh();
       const first = beginRun({ lock: LOCK, run: 'test:rta' });


### PR DESCRIPTION
# Overview

`npm run measure -- --deploy` published every measurement series with a null `commit`,
`dirty`, `deviceKey` and `startedAt`. `beginRun` writes `out/<kind>/run-meta.json` and
clears the module cache so the next `runProvenance()` re-reads the file — but `--deploy`
spawns `npm run build` *after* opening the run, and every build script starts with
`rimraf build/ out/`, taking that file with it. The re-read then caught and degraded to
`{}`.

So the one mode that *guarantees* the measured build came from this checkout was also the
only mode that could not say which checkout that was. `runs.jsonl` was unaffected
(`endRun` closes over the values in memory), which is why this stayed invisible: the run
ledger looked correct while the measurement ledger did not.

Found by dogfooding a main-vs-branch performance campaign, not by review.

## Changes

- Warm the existing `runMeta()` reader in `beginRun`, immediately after the record is
  written, so this process holds it in memory for the rest of the run. Warming the
  existing reader rather than assigning a hand-built object keeps one definition of the
  record — nothing can drift from `writeRunMeta`'s merge of `lock.meta` — and the file
  stays the source of truth for every other process.
- Add a regression test that deletes the whole run directory (what `rimraf` actually does)
  and asserts provenance still resolves. It takes its **first** provenance read after the
  delete: an earlier draft snapshotted a `before` value to compare against and thereby
  warmed the very cache under test, so it passed with the fix removed.

### Evidence

Measured rather than reasoned, against an independent 163-record ledger:

| | commit recorded |
|---|---|
| `deployedFromCheckout: true` | null in **33 of 34** |
| `deployedFromCheckout: false` | present in **126 of 127** |

Two consequences beyond attribution. `--select dirty=false` silently excluded every
`--deploy` series, because a null reads as the `(unrecorded)` third state rather than as
clean. And `crossedHourBoundary` is derived from `runProvenance().startedAt`, so the
hour-boundary integrity check could not fire on a `--deploy` run at all.

Verified on hardware after the fix — a `--deploy` series on `.177` now records
`commit ca7d67b5 · dirty false · deviceKey ac4701ca4a5d8a0b · crossedHourBoundary false`.

**Scope:** `measure --deploy`, and `measure:devices` / `measure:matrix` which forward it.
`test:rta` is unaffected — its npm script builds *before* the node process starts, so
`beginRun` runs after the `rimraf`.

## Follow-ups

None

## Issues

None

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=ca7d67b557934201e580f6a23255b6a3247439b4 ts=2026-08-19T20:56:00Z -->