### PR TITLE
fix: Register the `position` observer exactly once

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1208,6 +1208,11 @@ end sub
 sub onContentChange()
   if not isValid(m.top.content) then return
 
+  ' Unobserve before observing: `content` is re-set on every reload path
+  ' (audio/subtitle/source change, retry), and Roku does not dedupe identical
+  ' observeField registrations — each one fires the handler again per notify.
+  ' Same idiom as audioIndex and selectedSubtitle above.
+  m.top.unobserveField("position")
   m.top.observeField("position", "onPositionChanged")
 end sub
 
@@ -1234,8 +1239,6 @@ sub fetchNextEpisode()
       onNextEpisodeFetchFailed()
       return
     end if
-
-    m.top.observeField("position", "onPositionChanged")
 
     ' BuildGetEpisodesRequest(Limit 2) returns [current, next]; a count other
     ' than 2 means there is no next episode, so disable the Next Episode button.


### PR DESCRIPTION
# Overview

`position` — inherited from `Video`, notifying every 0.5s at Roku's default `notificationInterval` — was registered twice with the same handler: once in `onContentChange()`, and again inside `fetchNextEpisode()`'s `.then()`, where it had nothing to do with fetching. Roku does not dedupe identical `observeField(field, handler)` registrations (measured on a Roku Ultra, OS 15.3.4: 1 registration = 1 handler invocation per notification, 2 = 2).

It compounded. `onContentChange()` registered unconditionally with no unobserve, and `m.top.content` is re-set in `onVideoContentLoaded()` on every reload path (init, subtitle change, audio-index change, video-source change, retry). An episode where the user changes audio once and subtitles once ended with ~4 observers, running the 70-line `onPositionChanged()` ~8x/sec instead of 2x — 5 cross-node OSD writes, `captionTask` and `trickplayCarousel` writes, a scene-wide `getScene().findNode("dialogBackground")`, plus `checkMediaSegments()` and `checkTimeToDisplayNextEpisode()` each time.

This is a performance fix, not a correctness one. Dispatch is synchronous, so duplicates ran back-to-back on the same position; the auto-skip path was saved by `m.dismissedSegmentId` and the next-episode path is state-guarded. A single `unobserveField` removes all of a component's registrations for a field, so the existing `onDestroy` teardown was already correct — this was never a leak, only wasted work.

## Changes

- Delete the stray `observeField("position", ...)` inside `fetchNextEpisode()`'s `.then()`. Proven redundant rather than assumed: its only call site guards on `m.top.content.contenttype = 4`, dereferencing `content` after it is set, so `onContentChange()` had always registered first — and it only ran for episodes, never for movies.
- `onContentChange()` now calls `unobserveField("position")` before `observeField(...)`, matching the idiom already used in this file for `audioIndex` and `selectedSubtitle` — both registered in `init()` and re-registered only after an unobserve. `position` was the only one of the three doing neither.

Deliberately conservative: registering in `init()` and dropping `onContentChange()` would save a line, but it moves the observer live from first-content-set to component creation, and `onPositionChanged()` calls `m.top.getScene().findNode(...)` unguarded. Timing is preserved exactly.

## Follow-ups

None

## Issues

None

## Docs / context updates

`docs/architecture/playback.md` claims `VideoPlayerView.bs` in its `related-files`, so it was re-read. It does not document `position`-observer registration, and this change alters no subsystem shape or why — left untouched, `last-reviewed` deliberately not bumped.

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

## Verification

The mechanism is already established, so the bar was the static property "exactly one registration reachable", plus no regression:

- **grep** — one `observeField("position")` remains, immediately preceded by `unobserveField("position")` in the same function.
- **Scope check** — only this file observes `position` on its own `m.top` (`AudioPlayerView` observes a different node), and `unobserveField` only drops the calling component's own observers, so the unobserve has no external victim.
- **`npm run validate`** — clean.
- **`npm run test:unit`** on the Ultra (`.178`, OS 15.3.4) — 3333/3333 passed.
- **`npm run test:rta`** on the same device — 59 passed, 1 failed. That failure (`osd video-source button opens the list dialog`) was baselined rather than assumed environmental: re-running `dialogs.spec.js` against unmodified `main` reproduced the identical `OSD has no #showVideoSourceMenu — the item this spec plays no longer has enough streams/sources` error, and failed 4 tests there versus 2 on this branch. Pre-existing live-fixture instability against `demo.jellyfin.org`, not a regression from this change.

<!-- /pr render: sha=d019c1eec952c1ff483f354ec84f13c6ce112edc ts=2026-09-08T13:19:32Z -->