### PR TITLE
ci: cancel superseded PR device runs to drain the Roku queue

### DIFF
--- a/.github/workflows/device-unit-tests.yml
+++ b/.github/workflows/device-unit-tests.yml
@@ -46,6 +46,31 @@ on:
           - all
           - complete
 
+# One in-flight device run per PR (per branch for pushes). The Roku is a single
+# physical device behind one serial ephemeral runner at ~11 min a job, so a burst
+# of triggers queues rather than parallelising. On 2026-09-09 six device-eligible
+# runs landed in 23 minutes; the last sat queued ~57 min behind the others, which
+# reads as "the runner is dead" on the Actions page even though every job passed.
+# Superseded pushes to the same PR were most of that backlog.
+#
+# cancel-in-progress is TRUE for pull_request_target ONLY, and that asymmetry is
+# load-bearing — do not simplify it to a bare `true`. The hazard is the one
+# rta-functional-tests.yml documents: concurrency is evaluated BEFORE any job
+# runs, so a superseding docs-only trigger can cancel an in-flight run and then
+# skip via check-skip, leaving the earlier source change ungated. That is
+# reachable only on the `push` path, because .github/actions/changed-paths
+# resolves a push's file list from the before...after compare (that push's files
+# alone) but resolves a PR's from `gh pr diff` (the whole base...head diff). A
+# docs-only push to a PR therefore still sees the earlier source change and still
+# runs the device tests, so cancelling superseded PR runs cannot cause a false
+# skip — while cancelling superseded main pushes could. Hence false for push.
+#
+# Fork PRs stay fails-closed: cancelling a run awaiting fork-gate approval leaves
+# fork-gate 'cancelled', which the all-tests allowlist below treats as blocked.
+concurrency:
+  group: device-unit-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 # Restrict the default GITHUB_TOKEN to read-only contents access. This workflow
 # only checks out code, installs deps, and runs tests on the Roku — it never
 # pushes, comments, or otherwise mutates the repo. Without this, a malicious


### PR DESCRIPTION
# Overview

The self-hosted runner is not broken — it is queue-bound. One physical Roku sits behind one serial ephemeral runner at ~11 min a job, so device runs queue rather than parallelise. On 2026-09-09 six device-eligible runs landed in 23 minutes and the last sat `queued` for ~57 min; every job that ran passed, but an hour of `queued` is indistinguishable from a dead runner on the Actions page. Three of those six were superseded pushes to the same PR, two of them pure waste. This adds a concurrency group so a newer push to a PR cancels the device run it supersedes.

## Changes

- Add a workflow-level `concurrency` group to `device-unit-tests.yml`, keyed on the PR number (branch for pushes), named `device-unit-tests-*` to match the house style used by `rta-`, `journal-sync-` and `release-management-`.
- Set `cancel-in-progress` to an expression that is true for `pull_request_target` only, so superseded PR runs are cancelled while pushes to `main` continue to queue.
- Document why that asymmetry is load-bearing in a comment above the block, so it is not later simplified to a bare `true`.

The push path deliberately keeps `cancel-in-progress` false. Concurrency is evaluated before any job runs, so a superseding docs-only trigger could cancel an in-flight run and then skip via `check-skip`, leaving the earlier source change ungated — the hazard `rta-functional-tests.yml` already documents. That is reachable only on the push path, because `.github/actions/changed-paths` resolves a push's file list from the `before...after` compare (that push's files alone) but resolves a PR's from `gh pr diff` over the whole `base...head` diff. A docs-only push to a PR therefore still sees the earlier source change and still runs the device tests, so cancelling superseded PR runs cannot cause a false skip — while cancelling superseded pushes to `main` could.

Fork gating is unchanged and still fails closed: cancelling a run awaiting `fork-gate` approval leaves `fork-gate` at `cancelled`, which the existing `all-tests` allowlist (`success` or `skipped` only) treats as blocked, so a re-push requires fresh maintainer approval.

Verified on this PR: YAML parses with `on` / `permissions` / `jobs` unchanged and `all-tests` still `runs-on: [self-hosted, roku-device]`; the expression form of `cancel-in-progress` is confirmed supported by the GitHub workflow-syntax reference; and this PR's own device run reported a status with `all-tests` skipped, consuming zero device time.

Separately measured while diagnosing, and not addressed here: roughly 7 min median dead air between a job finishing and the next queued job starting (13m47s / 2m04s / 7m04s / 4m30s across four handoffs) while jobs were already waiting. The runner re-registers in 9s, so the delay is on GitHub's side assigning work to freshly-registered ephemeral runners. That is a batcave-side infrastructure question rather than jellyrock code, so it is tracked in the batcave repo.

## Follow-ups

None

## Issues

None

## Docs / context updates

- [x] None — this PR doesn't change any of the above
