### PR TITLE
ci: Bound RTA poll waits to their own timeout, cutting pre-push time

### DIFF
--- a/tests/rta/lib/steps.js
+++ b/tests/rta/lib/steps.js
@@ -24,6 +24,41 @@ export const press = (key) => ecp.sendKeypress(key);
 export const hasChildren = (n) => typeof n === 'number' && n > 0;
 
 /**
+ * How long the next poll tick may sleep: one `interval`, or whatever is left of the budget,
+ * or 0 when the budget is spent and the caller should stop.
+ *
+ * ## Why this exists
+ *
+ * `waitFor` and `waitFocused` slept a FULL interval after deciding the tick had failed, and
+ * only then re-checked the loop condition — so a wait overshot its own stated `timeout` by up
+ * to one interval. `waitOsdUp`'s OSD gate is `timeout: 30000, interval: 2000`, so "30 s"
+ * could be 32 s, and a caller budgeting a chain of waits was budgeting against a number that
+ * was not the truth. It is also pure waste: the loop has already read, already failed the
+ * predicate, and the remaining budget cannot fit another read, so the sleep buys nothing and
+ * only delays the diagnosis.
+ *
+ * Found from the other end — `steps.test.js` cases passing `timeout: 1` still cost 500 ms
+ * each, the default interval, which made that file the slowest in `test:scripts`.
+ *
+ * ## Why this returns a DURATION rather than doing the sleeping
+ *
+ * The obvious shape was a `sleepWithinBudget()` that awaited internally, and
+ * `jellyrock-rta/sleep-budgeted` rejected it — correctly by its own rule, which counts a
+ * `sleep()` as a poll tick only when it is lexically inside a loop. Moving the tick into a
+ * helper hid it from that test and it read as a bare arbitrary wait. Returning the duration
+ * keeps the `await sleep(...)` in the loop where the rule can see it, and keeps the part
+ * that is actually subtle — the arithmetic — in one place. The alternative was an
+ * `eslint-disable`, which would have been routing around a gate this suite added on purpose.
+ *
+ * The two SETTLE loops (`waitRowsSettled`, `waitCellsQuiet`) deliberately do NOT use this:
+ * their sleep sits at the TOP of the loop and IS the quiet window being measured, so
+ * truncating it would change what they detect rather than only when they give up.
+ */
+function nextTickMs(interval, deadline) {
+  return Math.max(0, Math.min(interval, deadline - Date.now()));
+}
+
+/**
  * One single read, reporting WHY there is no value: `{ value, failed }`.
  *
  * `failed` is true only when the request itself did not complete — a transport error, or
@@ -316,7 +351,9 @@ export async function waitFor(
       if (SCENE_ROOTED_READS.has(read)) await auditSceneResolution(keyPath, { label });
       return last;
     }
-    await sleep(interval);
+    const tick = nextTickMs(interval, start + timeout);
+    if (!tick) break;
+    await sleep(tick);
   }
   throw await diagnosedError(
     `nav timed out waiting for ${label || keyPath} (last=${JSON.stringify(last)})` +
@@ -382,7 +419,9 @@ export async function waitFocused(
     }
     last = `${f?.node?.subtype}@${f?.keyPath}`;
     if (f && predicate(f)) return f;
-    await sleep(interval);
+    const tick = nextTickMs(interval, start + timeout);
+    if (!tick) break;
+    await sleep(tick);
   }
   throw await diagnosedError(
     `nav timed out waiting for focus (${label || 'predicate'}); last=${last}` +

--- a/tests/rta/lib/steps.test.js
+++ b/tests/rta/lib/steps.test.js
@@ -114,6 +114,34 @@ beforeEach(() => {
   getFocusedNode.mockReset().mockResolvedValue(null);
 });
 
+/**
+ * Settle a poll-driven wait on a FAKE clock, so its intervals cost no real time.
+ *
+ * Used only by the handful of cases that genuinely need SEVERAL polls to make their point —
+ * "keeps re-pressing when a key is swallowed" needs three ticks of a 2 s interval, and
+ * asserting that on a real clock costs four seconds per run of `test:scripts`, which
+ * pre-push runs on any JS change.
+ *
+ * The rest of this file stays on the real clock deliberately. Faking time everywhere would
+ * mean every future test here has to know about the clock, and two cases below assert on
+ * real `Date.now()` deltas and would silently change meaning.
+ *
+ * The `.catch()` is not optional: while the clock is being advanced the wait may reject,
+ * and an unobserved rejection in that window is an unhandled-rejection crash rather than a
+ * test failure. The caller still awaits the same promise and still sees the rejection.
+ */
+async function onFakeClock(start, { budgetMs = 200_000 } = {}) {
+  vi.useFakeTimers();
+  try {
+    const settled = start();
+    settled.catch(() => {});
+    await vi.advanceTimersByTimeAsync(budgetMs);
+    return await settled;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
 describe('getActiveVals', () => {
   it('returns values positionally aligned with the keyPaths given', () => {
     getValues.mockResolvedValue({
@@ -560,7 +588,7 @@ describe("walkHomeToFirstRow — the precondition Home's Up-to-overhang escape r
       row -= 1;
     });
 
-    await expect(walkHomeToFirstRow()).resolves.toEqual({ walked: 3, from: 3 });
+    await expect(onFakeClock(() => walkHomeToFirstRow())).resolves.toEqual({ walked: 3, from: 3 });
     expect(sendKeypress).toHaveBeenCalledTimes(3);
     expect(sendKeypress).toHaveBeenLastCalledWith('Up');
   });
@@ -1758,6 +1786,43 @@ describe('waitRowsSettled', () => {
   });
 });
 
+describe('a wait does not outlive its own timeout', () => {
+  beforeEach(() => {
+    getValue.mockReset().mockResolvedValue({ found: true, value: 'never-matches' });
+    getFocusedNode.mockReset().mockResolvedValue(null);
+    getValues.mockReset().mockResolvedValue({ results: {} });
+  });
+
+  // Both loops used to sleep a FULL interval after the tick had already failed, and only
+  // then re-check the deadline — so `timeout` was a floor rather than a bound, overshooting
+  // by up to one interval. `waitOsdUp`'s OSD gate is 30 s at a 2 s interval, so "30 s" could
+  // be 32 s, and a caller budgeting a chain of waits was budgeting against a number that was
+  // not true. Asserted on the real clock deliberately: a fake one cannot catch a real sleep.
+  it('waitFor gives up within its budget, not a full interval past it', async () => {
+    const start = Date.now();
+    await expect(
+      waitFor('#x', (v) => v === 'match', { timeout: 50, interval: 5000 }),
+    ).rejects.toThrow();
+    // Generous against CI jitter and still ~100x under the 5 s interval it used to burn.
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  it('waitFocused gives up within its budget too', async () => {
+    const start = Date.now();
+    await expect(waitFocused(() => false, { timeout: 50, interval: 5000 })).rejects.toThrow();
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  it('still polls more than once when the budget allows it', async () => {
+    // The bound must not have been bought by turning a poll into a single read.
+    getValue.mockClear();
+    await expect(
+      waitFor('#x', (v) => v === 'match', { timeout: 120, interval: 20 }),
+    ).rejects.toThrow();
+    expect(getValue.mock.calls.length).toBeGreaterThan(2);
+  });
+});
+
 describe("waitFor's caller-supplied observed", () => {
   // The failure that motivated it: a confirm dialog that never appeared, where the
   // throw-time dump was taken 10s late and could not say what the press had landed on.
@@ -2177,7 +2242,9 @@ describe('waitOsdUp — no input before the app will accept it', () => {
     // whole ~5-7 s stream-start window, into a player designed not to answer.
     const p = player({ states: ['buffering', 'buffering', 'playing'] });
     // The state gate polls at 1 s, so three answers need room for three ticks.
-    await waitOsdUp('osd visible', { itemId: 'hero1', playableTimeout: 5000, timeout: 2000 });
+    await onFakeClock(() =>
+      waitOsdUp('osd visible', { itemId: 'hero1', playableTimeout: 5000, timeout: 2000 }),
+    );
     // Every Up was sent against a playable player — not merely "one Up was sent", which
     // stays true with the gate removed and is what let an earlier version of this test
     // pass a mutation that deleted the guard outright.
@@ -2213,7 +2280,9 @@ describe('waitOsdUp — no input before the app will accept it', () => {
 
   it('keeps re-pressing when a key is swallowed, rather than failing on one drop', async () => {
     player({ states: ['playing'], upPressesToOpen: 3 });
-    await waitOsdUp('osd visible', { itemId: 'hero1', playableTimeout: 2000, timeout: 12000 });
+    await onFakeClock(() =>
+      waitOsdUp('osd visible', { itemId: 'hero1', playableTimeout: 2000, timeout: 12000 }),
+    );
     expect(sendKeypress.mock.calls.filter(([k]) => k === 'Up').length).toBeGreaterThanOrEqual(3);
   });
 

--- a/vitest.rta.config.js
+++ b/vitest.rta.config.js
@@ -17,6 +17,10 @@ export default defineConfig({
     // longest: hardRelaunch 14s (exitMs + bootMs) + waitHome 65s (45s login + 20s rows) +
     // walkHomeToFirstRow 10s + overhang focus 15s + version label 20s + 1s settle = ~125s.
     // The OSD playback wait alone is ~90s. Re-do this arithmetic when a gate's timeout moves.
+    // That sum is a REAL bound as of the `nextTickMs` fix in `lib/steps.js`: `waitFor` and
+    // `waitFocused` used to sleep a full poll interval after deciding to give up, so each
+    // gate in the chain could overshoot its stated timeout by its own interval and the true
+    // worst case sat above this arithmetic rather than at it.
     testTimeout: 180_000,
     hookTimeout: 120_000, // deploy + boot in globalSetup/beforeAll
     // One real device — everything must run serially (Vitest 4: no poolOptions).


### PR DESCRIPTION
# Overview

`npm run test:scripts` took **30.6 s**, and `steps.test.js` was 16.5 s of it — the single
slowest file, on a suite pre-push runs for any JS change. Measuring why turned up a
correctness bug rather than a test-tuning problem.

`waitFor` and `waitFocused` slept a FULL poll interval *after* the tick had already failed,
and only then re-checked the deadline. So `timeout` was a floor, not a bound: a wait
overshot its stated budget by up to one interval. `waitOsdUp`'s OSD gate is
`timeout: 30000, interval: 2000`, so "30 s" could be 32 s, and anything budgeting a chain
of waits — `vitest.rta.config.js` does exactly that — was budgeting against a number that
was not true.

That is also what made the tests slow: thirteen of them pass `timeout: 1` and still burned
the 500 ms default interval each. The DX complaint and the bug were the same thing.

## Changes

- **A wait no longer outlives its own timeout.** `nextTickMs(interval, deadline)` returns
  the sleep the remaining budget allows, or 0 to stop. Read counts are unchanged — the loop
  condition still governs reads — so this only truncates the tail sleep.
- **It returns a duration rather than doing the sleeping, and a gate chose that shape.** The
  obvious `sleepWithinBudget()` that awaited internally was rejected by
  `jellyrock-rta/sleep-budgeted`, correctly on its own terms: it counts a `sleep()` as a
  poll tick only when it is lexically inside a loop, so moving the tick into a helper hid it
  from that test and it read as a bare arbitrary wait. Returning the duration keeps
  `await sleep(...)` where the rule can see it. The alternative was an `eslint-disable`,
  which would have been routing around a gate this suite added on purpose.
- **The two SETTLE loops are deliberately not converted.** `waitRowsSettled` and
  `waitCellsQuiet` sleep at the TOP of their loop, and that sleep IS the quiet window being
  measured — truncating it would change what they detect, not just when they give up.
- **Three regression tests, mutation-checked.** Reverting the fix makes the two bound
  assertions take 5035 ms and 5002 ms against a 5000 ms interval — exactly the overshoot.
  The third ("still polls more than once") passes either way by design: it is the
  counterweight stopping the bound being met by turning a poll into a single read.
- **Six remaining multi-tick cases move onto a fake clock** via `onFakeClock`, used only
  where a test genuinely needs several polls to make its point. The rest of the file stays
  on the real clock deliberately: two cases assert on real `Date.now()` deltas and would
  silently change meaning, and faking time file-wide would make every future test here have
  to know about the clock.
- `vitest.rta.config.js`'s worst-case arithmetic now says it is a real bound rather than a
  lower one.

**Result**

| | before | after |
|---|---|---|
| `npm run test:scripts` | 30.6 s | **11.4 s** |
| `tests/rta/lib/steps.test.js` | 16.5 s | 4.3 s |

A JS-only pre-push goes from ~28 s to ~11 s. The remaining long pole is
`icons-build.test.js` at ~11 s, which is real sharp rendering — work, not waste — and is
left alone.

**Validation:** full RTA suite green on a Stick 4K — **60 passed / 2 skipped / 0 failed**
(the two skips are the `BENCH_ENABLED` spec files), registry restored. This was verified on
hardware because the change is to the primitive every one of the suite's 96 waits runs
through, and a green unit suite is not sufficient evidence for that. 2341 hardware-free
tests pass. Note the 1310 s runtime is *within* the prior 1322–1348 s band, not evidence of
a speed-up: the fix only affects the timeout path, and a green run has no timeouts.

## Follow-ups

None

## Issues

None

## Docs / context updates

- [ ] **Architecture doc** updated if a system's *shape* or *why* changed → `docs/architecture/<topic>.md`
- [ ] **`docs/dev/` how-to** updated if a workflow / recipe changed (adding a setting, writing a migration, etc.)
- [ ] **Subdir `CLAUDE.md`** updated if a per-area rule / convention changed
- [ ] **`docs/adr/`** ADR added if an architectural / hard-to-reverse / cross-component decision was made (sub-architectural choice → **`docs/decisions.md`** note)
- [ ] **`docs/architecture/tech-debt.md`** entry removed if this PR fixes a listed item, or added if this PR introduces new debt or defers a follow-up
- [x] None — this PR doesn't change any of the above

<!-- /pr render: sha=7fbd72252fd855b03c6bdce52c8e7e27a37e45fc ts=2026-09-10T01:48:30Z -->
